### PR TITLE
Mapping Experiment 3: JSON -> models with the php-json-schema-model-generator library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,16 +8,19 @@
 		"symfony/http-kernel": "^7.0",
 		"pimple/pimple": "^3.0",
 		"swaggest/json-schema": "^0.12.42",
-		"swaggest/php-code-builder": "^0.2.41"
+		"swaggest/php-code-builder": "^0.2.41",
+		"wol-soft/php-json-schema-model-generator-production": "^0.19.0"
 	},
 	"require-dev": {
-		"pestphp/pest": "^2.33"
+		"pestphp/pest": "^2.33",
+		"wol-soft/php-json-schema-model-generator": "^0.24.0"
 	},
 	"config": {
 		"optimize-autoloader": true,
 		"preferred-install": "dist",
 		"allow-plugins": {
-			"pestphp/pest-plugin": true
+			"pestphp/pest-plugin": true,
+			"php-http/discovery": true
 		}
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c601d877ae171a684d68ee71f6518c7",
+    "content-hash": "9f4beb3d54104a25daf30f5663ae36f1",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -1757,6 +1757,51 @@
                 }
             ],
             "time": "2024-01-23T15:02:46+00:00"
+        },
+        {
+            "name": "wol-soft/php-json-schema-model-generator-production",
+            "version": "0.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wol-soft/php-json-schema-model-generator-production.git",
+                "reference": "01dfe21b8306773252ea21873c70dea4b60859a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wol-soft/php-json-schema-model-generator-production/zipball/01dfe21b8306773252ea21873c70dea4b60859a7",
+                "reference": "01dfe21b8306773252ea21873c70dea4b60859a7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPModelGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Enno Woortmann",
+                    "email": "enno.woortmann@web.de"
+                }
+            ],
+            "description": "Provides the production code required to use php-json-schema-model-generator as dev dependency",
+            "homepage": "https://github.com/wol-soft/php-json-schema-model-generator-production",
+            "support": {
+                "issues": "https://github.com/wol-soft/php-json-schema-model-generator-production/issues",
+                "source": "https://github.com/wol-soft/php-json-schema-model-generator-production/tree/0.19.0"
+            },
+            "time": "2023-10-17T09:44:24+00:00"
         }
     ],
     "packages-dev": [
@@ -4623,6 +4668,82 @@
             "time": "2024-01-29T20:11:03+00:00"
         },
         {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "c565ad1e63f30e7477fc40738343c62b40bc672d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/c565ad1e63f30e7477fc40738343c62b40bc672d",
+                "reference": "c565ad1e63f30e7477fc40738343c62b40bc672d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
             "name": "symfony/process",
             "version": "v7.0.3",
             "source": {
@@ -4935,6 +5056,99 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "wol-soft/php-json-schema-model-generator",
+            "version": "0.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wol-soft/php-json-schema-model-generator.git",
+                "reference": "2121ea925cda90b3af39e1b4f3c4e0d251aac738"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wol-soft/php-json-schema-model-generator/zipball/2121ea925cda90b3af39e1b4f3c4e0d251aac738",
+                "reference": "2121ea925cda90b3af39e1b4f3c4e0d251aac738",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.0",
+                "symfony/polyfill-php81": "^1.28",
+                "wol-soft/php-json-schema-model-generator-production": "^0.19.0",
+                "wol-soft/php-micro-template": "^1.9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPModelGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Enno Woortmann",
+                    "email": "enno.woortmann@web.de"
+                }
+            ],
+            "description": "Creates (immutable) PHP model classes from JSON-Schema files including all validation rules as PHP code",
+            "homepage": "https://github.com/wol-soft/php-json-schema-model-generator",
+            "support": {
+                "issues": "https://github.com/wol-soft/php-json-schema-model-generator/issues",
+                "source": "https://github.com/wol-soft/php-json-schema-model-generator/tree/0.24.0"
+            },
+            "time": "2023-10-17T10:20:09+00:00"
+        },
+        {
+            "name": "wol-soft/php-micro-template",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wol-soft/php-micro-template.git",
+                "reference": "c09d4204a31bc0167652d6d301cd5af7d72e9000"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wol-soft/php-micro-template/zipball/c09d4204a31bc0167652d6d301cd5af7d72e9000",
+                "reference": "c09d4204a31bc0167652d6d301cd5af7d72e9000",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMicroTemplate\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Enno Woortmann",
+                    "email": "enno.woortmann@web.de"
+                }
+            ],
+            "description": "A minimalistic templating engine for PHP",
+            "homepage": "https://github.com/wol-soft/php-micro-template",
+            "support": {
+                "issues": "https://github.com/wol-soft/php-micro-template/issues",
+                "source": "https://github.com/wol-soft/php-micro-template/tree/1.9.0"
+            },
+            "time": "2023-09-05T14:24:31+00:00"
         }
     ],
     "aliases": [],

--- a/generate.php
+++ b/generate.php
@@ -1,0 +1,19 @@
+<?php
+
+require 'vendor/autoload.php';
+
+use PHPModelGenerator\Model\GeneratorConfiguration;
+use PHPModelGenerator\ModelGenerator;
+use PHPModelGenerator\SchemaProvider\RecursiveDirectoryProvider;
+
+$generator = new ModelGenerator(
+	( new GeneratorConfiguration() )
+		->setNamespacePrefix( 'MyApp\Model' )
+		->setImmutable( false )
+);
+
+$generator
+	->generateModelDirectory( __DIR__ . '/result' )
+	->generateModels( new RecursiveDirectoryProvider( __DIR__ . '/src/WordPress/Blueprints' ), __DIR__ . '/result' );
+
+

--- a/generate.php
+++ b/generate.php
@@ -10,6 +10,7 @@ $generator = new ModelGenerator(
 	( new GeneratorConfiguration() )
 		->setNamespacePrefix( 'MyApp\Model' )
 		->setImmutable( false )
+		->setDenyAdditionalProperties( true )
 );
 
 $generator

--- a/result/Schema.php
+++ b/result/Schema.php
@@ -1,0 +1,2018 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema implements JSONModelInterface
+{
+    
+
+    
+        /** @var string|null The URL to navigate to after the blueprint has been run. */
+        protected $landingPage;
+    
+        /** @var string|null Optional description. It doesn't do anything but is exposed as a courtesy to developers who may want to document which blueprint file does what. */
+        protected $description;
+    
+        /** @var Schema_PreferredVersions65d4b00f3b0f0|null The preferred PHP and WordPress versions to use. */
+        protected $preferredVersions;
+    
+        /** @var Schema_Features65d4b00f3b44e|null */
+        protected $features;
+    
+        /** @var Schema_Constants65d4b00f3b4a2|null PHP Constants to define on every request */
+        protected $constants;
+    
+        /** @var string[]|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c[]|null WordPress plugins to install and activate */
+        protected $plugins;
+    
+        /** @var Schema_SiteOptions65d4b00f3bb76|null WordPress site options to define */
+        protected $siteOptions;
+    
+        /** @var string[]|null The PHP extensions to use. */
+        protected $phpExtensionBundles;
+    
+        /** @var string[]|mixed[]|bool[]|null[]|Schema_Itemofarraysteps65d4b00f3bc1a[]|Schema_Itemofarraysteps65d4b00f3bd2b[]|Schema_Itemofarraysteps65d4b00f3bd71[]|Schema_Itemofarraysteps65d4b00f3bdb9[]|Schema_Itemofarraysteps65d4b00f3be19[]|Schema_Itemofarraysteps65d4b00f3be55[]|Schema_Itemofarraysteps65d4b00f3be88[]|Schema_Itemofarraysteps65d4b00f3bec0[]|Schema_Itemofarraysteps65d4b00f3bf1f[]|Schema_Itemofarraysteps65d4b00f3bf77[]|Schema_Itemofarraysteps65d4b00f3bfac[]|Schema_Itemofarraysteps65d4b00f3bfed[]|Schema_Itemofarraysteps65d4b00f3c026[]|Schema_Itemofarraysteps65d4b00f3c05a[]|Schema_Itemofarraysteps65d4b00f3c092[]|Schema_Itemofarraysteps65d4b00f3c0e9[]|Schema_Itemofarraysteps65d4b00f3c123[]|Schema_Itemofarraysteps65d4b00f3c166[]|Schema_Itemofarraysteps65d4b00f3c1ae[]|Schema_Itemofarraysteps65d4b00f3c217[] The steps to run after every other operation in this Blueprint was executed. */
+        protected $steps;
+    
+        /** @var string|null */
+        protected $schema;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+
+        
+            
+                $this->processLandingPage($rawModelDataInput);
+            
+        
+            
+                $this->processDescription($rawModelDataInput);
+            
+        
+            
+                $this->processPreferredVersions($rawModelDataInput);
+            
+        
+            
+                $this->processFeatures($rawModelDataInput);
+            
+        
+            
+                $this->processConstants($rawModelDataInput);
+            
+        
+            
+                $this->processPlugins($rawModelDataInput);
+            
+        
+            
+                $this->processSiteOptions($rawModelDataInput);
+            
+        
+            
+                $this->processPhpExtensionBundles($rawModelDataInput);
+            
+        
+            
+                $this->processSteps($rawModelDataInput);
+            
+        
+            
+                $this->processSchema($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of landingPage.
+             *
+             * The URL to navigate to after the blueprint has been run.
+             *
+             * @return string|null
+             */
+            public function getLandingPage()
+                : ?string
+            {
+                
+
+                return $this->landingPage;
+            }
+
+            
+                /**
+                 * Set the value of landingPage.
+                 *
+                 * @param string $landingPage The URL to navigate to after the blueprint has been run.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setLandingPage(
+                    string $landingPage
+                ): self {
+                    if ($this->landingPage === $landingPage) {
+                        return $this;
+                    }
+
+                    $value = $modelData['landingPage'] = $landingPage;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateLandingPage($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->landingPage = $value;
+                    $this->_rawModelDataInput['landingPage'] = $landingPage;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property landingPage
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processLandingPage(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('landingPage', $modelData) && $this->landingPage === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('landingPage', $modelData) ? $modelData['landingPage'] : $this->landingPage;
+
+                
+
+                $this->landingPage = $this->validateLandingPage($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property landingPage
+             */
+            protected function validateLandingPage($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'landingPage',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of description.
+             *
+             * Optional description. It doesn't do anything but is exposed as a courtesy to developers who may want to document which blueprint file does what.
+             *
+             * @return string|null
+             */
+            public function getDescription()
+                : ?string
+            {
+                
+
+                return $this->description;
+            }
+
+            
+                /**
+                 * Set the value of description.
+                 *
+                 * @param string $description Optional description. It doesn't do anything but is exposed as a courtesy to developers who may want to document which blueprint file does what.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setDescription(
+                    string $description
+                ): self {
+                    if ($this->description === $description) {
+                        return $this;
+                    }
+
+                    $value = $modelData['description'] = $description;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateDescription($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->description = $value;
+                    $this->_rawModelDataInput['description'] = $description;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property description
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processDescription(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('description', $modelData) && $this->description === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('description', $modelData) ? $modelData['description'] : $this->description;
+
+                
+
+                $this->description = $this->validateDescription($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property description
+             */
+            protected function validateDescription($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'description',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of preferredVersions.
+             *
+             * The preferred PHP and WordPress versions to use.
+             *
+             * @return Schema_PreferredVersions65d4b00f3b0f0|null
+             */
+            public function getPreferredVersions()
+                : ?Schema_PreferredVersions65d4b00f3b0f0
+            {
+                
+
+                return $this->preferredVersions;
+            }
+
+            
+                /**
+                 * Set the value of preferredVersions.
+                 *
+                 * @param Schema_PreferredVersions65d4b00f3b0f0 $preferredVersions The preferred PHP and WordPress versions to use.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPreferredVersions(
+                    Schema_PreferredVersions65d4b00f3b0f0 $preferredVersions
+                ): self {
+                    if ($this->preferredVersions === $preferredVersions) {
+                        return $this;
+                    }
+
+                    $value = $modelData['preferredVersions'] = $preferredVersions;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePreferredVersions($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->preferredVersions = $value;
+                    $this->_rawModelDataInput['preferredVersions'] = $preferredVersions;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property preferredVersions
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPreferredVersions(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('preferredVersions', $modelData) && $this->preferredVersions === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('preferredVersions', $modelData) ? $modelData['preferredVersions'] : $this->preferredVersions;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_PreferredVersions65d4b00f3b0f0($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'preferredVersions',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->preferredVersions = $this->validatePreferredVersions($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property preferredVersions
+             */
+            protected function validatePreferredVersions($value, array $modelData)
+            {
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'preferredVersions',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_PreferredVersions65d4b00f3b0f0)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'preferredVersions',
+  1 => 'Schema_PreferredVersions65d4b00f3b0f0',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of features.
+             *
+             * 
+             *
+             * @return Schema_Features65d4b00f3b44e|null
+             */
+            public function getFeatures()
+                : ?Schema_Features65d4b00f3b44e
+            {
+                
+
+                return $this->features;
+            }
+
+            
+                /**
+                 * Set the value of features.
+                 *
+                 * @param Schema_Features65d4b00f3b44e $features
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setFeatures(
+                    Schema_Features65d4b00f3b44e $features
+                ): self {
+                    if ($this->features === $features) {
+                        return $this;
+                    }
+
+                    $value = $modelData['features'] = $features;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateFeatures($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->features = $value;
+                    $this->_rawModelDataInput['features'] = $features;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property features
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processFeatures(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('features', $modelData) && $this->features === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('features', $modelData) ? $modelData['features'] : $this->features;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Features65d4b00f3b44e($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'features',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->features = $this->validateFeatures($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property features
+             */
+            protected function validateFeatures($value, array $modelData)
+            {
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'features',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Features65d4b00f3b44e)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'features',
+  1 => 'Schema_Features65d4b00f3b44e',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of constants.
+             *
+             * PHP Constants to define on every request
+             *
+             * @return Schema_Constants65d4b00f3b4a2|null
+             */
+            public function getConstants()
+                : ?Schema_Constants65d4b00f3b4a2
+            {
+                
+
+                return $this->constants;
+            }
+
+            
+                /**
+                 * Set the value of constants.
+                 *
+                 * @param Schema_Constants65d4b00f3b4a2 $constants PHP Constants to define on every request
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setConstants(
+                    Schema_Constants65d4b00f3b4a2 $constants
+                ): self {
+                    if ($this->constants === $constants) {
+                        return $this;
+                    }
+
+                    $value = $modelData['constants'] = $constants;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateConstants($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->constants = $value;
+                    $this->_rawModelDataInput['constants'] = $constants;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property constants
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processConstants(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('constants', $modelData) && $this->constants === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('constants', $modelData) ? $modelData['constants'] : $this->constants;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Constants65d4b00f3b4a2($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'constants',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->constants = $this->validateConstants($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property constants
+             */
+            protected function validateConstants($value, array $modelData)
+            {
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'constants',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Constants65d4b00f3b4a2)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'constants',
+  1 => 'Schema_Constants65d4b00f3b4a2',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of plugins.
+             *
+             * WordPress plugins to install and activate
+             *
+             * @return string[]|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c[]|null
+             */
+            public function getPlugins()
+                : ?array
+            {
+                
+
+                return $this->plugins;
+            }
+
+            
+                /**
+                 * Set the value of plugins.
+                 *
+                 * @param string[]|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c[] $plugins WordPress plugins to install and activate
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPlugins(
+                    array $plugins
+                ): self {
+                    if ($this->plugins === $plugins) {
+                        return $this;
+                    }
+
+                    $value = $modelData['plugins'] = $plugins;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePlugins($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->plugins = $value;
+                    $this->_rawModelDataInput['plugins'] = $plugins;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property plugins
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPlugins(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('plugins', $modelData) && $this->plugins === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('plugins', $modelData) ? $modelData['plugins'] : $this->plugins;
+
+                
+
+                $this->plugins = $this->validatePlugins($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property plugins
+             */
+            protected function validatePlugins($value, array $modelData)
+            {
+                
+                    
+
+if (!is_array($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'plugins',
+  1 => 'array',
+)));
+}
+
+                
+                    $this->validatePlugins_ArrayItem_65d4b00f3bb68($value);
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of siteOptions.
+             *
+             * WordPress site options to define
+             *
+             * @return Schema_SiteOptions65d4b00f3bb76|null
+             */
+            public function getSiteOptions()
+                : ?Schema_SiteOptions65d4b00f3bb76
+            {
+                
+
+                return $this->siteOptions;
+            }
+
+            
+                /**
+                 * Set the value of siteOptions.
+                 *
+                 * @param Schema_SiteOptions65d4b00f3bb76 $siteOptions WordPress site options to define
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSiteOptions(
+                    Schema_SiteOptions65d4b00f3bb76 $siteOptions
+                ): self {
+                    if ($this->siteOptions === $siteOptions) {
+                        return $this;
+                    }
+
+                    $value = $modelData['siteOptions'] = $siteOptions;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSiteOptions($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->siteOptions = $value;
+                    $this->_rawModelDataInput['siteOptions'] = $siteOptions;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property siteOptions
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSiteOptions(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('siteOptions', $modelData) && $this->siteOptions === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('siteOptions', $modelData) ? $modelData['siteOptions'] : $this->siteOptions;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_SiteOptions65d4b00f3bb76($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'siteOptions',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->siteOptions = $this->validateSiteOptions($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property siteOptions
+             */
+            protected function validateSiteOptions($value, array $modelData)
+            {
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'siteOptions',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_SiteOptions65d4b00f3bb76)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'siteOptions',
+  1 => 'Schema_SiteOptions65d4b00f3bb76',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of phpExtensionBundles.
+             *
+             * The PHP extensions to use.
+             *
+             * @return string[]|null
+             */
+            public function getPhpExtensionBundles()
+                : ?array
+            {
+                
+
+                return $this->phpExtensionBundles;
+            }
+
+            
+                /**
+                 * Set the value of phpExtensionBundles.
+                 *
+                 * @param string[] $phpExtensionBundles The PHP extensions to use.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPhpExtensionBundles(
+                    array $phpExtensionBundles
+                ): self {
+                    if ($this->phpExtensionBundles === $phpExtensionBundles) {
+                        return $this;
+                    }
+
+                    $value = $modelData['phpExtensionBundles'] = $phpExtensionBundles;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePhpExtensionBundles($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->phpExtensionBundles = $value;
+                    $this->_rawModelDataInput['phpExtensionBundles'] = $phpExtensionBundles;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property phpExtensionBundles
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPhpExtensionBundles(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('phpExtensionBundles', $modelData) && $this->phpExtensionBundles === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('phpExtensionBundles', $modelData) ? $modelData['phpExtensionBundles'] : $this->phpExtensionBundles;
+
+                
+
+                $this->phpExtensionBundles = $this->validatePhpExtensionBundles($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property phpExtensionBundles
+             */
+            protected function validatePhpExtensionBundles($value, array $modelData)
+            {
+                
+                    
+
+if (!is_array($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'phpExtensionBundles',
+  1 => 'array',
+)));
+}
+
+                
+                    $this->validatePhpExtensionBundles_ArrayItem_65d4b00f3bbc1($value);
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of steps.
+             *
+             * The steps to run after every other operation in this Blueprint was executed.
+             *
+             * @return string[]|mixed[]|bool[]|null[]|Schema_Itemofarraysteps65d4b00f3bc1a[]|Schema_Itemofarraysteps65d4b00f3bd2b[]|Schema_Itemofarraysteps65d4b00f3bd71[]|Schema_Itemofarraysteps65d4b00f3bdb9[]|Schema_Itemofarraysteps65d4b00f3be19[]|Schema_Itemofarraysteps65d4b00f3be55[]|Schema_Itemofarraysteps65d4b00f3be88[]|Schema_Itemofarraysteps65d4b00f3bec0[]|Schema_Itemofarraysteps65d4b00f3bf1f[]|Schema_Itemofarraysteps65d4b00f3bf77[]|Schema_Itemofarraysteps65d4b00f3bfac[]|Schema_Itemofarraysteps65d4b00f3bfed[]|Schema_Itemofarraysteps65d4b00f3c026[]|Schema_Itemofarraysteps65d4b00f3c05a[]|Schema_Itemofarraysteps65d4b00f3c092[]|Schema_Itemofarraysteps65d4b00f3c0e9[]|Schema_Itemofarraysteps65d4b00f3c123[]|Schema_Itemofarraysteps65d4b00f3c166[]|Schema_Itemofarraysteps65d4b00f3c1ae[]|Schema_Itemofarraysteps65d4b00f3c217[]
+             */
+            public function getSteps()
+                : ?array
+            {
+                
+
+                return $this->steps;
+            }
+
+            
+                /**
+                 * Set the value of steps.
+                 *
+                 * @param string[]|mixed[]|bool[]|null[]|Schema_Itemofarraysteps65d4b00f3bc1a[]|Schema_Itemofarraysteps65d4b00f3bd2b[]|Schema_Itemofarraysteps65d4b00f3bd71[]|Schema_Itemofarraysteps65d4b00f3bdb9[]|Schema_Itemofarraysteps65d4b00f3be19[]|Schema_Itemofarraysteps65d4b00f3be55[]|Schema_Itemofarraysteps65d4b00f3be88[]|Schema_Itemofarraysteps65d4b00f3bec0[]|Schema_Itemofarraysteps65d4b00f3bf1f[]|Schema_Itemofarraysteps65d4b00f3bf77[]|Schema_Itemofarraysteps65d4b00f3bfac[]|Schema_Itemofarraysteps65d4b00f3bfed[]|Schema_Itemofarraysteps65d4b00f3c026[]|Schema_Itemofarraysteps65d4b00f3c05a[]|Schema_Itemofarraysteps65d4b00f3c092[]|Schema_Itemofarraysteps65d4b00f3c0e9[]|Schema_Itemofarraysteps65d4b00f3c123[]|Schema_Itemofarraysteps65d4b00f3c166[]|Schema_Itemofarraysteps65d4b00f3c1ae[]|Schema_Itemofarraysteps65d4b00f3c217[] $steps The steps to run after every other operation in this Blueprint was executed.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSteps(
+                    array $steps
+                ): self {
+                    if ($this->steps === $steps) {
+                        return $this;
+                    }
+
+                    $value = $modelData['steps'] = $steps;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSteps($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->steps = $value;
+                    $this->_rawModelDataInput['steps'] = $steps;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property steps
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSteps(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('steps', $modelData) && $this->steps === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('steps', $modelData) ? $modelData['steps'] : $this->steps;
+
+                
+
+                $this->steps = $this->validateSteps($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property steps
+             */
+            protected function validateSteps($value, array $modelData)
+            {
+                
+                    
+
+if (!is_array($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'steps',
+  1 => 'array',
+)));
+}
+
+                
+                    $this->validateSteps_ArrayItem_65d4b00f3c505($value);
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of $schema.
+             *
+             * 
+             *
+             * @return string|null
+             */
+            public function getSchema()
+                : ?string
+            {
+                
+
+                return $this->schema;
+            }
+
+            
+                /**
+                 * Set the value of $schema.
+                 *
+                 * @param string $schema
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSchema(
+                    string $schema
+                ): self {
+                    if ($this->schema === $schema) {
+                        return $this;
+                    }
+
+                    $value = $modelData['$schema'] = $schema;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSchema($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->schema = $value;
+                    $this->_rawModelDataInput['$schema'] = $schema;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property schema
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSchema(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('$schema', $modelData) && $this->schema === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('$schema', $modelData) ? $modelData['$schema'] : $this->schema;
+
+                
+
+                $this->schema = $this->validateSchema($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property schema
+             */
+            protected function validateSchema($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => '$schema',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    private function validatePlugins_ArrayItem_65d4b00f3bb68(&$value): void {
+                    $invalidItems_632057b18481b76cbe71c78b86275801 = [];
+                    
+                    if (is_array($value) && (function (&$items) use (&$invalidItems_632057b18481b76cbe71c78b86275801) {
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    foreach ($items as $index => &$value) {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        try {
+            
+
+            
+                $this->validateItemOfArrayPlugins_ComposedProperty_65d4b00f3bb2c($value);
+            
+
+            
+                if ($this->_errorRegistry->getErrors()) {
+                    $invalidItems_632057b18481b76cbe71c78b86275801[$index] = $this->_errorRegistry->getErrors();
+                }
+            
+        } catch (\Exception $e) {
+            // collect all errors concerning invalid items
+            isset($invalidItems_632057b18481b76cbe71c78b86275801[$index])
+                ? $invalidItems_632057b18481b76cbe71c78b86275801[$index][] = $e
+                : $invalidItems_632057b18481b76cbe71c78b86275801[$index] = [$e];
+        }
+    }
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    return !empty($invalidItems_632057b18481b76cbe71c78b86275801);
+})($value)) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Arrays\InvalidItemException($value ?? null, ...array (
+  0 => 'plugins',
+  1 => $invalidItems_632057b18481b76cbe71c78b86275801,
+)));
+                    }
+                }
+
+private function validatePhpExtensionBundles_ArrayItem_65d4b00f3bbc1(&$value): void {
+                    $invalidItems_18533bc0ecb84ac2004c095f11545d3d = [];
+                    
+                    if (is_array($value) && (function (&$items) use (&$invalidItems_18533bc0ecb84ac2004c095f11545d3d) {
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    foreach ($items as $index => &$value) {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        try {
+            
+
+            
+                
+
+if ($value !== 'kitchen-sink') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'item of array phpExtensionBundles',
+  1 => 'kitchen-sink',
+)));
+}
+
+            
+
+            
+                if ($this->_errorRegistry->getErrors()) {
+                    $invalidItems_18533bc0ecb84ac2004c095f11545d3d[$index] = $this->_errorRegistry->getErrors();
+                }
+            
+        } catch (\Exception $e) {
+            // collect all errors concerning invalid items
+            isset($invalidItems_18533bc0ecb84ac2004c095f11545d3d[$index])
+                ? $invalidItems_18533bc0ecb84ac2004c095f11545d3d[$index][] = $e
+                : $invalidItems_18533bc0ecb84ac2004c095f11545d3d[$index] = [$e];
+        }
+    }
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    return !empty($invalidItems_18533bc0ecb84ac2004c095f11545d3d);
+})($value)) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Arrays\InvalidItemException($value ?? null, ...array (
+  0 => 'phpExtensionBundles',
+  1 => $invalidItems_18533bc0ecb84ac2004c095f11545d3d,
+)));
+                    }
+                }
+
+private function validateSteps_ArrayItem_65d4b00f3c505(&$value): void {
+                    $invalidItems_26bac3b864e3e68291033f71170da9a3 = [];
+                    
+                    if (is_array($value) && (function (&$items) use (&$invalidItems_26bac3b864e3e68291033f71170da9a3) {
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    foreach ($items as $index => &$value) {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        try {
+            
+
+            
+                $this->validateItemOfArraySteps_ComposedProperty_65d4b00f3c500($value);
+            
+
+            
+                if ($this->_errorRegistry->getErrors()) {
+                    $invalidItems_26bac3b864e3e68291033f71170da9a3[$index] = $this->_errorRegistry->getErrors();
+                }
+            
+        } catch (\Exception $e) {
+            // collect all errors concerning invalid items
+            isset($invalidItems_26bac3b864e3e68291033f71170da9a3[$index])
+                ? $invalidItems_26bac3b864e3e68291033f71170da9a3[$index][] = $e
+                : $invalidItems_26bac3b864e3e68291033f71170da9a3[$index] = [$e];
+        }
+    }
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    return !empty($invalidItems_26bac3b864e3e68291033f71170da9a3);
+})($value)) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Arrays\InvalidItemException($value ?? null, ...array (
+  0 => 'steps',
+  1 => $invalidItems_26bac3b864e3e68291033f71170da9a3,
+)));
+                    }
+                }
+
+private function validateItemOfArrayPlugins_ComposedProperty_65d4b00f3bb2c(&$value): void {
+                    
+            $succeededCompositionElements = 0;
+            $compositionErrorCollection = [];
+        
+                    
+                    if (
+(function (&$value) use (
+    &$modelData,
+    &$modifiedModelData,
+    &$compositionErrorCollection,
+    &$succeededCompositionElements,
+    &$validatorIndex
+) {
+    $succeededCompositionElements = 2;
+    $validatorComponentIndex = 0;
+    $originalModelData = $value;
+    $proposedValue = null;
+    $modifiedValues = [];
+
+    
+
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'item of array plugins',
+  1 => 'string',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_2c62e($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_2c62e($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+
+    
+        $value = $proposedValue;
+    
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    $result = !($succeededCompositionElements > 0);
+
+    
+
+    return $result;
+})($value)
+) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\ComposedValue\AnyOfException($value ?? null, ...array (
+  0 => 'item of array plugins',
+  1 => $succeededCompositionElements,
+  2 => $compositionErrorCollection,
+)));
+                    }
+                }
+
+private function validateItemOfArraySteps_ComposedProperty_65d4b00f3c500(&$value): void {
+                    
+            $succeededCompositionElements = 0;
+            $compositionErrorCollection = [];
+        
+                    
+                    if (
+(function (&$value) use (
+    &$modelData,
+    &$modifiedModelData,
+    &$compositionErrorCollection,
+    &$succeededCompositionElements,
+    &$validatorIndex
+) {
+    $succeededCompositionElements = 5;
+    $validatorComponentIndex = 0;
+    $originalModelData = $value;
+    $proposedValue = null;
+    $modifiedValues = [];
+
+    
+
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c28b($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3c28b)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_a60e8($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => 'string',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_a60e8($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_a60e8($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if ($value !== false) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => false,
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_a60e8($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if (!is_null($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => 'null',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_a60e8($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+
+    
+        if (is_object($proposedValue)) {
+            if ($modifiedValues) {
+                $value = array_merge($value, $modifiedValues);
+            }
+
+            $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c28b($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+        } else {
+            $value = $proposedValue;
+        }
+    
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    $result = !($succeededCompositionElements > 0);
+
+    
+
+    return $result;
+})($value)
+) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\ComposedValue\AnyOfException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => $succeededCompositionElements,
+  2 => $compositionErrorCollection,
+)));
+                    }
+                }
+
+
+                        private function _getModifiedValues_2c62e(array $originalModelData, object $nestedCompositionObject): array {
+                            $modifiedValues = [];
+                            $defaultValueMap = array (
+);
+    
+                            foreach (array (
+) as $key => $accessor) {
+                                if ((isset($originalModelData[$key]) || in_array($key, $defaultValueMap))
+                                    && method_exists($nestedCompositionObject, $accessor)
+                                    && ($modifiedValue = $nestedCompositionObject->$accessor()) !== ($originalModelData[$key] ?? !$modifiedValue)
+                                ) {
+                                    $modifiedValues[$key] = $modifiedValue;
+                                }
+                            }
+    
+                            return $modifiedValues;
+                        }
+
+
+                        private function _getModifiedValues_a60e8(array $originalModelData, object $nestedCompositionObject): array {
+                            $modifiedValues = [];
+                            $defaultValueMap = array (
+  0 => 'propertyValidationState',
+);
+    
+                            foreach (array (
+  'step' => 'getStep',
+  'progress' => 'getProgress',
+  'continueOnError' => 'getContinueOnError',
+  'slug' => 'getSlug',
+  'fromPath' => 'getFromPath',
+  'toPath' => 'getToPath',
+  'consts' => 'getConsts',
+  'siteUrl' => 'getSiteUrl',
+  'item of array plugins' => 'getItemOfArrayPlugins',
+  'options' => 'getOptions',
+  'path' => 'getPath',
+  'code' => 'getCode',
+  'zipPath' => 'getZipPath',
+  'extractToPath' => 'getExtractToPath',
+  'data' => 'getData',
+  'command' => 'getCommand',
+  'propertyValidationState' => 'get_propertyValidationState',
+) as $key => $accessor) {
+                                if ((isset($originalModelData[$key]) || in_array($key, $defaultValueMap))
+                                    && method_exists($nestedCompositionObject, $accessor)
+                                    && ($modifiedValue = $nestedCompositionObject->$accessor()) !== ($originalModelData[$key] ?? !$modifiedValue)
+                                ) {
+                                    $modifiedValues[$key] = $modifiedValue;
+                                }
+                            }
+    
+                            return $modifiedValues;
+                        }
+
+
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Constants65d4b00f3b4a2.php
+++ b/result/Schema_Constants65d4b00f3b4a2.php
@@ -1,0 +1,154 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare( strict_types=1 );
+
+
+namespace MyApp\Model;
+
+
+use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Constants65d4b00f3b4a2
+ * @package MyApp\Model
+ *
+ * PHP Constants to define on every request
+ *
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Constants65d4b00f3b4a2 implements JSONModelInterface {
+
+
+	/** @var string[] Collect all additional properties provided to the schema */
+	private $_additionalProperties = array();
+
+	/** @var array */
+	protected $_rawModelDataInput = [];
+
+
+	/** @var ErrorRegistryException Collect all validation errors */
+	protected $_errorRegistry;
+
+
+	/**
+	 * Schema_Constants65d4b00f3b4a2 constructor.
+	 *
+	 * @param array $rawModelDataInput
+	 *
+	 * @throws ErrorRegistryException
+	 */
+	public function __construct( array $rawModelDataInput = [] ) {
+
+		$this->_errorRegistry = new ErrorRegistryException();
+
+
+		$this->executeBaseValidators( $rawModelDataInput );
+
+
+		if ( count( $this->_errorRegistry->getErrors() ) ) {
+			throw $this->_errorRegistry;
+		}
+
+
+		$this->_rawModelDataInput = $rawModelDataInput;
+
+
+	}
+
+
+	protected function executeBaseValidators( array &$modelData ): void {
+		$value = &$modelData;
+
+
+		$properties = $value;
+		$invalidProperties = [];
+
+		if ( ( function () use ( $properties, &$invalidProperties ) {
+
+			$originalErrorRegistry = $this->_errorRegistry;
+
+
+			$rollbackValues = $this->_additionalProperties;
+
+
+			foreach (
+				array_diff( array_keys( $properties ), array() ) as $propertyKey
+			) {
+
+
+				try {
+					$value = $properties[ $propertyKey ];
+
+
+					$this->_errorRegistry = new ErrorRegistryException();
+
+
+					if ( ! is_string( $value ) ) {
+						$this->_errorRegistry->addError( new \PHPModelGenerator\Exception\Generic\InvalidTypeException( $value ?? null,
+							...
+							array(
+								0 => 'additional property',
+								1 => 'string',
+							) ) );
+					}
+
+
+					if ( $this->_errorRegistry->getErrors() ) {
+						$invalidProperties[ $propertyKey ] = $this->_errorRegistry->getErrors();
+					}
+
+
+					$this->_additionalProperties[ $propertyKey ] = $value;
+
+				} catch ( \Exception $e ) {
+					// collect all errors concerning invalid additional properties
+					isset( $invalidProperties[ $propertyKey ] )
+						? $invalidProperties[ $propertyKey ][] = $e
+						: $invalidProperties[ $propertyKey ] = [ $e ];
+				}
+			}
+
+
+			$this->_errorRegistry = $originalErrorRegistry;
+
+
+			if ( ! empty( $invalidProperties ) ) {
+				$this->_additionalProperties = $rollbackValues;
+			}
+
+
+			return ! empty( $invalidProperties );
+		} )() ) {
+			$this->_errorRegistry->addError( new \PHPModelGenerator\Exception\Object\InvalidAdditionalPropertiesException( $value ?? null,
+				...
+				array(
+					0 => 'Schema_Constants65d4b00f3b4a2',
+					1 => $invalidProperties,
+				) ) );
+		}
+
+
+	}
+
+
+	/**
+	 * Get the raw input used to set up the model
+	 *
+	 * @return array
+	 */
+	public function getRawModelDataInput(): array {
+		return $this->_rawModelDataInput;
+	}
+
+
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Consts65d4b00f3bde0.php
+++ b/result/Schema_Consts65d4b00f3bde0.php
@@ -1,0 +1,171 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Consts65d4b00f3bde0
+ * @package MyApp\Model 
+ *
+ * The constants to define
+ *
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Consts65d4b00f3bde0 implements JSONModelInterface
+{
+    
+
+    
+        /** @var mixed[] Collect all additional properties provided to the schema */
+        private $_additionalProperties = array (
+);
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Consts65d4b00f3bde0 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+            $properties = $value;
+            $invalidProperties = [];
+        
+if ((function () use ($properties, &$invalidProperties) {
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+    
+        $rollbackValues = $this->_additionalProperties;
+    
+
+    foreach (array_diff(array_keys($properties), array (
+)) as $propertyKey) {
+        
+
+        try {
+            $value = $properties[$propertyKey];
+
+            
+                $this->_errorRegistry = new ErrorRegistryException();
+            
+
+            
+
+            
+
+            
+                if ($this->_errorRegistry->getErrors()) {
+                    $invalidProperties[$propertyKey] = $this->_errorRegistry->getErrors();
+                }
+            
+
+            
+                $this->_additionalProperties[$propertyKey] = $value;
+            
+        } catch (\Exception $e) {
+            // collect all errors concerning invalid additional properties
+            isset($invalidProperties[$propertyKey])
+                ? $invalidProperties[$propertyKey][] = $e
+                : $invalidProperties[$propertyKey] = [$e];
+        }
+    }
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    
+        if (!empty($invalidProperties)) {
+            $this->_additionalProperties = $rollbackValues;
+        }
+    
+
+    return !empty($invalidProperties);
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidAdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Consts65d4b00f3bde0',
+  1 => $invalidProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Features65d4b00f3b44e.php
+++ b/result/Schema_Features65d4b00f3b44e.php
@@ -1,0 +1,226 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Features65d4b00f3b44e
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Features65d4b00f3b44e implements JSONModelInterface
+{
+    
+
+    
+        /** @var bool|null Should boot with support for network request via wp_safe_remote_get? */
+        protected $networking;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Features65d4b00f3b44e constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processNetworking($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'networking',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Features65d4b00f3b44e',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of networking.
+             *
+             * Should boot with support for network request via wp_safe_remote_get?
+             *
+             * @return bool|null
+             */
+            public function getNetworking()
+                : ?bool
+            {
+                
+
+                return $this->networking;
+            }
+
+            
+                /**
+                 * Set the value of networking.
+                 *
+                 * @param bool $networking Should boot with support for network request via wp_safe_remote_get?
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setNetworking(
+                    bool $networking
+                ): self {
+                    if ($this->networking === $networking) {
+                        return $this;
+                    }
+
+                    $value = $modelData['networking'] = $networking;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateNetworking($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->networking = $value;
+                    $this->_rawModelDataInput['networking'] = $networking;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property networking
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processNetworking(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('networking', $modelData) && $this->networking === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('networking', $modelData) ? $modelData['networking'] : $this->networking;
+
+                
+
+                $this->networking = $this->validateNetworking($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property networking
+             */
+            protected function validateNetworking($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'networking',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarrayplugins65d4b00f3b8b0.php
+++ b/result/Schema_Itemofarrayplugins65d4b00f3b8b0.php
@@ -1,0 +1,338 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarrayplugins65d4b00f3b8b0
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarrayplugins65d4b00f3b8b0 implements JSONModelInterface
+{
+    
+
+    
+        /** @var string Identifies the file resource as Virtual File System (VFS) */
+        protected $resource;
+    
+        /** @var string The path to the file in the VFS */
+        protected $path;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarrayplugins65d4b00f3b8b0 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processResource($rawModelDataInput);
+            
+        
+            
+                $this->processPath($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'resource',
+   'path',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarrayplugins65d4b00f3b8b0',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of resource.
+             *
+             * Identifies the file resource as Virtual File System (VFS)
+             *
+             * @return string
+             */
+            public function getResource()
+                : string
+            {
+                
+
+                return $this->resource;
+            }
+
+            
+                /**
+                 * Set the value of resource.
+                 *
+                 * @param string $resource Identifies the file resource as Virtual File System (VFS)
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setResource(
+                    string $resource
+                ): self {
+                    if ($this->resource === $resource) {
+                        return $this;
+                    }
+
+                    $value = $modelData['resource'] = $resource;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateResource($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->resource = $value;
+                    $this->_rawModelDataInput['resource'] = $resource;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property resource
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processResource(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('resource', $modelData) ? $modelData['resource'] : $this->resource;
+
+                
+
+                $this->resource = $this->validateResource($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property resource
+             */
+            protected function validateResource($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'filesystem') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'resource',
+  1 => 'filesystem',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of path.
+             *
+             * The path to the file in the VFS
+             *
+             * @return string
+             */
+            public function getPath()
+                : string
+            {
+                
+
+                return $this->path;
+            }
+
+            
+                /**
+                 * Set the value of path.
+                 *
+                 * @param string $path The path to the file in the VFS
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPath(
+                    string $path
+                ): self {
+                    if ($this->path === $path) {
+                        return $this;
+                    }
+
+                    $value = $modelData['path'] = $path;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->path = $value;
+                    $this->_rawModelDataInput['path'] = $path;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property path
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('path', $modelData) ? $modelData['path'] : $this->path;
+
+                
+
+                $this->path = $this->validatePath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property path
+             */
+            protected function validatePath($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('path', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'path',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'path',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarrayplugins65d4b00f3b94b.php
+++ b/result/Schema_Itemofarrayplugins65d4b00f3b94b.php
@@ -1,0 +1,296 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare( strict_types=1 );
+
+
+namespace MyApp\Model;
+
+
+use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarrayplugins65d4b00f3b94b
+ * @package MyApp\Model
+ *
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarrayplugins65d4b00f3b94b implements JSONModelInterface {
+
+
+	/** @var string Identifies the file resource as an inline string */
+	protected $resource;
+
+	/** @var string The contents of the file */
+	protected $contents;
+
+	/** @var array */
+	protected $_rawModelDataInput = [];
+
+
+	/** @var ErrorRegistryException Collect all validation errors */
+	protected $_errorRegistry;
+
+
+	/**
+	 * Schema_Itemofarrayplugins65d4b00f3b94b constructor.
+	 *
+	 * @param array $rawModelDataInput
+	 *
+	 * @throws ErrorRegistryException
+	 */
+	public function __construct( array $rawModelDataInput = [] ) {
+
+		$this->_errorRegistry = new ErrorRegistryException();
+
+
+		$this->executeBaseValidators( $rawModelDataInput );
+
+
+		$this->processResource( $rawModelDataInput );
+
+
+		$this->processContents( $rawModelDataInput );
+
+
+		if ( count( $this->_errorRegistry->getErrors() ) ) {
+			throw $this->_errorRegistry;
+		}
+
+
+		$this->_rawModelDataInput = $rawModelDataInput;
+
+
+	}
+
+
+	protected function executeBaseValidators( array &$modelData ): void {
+		$value = &$modelData;
+
+
+		if ( $additionalProperties = ( static function () use ( $modelData ): array {
+			$additionalProperties = array_diff( array_keys( $modelData ), array(
+				'resource',
+				'contents',
+			) );
+
+
+			return $additionalProperties;
+		} )() ) {
+			$this->_errorRegistry->addError( new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException( $value ?? null,
+				...
+				array(
+					0 => 'Schema_Itemofarrayplugins65d4b00f3b94b',
+					1 => $additionalProperties,
+				) ) );
+		}
+
+
+	}
+
+
+	/**
+	 * Get the raw input used to set up the model
+	 *
+	 * @return array
+	 */
+	public function getRawModelDataInput(): array {
+		return $this->_rawModelDataInput;
+	}
+
+
+	/**
+	 * Get the value of resource.
+	 *
+	 * Identifies the file resource as an inline string
+	 *
+	 * @return string
+	 */
+	public function getResource(): string {
+
+
+		return $this->resource;
+	}
+
+
+	/**
+	 * Set the value of resource.
+	 *
+	 * @param string $resource Identifies the file resource as an inline string
+	 *
+	 * @return self
+	 * @throws ErrorRegistryException
+	 *
+	 */
+	public function setResource(
+		string $resource
+	): self {
+		if ( $this->resource === $resource ) {
+			return $this;
+		}
+
+		$value = $modelData['resource'] = $resource;
+
+
+		$this->_errorRegistry = new ErrorRegistryException();
+
+
+		$value = $this->validateResource( $value, $modelData );
+
+
+		if ( $this->_errorRegistry->getErrors() ) {
+			throw $this->_errorRegistry;
+		}
+
+
+		$this->resource = $value;
+		$this->_rawModelDataInput['resource'] = $resource;
+
+
+		return $this;
+	}
+
+
+	/**
+	 * Extract the value, perform validations and set the property resource
+	 *
+	 * @param array $modelData
+	 *
+	 * @throws ErrorRegistryException
+	 */
+	protected function processResource( array $modelData ): void {
+
+
+		$value = array_key_exists( 'resource', $modelData ) ? $modelData['resource'] : $this->resource;
+
+
+		$this->resource = $this->validateResource( $value, $modelData );
+	}
+
+	/**
+	 * Execute all validators for the property resource
+	 */
+	protected function validateResource( $value, array $modelData ) {
+
+
+		if ( $value !== 'inline' ) {
+			$this->_errorRegistry->addError( new \PHPModelGenerator\Exception\Generic\InvalidConstException( $value ?? null,
+				...
+				array(
+					0 => 'resource',
+					1 => 'inline',
+				) ) );
+		}
+
+
+		return $value;
+	}
+
+
+	/**
+	 * Get the value of contents.
+	 *
+	 * The contents of the file
+	 *
+	 * @return string
+	 */
+	public function getContents(): string {
+
+
+		return $this->contents;
+	}
+
+
+	/**
+	 * Set the value of contents.
+	 *
+	 * @param string $contents The contents of the file
+	 *
+	 * @return self
+	 * @throws ErrorRegistryException
+	 *
+	 */
+	public function setContents(
+		string $contents
+	): self {
+		if ( $this->contents === $contents ) {
+			return $this;
+		}
+
+		$value = $modelData['contents'] = $contents;
+
+
+		$this->_errorRegistry = new ErrorRegistryException();
+
+
+		$value = $this->validateContents( $value, $modelData );
+
+
+		if ( $this->_errorRegistry->getErrors() ) {
+			throw $this->_errorRegistry;
+		}
+
+
+		$this->contents = $value;
+		$this->_rawModelDataInput['contents'] = $contents;
+
+
+		return $this;
+	}
+
+
+	/**
+	 * Extract the value, perform validations and set the property contents
+	 *
+	 * @param array $modelData
+	 *
+	 * @throws ErrorRegistryException
+	 */
+	protected function processContents( array $modelData ): void {
+
+
+		$value = array_key_exists( 'contents', $modelData ) ? $modelData['contents'] : $this->contents;
+
+
+		$this->contents = $this->validateContents( $value, $modelData );
+	}
+
+	/**
+	 * Execute all validators for the property contents
+	 */
+	protected function validateContents( $value, array $modelData ) {
+
+
+		if ( ! array_key_exists( 'contents', $modelData ) ) {
+			$this->_errorRegistry->addError( new \PHPModelGenerator\Exception\Object\RequiredValueException( $value ?? null,
+				...
+				array(
+					0 => 'contents',
+				) ) );
+		}
+
+
+		if ( ! is_string( $value ) ) {
+			$this->_errorRegistry->addError( new \PHPModelGenerator\Exception\Generic\InvalidTypeException( $value ?? null,
+				...
+				array(
+					0 => 'contents',
+					1 => 'string',
+				) ) );
+		}
+
+
+		return $value;
+	}
+
+
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarrayplugins65d4b00f3b986.php
+++ b/result/Schema_Itemofarrayplugins65d4b00f3b986.php
@@ -1,0 +1,338 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarrayplugins65d4b00f3b986
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarrayplugins65d4b00f3b986 implements JSONModelInterface
+{
+    
+
+    
+        /** @var string Identifies the file resource as a WordPress Core theme */
+        protected $resource;
+    
+        /** @var string The slug of the WordPress Core theme */
+        protected $slug;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarrayplugins65d4b00f3b986 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processResource($rawModelDataInput);
+            
+        
+            
+                $this->processSlug($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'resource',
+   'slug',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarrayplugins65d4b00f3b986',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of resource.
+             *
+             * Identifies the file resource as a WordPress Core theme
+             *
+             * @return string
+             */
+            public function getResource()
+                : string
+            {
+                
+
+                return $this->resource;
+            }
+
+            
+                /**
+                 * Set the value of resource.
+                 *
+                 * @param string $resource Identifies the file resource as a WordPress Core theme
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setResource(
+                    string $resource
+                ): self {
+                    if ($this->resource === $resource) {
+                        return $this;
+                    }
+
+                    $value = $modelData['resource'] = $resource;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateResource($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->resource = $value;
+                    $this->_rawModelDataInput['resource'] = $resource;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property resource
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processResource(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('resource', $modelData) ? $modelData['resource'] : $this->resource;
+
+                
+
+                $this->resource = $this->validateResource($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property resource
+             */
+            protected function validateResource($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'wordpress.org/themes') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'resource',
+  1 => 'wordpress.org/themes',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of slug.
+             *
+             * The slug of the WordPress Core theme
+             *
+             * @return string
+             */
+            public function getSlug()
+                : string
+            {
+                
+
+                return $this->slug;
+            }
+
+            
+                /**
+                 * Set the value of slug.
+                 *
+                 * @param string $slug The slug of the WordPress Core theme
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSlug(
+                    string $slug
+                ): self {
+                    if ($this->slug === $slug) {
+                        return $this;
+                    }
+
+                    $value = $modelData['slug'] = $slug;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSlug($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->slug = $value;
+                    $this->_rawModelDataInput['slug'] = $slug;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property slug
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSlug(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('slug', $modelData) ? $modelData['slug'] : $this->slug;
+
+                
+
+                $this->slug = $this->validateSlug($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property slug
+             */
+            protected function validateSlug($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('slug', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'slug',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'slug',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarrayplugins65d4b00f3b9ba.php
+++ b/result/Schema_Itemofarrayplugins65d4b00f3b9ba.php
@@ -1,0 +1,338 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarrayplugins65d4b00f3b9ba
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarrayplugins65d4b00f3b9ba implements JSONModelInterface
+{
+    
+
+    
+        /** @var string Identifies the file resource as a WordPress Core plugin */
+        protected $resource;
+    
+        /** @var string The slug of the WordPress Core plugin */
+        protected $slug;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarrayplugins65d4b00f3b9ba constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processResource($rawModelDataInput);
+            
+        
+            
+                $this->processSlug($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'resource',
+   'slug',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarrayplugins65d4b00f3b9ba',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of resource.
+             *
+             * Identifies the file resource as a WordPress Core plugin
+             *
+             * @return string
+             */
+            public function getResource()
+                : string
+            {
+                
+
+                return $this->resource;
+            }
+
+            
+                /**
+                 * Set the value of resource.
+                 *
+                 * @param string $resource Identifies the file resource as a WordPress Core plugin
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setResource(
+                    string $resource
+                ): self {
+                    if ($this->resource === $resource) {
+                        return $this;
+                    }
+
+                    $value = $modelData['resource'] = $resource;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateResource($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->resource = $value;
+                    $this->_rawModelDataInput['resource'] = $resource;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property resource
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processResource(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('resource', $modelData) ? $modelData['resource'] : $this->resource;
+
+                
+
+                $this->resource = $this->validateResource($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property resource
+             */
+            protected function validateResource($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'wordpress.org/plugins') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'resource',
+  1 => 'wordpress.org/plugins',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of slug.
+             *
+             * The slug of the WordPress Core plugin
+             *
+             * @return string
+             */
+            public function getSlug()
+                : string
+            {
+                
+
+                return $this->slug;
+            }
+
+            
+                /**
+                 * Set the value of slug.
+                 *
+                 * @param string $slug The slug of the WordPress Core plugin
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSlug(
+                    string $slug
+                ): self {
+                    if ($this->slug === $slug) {
+                        return $this;
+                    }
+
+                    $value = $modelData['slug'] = $slug;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSlug($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->slug = $value;
+                    $this->_rawModelDataInput['slug'] = $slug;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property slug
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSlug(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('slug', $modelData) ? $modelData['slug'] : $this->slug;
+
+                
+
+                $this->slug = $this->validateSlug($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property slug
+             */
+            protected function validateSlug($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('slug', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'slug',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'slug',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarrayplugins65d4b00f3b9ea.php
+++ b/result/Schema_Itemofarrayplugins65d4b00f3b9ea.php
@@ -1,0 +1,449 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarrayplugins65d4b00f3b9ea
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarrayplugins65d4b00f3b9ea implements JSONModelInterface
+{
+    
+
+    
+        /** @var string Identifies the file resource as a URL */
+        protected $resource;
+    
+        /** @var string The URL of the file */
+        protected $url;
+    
+        /** @var string|null Optional caption for displaying a progress message */
+        protected $caption;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarrayplugins65d4b00f3b9ea constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processResource($rawModelDataInput);
+            
+        
+            
+                $this->processUrl($rawModelDataInput);
+            
+        
+            
+                $this->processCaption($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'resource',
+   'url',
+   'caption',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarrayplugins65d4b00f3b9ea',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of resource.
+             *
+             * Identifies the file resource as a URL
+             *
+             * @return string
+             */
+            public function getResource()
+                : string
+            {
+                
+
+                return $this->resource;
+            }
+
+            
+                /**
+                 * Set the value of resource.
+                 *
+                 * @param string $resource Identifies the file resource as a URL
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setResource(
+                    string $resource
+                ): self {
+                    if ($this->resource === $resource) {
+                        return $this;
+                    }
+
+                    $value = $modelData['resource'] = $resource;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateResource($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->resource = $value;
+                    $this->_rawModelDataInput['resource'] = $resource;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property resource
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processResource(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('resource', $modelData) ? $modelData['resource'] : $this->resource;
+
+                
+
+                $this->resource = $this->validateResource($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property resource
+             */
+            protected function validateResource($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'url') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'resource',
+  1 => 'url',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of url.
+             *
+             * The URL of the file
+             *
+             * @return string
+             */
+            public function getUrl()
+                : string
+            {
+                
+
+                return $this->url;
+            }
+
+            
+                /**
+                 * Set the value of url.
+                 *
+                 * @param string $url The URL of the file
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setUrl(
+                    string $url
+                ): self {
+                    if ($this->url === $url) {
+                        return $this;
+                    }
+
+                    $value = $modelData['url'] = $url;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateUrl($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->url = $value;
+                    $this->_rawModelDataInput['url'] = $url;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property url
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processUrl(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('url', $modelData) ? $modelData['url'] : $this->url;
+
+                
+
+                $this->url = $this->validateUrl($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property url
+             */
+            protected function validateUrl($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('url', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'url',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'url',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of caption.
+             *
+             * Optional caption for displaying a progress message
+             *
+             * @return string|null
+             */
+            public function getCaption()
+                : ?string
+            {
+                
+
+                return $this->caption;
+            }
+
+            
+                /**
+                 * Set the value of caption.
+                 *
+                 * @param string $caption Optional caption for displaying a progress message
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setCaption(
+                    string $caption
+                ): self {
+                    if ($this->caption === $caption) {
+                        return $this;
+                    }
+
+                    $value = $modelData['caption'] = $caption;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateCaption($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->caption = $value;
+                    $this->_rawModelDataInput['caption'] = $caption;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property caption
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processCaption(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('caption', $modelData) && $this->caption === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('caption', $modelData) ? $modelData['caption'] : $this->caption;
+
+                
+
+                $this->caption = $this->validateCaption($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property caption
+             */
+            protected function validateCaption($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'caption',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3bc1a.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3bc1a.php
@@ -1,0 +1,566 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3bc1a
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3bc1a implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string Plugin slug, like 'gutenberg' or 'hello-dolly'. */
+        protected $slug;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3bc1a constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processSlug($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'slug',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3bc1a',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'activatePlugin') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'activatePlugin',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of slug.
+             *
+             * Plugin slug, like 'gutenberg' or 'hello-dolly'.
+             *
+             * @return string
+             */
+            public function getSlug()
+                : string
+            {
+                
+
+                return $this->slug;
+            }
+
+            
+                /**
+                 * Set the value of slug.
+                 *
+                 * @param string $slug Plugin slug, like 'gutenberg' or 'hello-dolly'.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSlug(
+                    string $slug
+                ): self {
+                    if ($this->slug === $slug) {
+                        return $this;
+                    }
+
+                    $value = $modelData['slug'] = $slug;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSlug($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->slug = $value;
+                    $this->_rawModelDataInput['slug'] = $slug;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property slug
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSlug(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('slug', $modelData) ? $modelData['slug'] : $this->slug;
+
+                
+
+                $this->slug = $this->validateSlug($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property slug
+             */
+            protected function validateSlug($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('slug', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'slug',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'slug',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3bd2b.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3bd2b.php
@@ -1,0 +1,566 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3bd2b
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3bd2b implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string Theme slug, like 'twentytwentythree'. */
+        protected $slug;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3bd2b constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processSlug($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'slug',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3bd2b',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'activateTheme') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'activateTheme',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of slug.
+             *
+             * Theme slug, like 'twentytwentythree'.
+             *
+             * @return string
+             */
+            public function getSlug()
+                : string
+            {
+                
+
+                return $this->slug;
+            }
+
+            
+                /**
+                 * Set the value of slug.
+                 *
+                 * @param string $slug Theme slug, like 'twentytwentythree'.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSlug(
+                    string $slug
+                ): self {
+                    if ($this->slug === $slug) {
+                        return $this;
+                    }
+
+                    $value = $modelData['slug'] = $slug;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSlug($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->slug = $value;
+                    $this->_rawModelDataInput['slug'] = $slug;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property slug
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSlug(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('slug', $modelData) ? $modelData['slug'] : $this->slug;
+
+                
+
+                $this->slug = $this->validateSlug($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property slug
+             */
+            protected function validateSlug($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('slug', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'slug',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'slug',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3bd71.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3bd71.php
@@ -1,0 +1,682 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3bd71
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3bd71 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string Source path */
+        protected $fromPath;
+    
+        /** @var string Target path */
+        protected $toPath;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3bd71 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processFromPath($rawModelDataInput);
+            
+        
+            
+                $this->processToPath($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'fromPath',
+   'toPath',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3bd71',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'cp') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'cp',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of fromPath.
+             *
+             * Source path
+             *
+             * @return string
+             */
+            public function getFromPath()
+                : string
+            {
+                
+
+                return $this->fromPath;
+            }
+
+            
+                /**
+                 * Set the value of fromPath.
+                 *
+                 * @param string $fromPath Source path
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setFromPath(
+                    string $fromPath
+                ): self {
+                    if ($this->fromPath === $fromPath) {
+                        return $this;
+                    }
+
+                    $value = $modelData['fromPath'] = $fromPath;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateFromPath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->fromPath = $value;
+                    $this->_rawModelDataInput['fromPath'] = $fromPath;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property fromPath
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processFromPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('fromPath', $modelData) ? $modelData['fromPath'] : $this->fromPath;
+
+                
+
+                $this->fromPath = $this->validateFromPath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property fromPath
+             */
+            protected function validateFromPath($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('fromPath', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'fromPath',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'fromPath',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of toPath.
+             *
+             * Target path
+             *
+             * @return string
+             */
+            public function getToPath()
+                : string
+            {
+                
+
+                return $this->toPath;
+            }
+
+            
+                /**
+                 * Set the value of toPath.
+                 *
+                 * @param string $toPath Target path
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setToPath(
+                    string $toPath
+                ): self {
+                    if ($this->toPath === $toPath) {
+                        return $this;
+                    }
+
+                    $value = $modelData['toPath'] = $toPath;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateToPath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->toPath = $value;
+                    $this->_rawModelDataInput['toPath'] = $toPath;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property toPath
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processToPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('toPath', $modelData) ? $modelData['toPath'] : $this->toPath;
+
+                
+
+                $this->toPath = $this->validateToPath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property toPath
+             */
+            protected function validateToPath($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('toPath', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'toPath',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'toPath',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3bdb9.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3bdb9.php
@@ -1,0 +1,592 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3bdb9
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3bdb9 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var Schema_Consts65d4b00f3bde0 The constants to define */
+        protected $consts;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3bdb9 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processConsts($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'consts',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3bdb9',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'defineWpConfigConsts') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'defineWpConfigConsts',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of consts.
+             *
+             * The constants to define
+             *
+             * @return Schema_Consts65d4b00f3bde0
+             */
+            public function getConsts()
+                : Schema_Consts65d4b00f3bde0
+            {
+                
+
+                return $this->consts;
+            }
+
+            
+                /**
+                 * Set the value of consts.
+                 *
+                 * @param Schema_Consts65d4b00f3bde0 $consts The constants to define
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setConsts(
+                    Schema_Consts65d4b00f3bde0 $consts
+                ): self {
+                    if ($this->consts === $consts) {
+                        return $this;
+                    }
+
+                    $value = $modelData['consts'] = $consts;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateConsts($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->consts = $value;
+                    $this->_rawModelDataInput['consts'] = $consts;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property consts
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processConsts(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('consts', $modelData) ? $modelData['consts'] : $this->consts;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Consts65d4b00f3bde0($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'consts',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->consts = $this->validateConsts($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property consts
+             */
+            protected function validateConsts($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('consts', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'consts',
+)));
+}
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'consts',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Consts65d4b00f3bde0)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'consts',
+  1 => 'Schema_Consts65d4b00f3bde0',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3be19.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3be19.php
@@ -1,0 +1,566 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3be19
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3be19 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string The URL */
+        protected $siteUrl;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3be19 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processSiteUrl($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'siteUrl',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3be19',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'defineSiteUrl') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'defineSiteUrl',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of siteUrl.
+             *
+             * The URL
+             *
+             * @return string
+             */
+            public function getSiteUrl()
+                : string
+            {
+                
+
+                return $this->siteUrl;
+            }
+
+            
+                /**
+                 * Set the value of siteUrl.
+                 *
+                 * @param string $siteUrl The URL
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSiteUrl(
+                    string $siteUrl
+                ): self {
+                    if ($this->siteUrl === $siteUrl) {
+                        return $this;
+                    }
+
+                    $value = $modelData['siteUrl'] = $siteUrl;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSiteUrl($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->siteUrl = $value;
+                    $this->_rawModelDataInput['siteUrl'] = $siteUrl;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property siteUrl
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSiteUrl(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('siteUrl', $modelData) ? $modelData['siteUrl'] : $this->siteUrl;
+
+                
+
+                $this->siteUrl = $this->validateSiteUrl($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property siteUrl
+             */
+            protected function validateSiteUrl($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('siteUrl', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'siteUrl',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'siteUrl',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3be55.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3be55.php
@@ -1,0 +1,450 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3be55
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3be55 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3be55 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3be55',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'enableMultisite') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'enableMultisite',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3be88.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3be88.php
@@ -1,0 +1,551 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3be88
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3be88 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null */
+        protected $file;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3be88 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processFile($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'file',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3be88',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'importFile') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'importFile',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of file.
+             *
+             * 
+             *
+             * @return string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null
+             */
+            public function getFile()
+                
+            {
+                
+
+                return $this->file;
+            }
+
+            
+                /**
+                 * Set the value of file.
+                 *
+                 * @param string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c $file
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setFile(
+                     $file
+                ): self {
+                    if ($this->file === $file) {
+                        return $this;
+                    }
+
+                    $value = $modelData['file'] = $file;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateFile($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->file = $value;
+                    $this->_rawModelDataInput['file'] = $file;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property file
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processFile(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('file', $modelData) && $this->file === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('file', $modelData) ? $modelData['file'] : $this->file;
+
+                
+
+                $this->file = $this->validateFile($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property file
+             */
+            protected function validateFile($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3bec0.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3bec0.php
@@ -1,0 +1,688 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3bec0
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3bec0 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string The step identifier. */
+        protected $step;
+    
+        /** @var string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null */
+        protected $pluginZipFile;
+    
+        /** @var Schema_Options65d4b00f3beeb|null */
+        protected $options;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3bec0 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processPluginZipFile($rawModelDataInput);
+            
+        
+            
+                $this->processOptions($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'pluginZipFile',
+   'options',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3bec0',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * The step identifier.
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step The step identifier.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'installPlugin') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'installPlugin',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of pluginZipFile.
+             *
+             * 
+             *
+             * @return string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null
+             */
+            public function getPluginZipFile()
+                
+            {
+                
+
+                return $this->pluginZipFile;
+            }
+
+            
+                /**
+                 * Set the value of pluginZipFile.
+                 *
+                 * @param string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c $pluginZipFile
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setPluginZipFile(
+                     $pluginZipFile
+                ): self {
+                    if ($this->pluginZipFile === $pluginZipFile) {
+                        return $this;
+                    }
+
+                    $value = $modelData['pluginZipFile'] = $pluginZipFile;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePluginZipFile($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->pluginZipFile = $value;
+                    $this->_rawModelDataInput['pluginZipFile'] = $pluginZipFile;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property pluginZipFile
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processPluginZipFile(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('pluginZipFile', $modelData) && $this->pluginZipFile === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('pluginZipFile', $modelData) ? $modelData['pluginZipFile'] : $this->pluginZipFile;
+
+                
+
+                $this->pluginZipFile = $this->validatePluginZipFile($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property pluginZipFile
+             */
+            protected function validatePluginZipFile($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of options.
+             *
+             * 
+             *
+             * @return Schema_Options65d4b00f3beeb|null
+             */
+            public function getOptions()
+                : ?Schema_Options65d4b00f3beeb
+            {
+                
+
+                return $this->options;
+            }
+
+            
+                /**
+                 * Set the value of options.
+                 *
+                 * @param Schema_Options65d4b00f3beeb $options
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setOptions(
+                    Schema_Options65d4b00f3beeb $options
+                ): self {
+                    if ($this->options === $options) {
+                        return $this;
+                    }
+
+                    $value = $modelData['options'] = $options;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateOptions($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->options = $value;
+                    $this->_rawModelDataInput['options'] = $options;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property options
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processOptions(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('options', $modelData) && $this->options === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('options', $modelData) ? $modelData['options'] : $this->options;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Options65d4b00f3beeb($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'options',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->options = $this->validateOptions($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property options
+             */
+            protected function validateOptions($value, array $modelData)
+            {
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'options',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Options65d4b00f3beeb)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'options',
+  1 => 'Schema_Options65d4b00f3beeb',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3bf1f.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3bf1f.php
@@ -1,0 +1,688 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3bf1f
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3bf1f implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string The step identifier. */
+        protected $step;
+    
+        /** @var string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null */
+        protected $themeZipFile;
+    
+        /** @var Schema_Options65d4b00f3bf49|null Optional installation options. */
+        protected $options;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3bf1f constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processThemeZipFile($rawModelDataInput);
+            
+        
+            
+                $this->processOptions($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'themeZipFile',
+   'options',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3bf1f',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * The step identifier.
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step The step identifier.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'installTheme') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'installTheme',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of themeZipFile.
+             *
+             * 
+             *
+             * @return string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null
+             */
+            public function getThemeZipFile()
+                
+            {
+                
+
+                return $this->themeZipFile;
+            }
+
+            
+                /**
+                 * Set the value of themeZipFile.
+                 *
+                 * @param string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c $themeZipFile
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setThemeZipFile(
+                     $themeZipFile
+                ): self {
+                    if ($this->themeZipFile === $themeZipFile) {
+                        return $this;
+                    }
+
+                    $value = $modelData['themeZipFile'] = $themeZipFile;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateThemeZipFile($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->themeZipFile = $value;
+                    $this->_rawModelDataInput['themeZipFile'] = $themeZipFile;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property themeZipFile
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processThemeZipFile(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('themeZipFile', $modelData) && $this->themeZipFile === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('themeZipFile', $modelData) ? $modelData['themeZipFile'] : $this->themeZipFile;
+
+                
+
+                $this->themeZipFile = $this->validateThemeZipFile($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property themeZipFile
+             */
+            protected function validateThemeZipFile($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of options.
+             *
+             * Optional installation options.
+             *
+             * @return Schema_Options65d4b00f3bf49|null
+             */
+            public function getOptions()
+                : ?Schema_Options65d4b00f3bf49
+            {
+                
+
+                return $this->options;
+            }
+
+            
+                /**
+                 * Set the value of options.
+                 *
+                 * @param Schema_Options65d4b00f3bf49 $options Optional installation options.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setOptions(
+                    Schema_Options65d4b00f3bf49 $options
+                ): self {
+                    if ($this->options === $options) {
+                        return $this;
+                    }
+
+                    $value = $modelData['options'] = $options;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateOptions($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->options = $value;
+                    $this->_rawModelDataInput['options'] = $options;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property options
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processOptions(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('options', $modelData) && $this->options === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('options', $modelData) ? $modelData['options'] : $this->options;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Options65d4b00f3bf49($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'options',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->options = $this->validateOptions($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property options
+             */
+            protected function validateOptions($value, array $modelData)
+            {
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'options',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Options65d4b00f3bf49)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'options',
+  1 => 'Schema_Options65d4b00f3bf49',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3bf77.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3bf77.php
@@ -1,0 +1,566 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3bf77
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3bf77 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string The path of the directory you want to create */
+        protected $path;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3bf77 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processPath($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'path',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3bf77',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'mkdir') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'mkdir',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of path.
+             *
+             * The path of the directory you want to create
+             *
+             * @return string
+             */
+            public function getPath()
+                : string
+            {
+                
+
+                return $this->path;
+            }
+
+            
+                /**
+                 * Set the value of path.
+                 *
+                 * @param string $path The path of the directory you want to create
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPath(
+                    string $path
+                ): self {
+                    if ($this->path === $path) {
+                        return $this;
+                    }
+
+                    $value = $modelData['path'] = $path;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->path = $value;
+                    $this->_rawModelDataInput['path'] = $path;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property path
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('path', $modelData) ? $modelData['path'] : $this->path;
+
+                
+
+                $this->path = $this->validatePath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property path
+             */
+            protected function validatePath($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('path', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'path',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'path',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3bfac.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3bfac.php
@@ -1,0 +1,682 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3bfac
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3bfac implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string Source path */
+        protected $fromPath;
+    
+        /** @var string Target path */
+        protected $toPath;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3bfac constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processFromPath($rawModelDataInput);
+            
+        
+            
+                $this->processToPath($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'fromPath',
+   'toPath',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3bfac',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'mv') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'mv',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of fromPath.
+             *
+             * Source path
+             *
+             * @return string
+             */
+            public function getFromPath()
+                : string
+            {
+                
+
+                return $this->fromPath;
+            }
+
+            
+                /**
+                 * Set the value of fromPath.
+                 *
+                 * @param string $fromPath Source path
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setFromPath(
+                    string $fromPath
+                ): self {
+                    if ($this->fromPath === $fromPath) {
+                        return $this;
+                    }
+
+                    $value = $modelData['fromPath'] = $fromPath;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateFromPath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->fromPath = $value;
+                    $this->_rawModelDataInput['fromPath'] = $fromPath;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property fromPath
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processFromPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('fromPath', $modelData) ? $modelData['fromPath'] : $this->fromPath;
+
+                
+
+                $this->fromPath = $this->validateFromPath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property fromPath
+             */
+            protected function validateFromPath($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('fromPath', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'fromPath',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'fromPath',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of toPath.
+             *
+             * Target path
+             *
+             * @return string
+             */
+            public function getToPath()
+                : string
+            {
+                
+
+                return $this->toPath;
+            }
+
+            
+                /**
+                 * Set the value of toPath.
+                 *
+                 * @param string $toPath Target path
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setToPath(
+                    string $toPath
+                ): self {
+                    if ($this->toPath === $toPath) {
+                        return $this;
+                    }
+
+                    $value = $modelData['toPath'] = $toPath;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateToPath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->toPath = $value;
+                    $this->_rawModelDataInput['toPath'] = $toPath;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property toPath
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processToPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('toPath', $modelData) ? $modelData['toPath'] : $this->toPath;
+
+                
+
+                $this->toPath = $this->validateToPath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property toPath
+             */
+            protected function validateToPath($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('toPath', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'toPath',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'toPath',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3bfed.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3bfed.php
@@ -1,0 +1,566 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3bfed
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3bfed implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string The path to remove */
+        protected $path;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3bfed constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processPath($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'path',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3bfed',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'rm') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'rm',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of path.
+             *
+             * The path to remove
+             *
+             * @return string
+             */
+            public function getPath()
+                : string
+            {
+                
+
+                return $this->path;
+            }
+
+            
+                /**
+                 * Set the value of path.
+                 *
+                 * @param string $path The path to remove
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPath(
+                    string $path
+                ): self {
+                    if ($this->path === $path) {
+                        return $this;
+                    }
+
+                    $value = $modelData['path'] = $path;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->path = $value;
+                    $this->_rawModelDataInput['path'] = $path;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property path
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('path', $modelData) ? $modelData['path'] : $this->path;
+
+                
+
+                $this->path = $this->validatePath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property path
+             */
+            protected function validatePath($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('path', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'path',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'path',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3c026.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3c026.php
@@ -1,0 +1,566 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3c026
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3c026 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string The path to remove */
+        protected $path;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3c026 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processPath($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'path',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c026',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'rmdir') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'rmdir',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of path.
+             *
+             * The path to remove
+             *
+             * @return string
+             */
+            public function getPath()
+                : string
+            {
+                
+
+                return $this->path;
+            }
+
+            
+                /**
+                 * Set the value of path.
+                 *
+                 * @param string $path The path to remove
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPath(
+                    string $path
+                ): self {
+                    if ($this->path === $path) {
+                        return $this;
+                    }
+
+                    $value = $modelData['path'] = $path;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->path = $value;
+                    $this->_rawModelDataInput['path'] = $path;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property path
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('path', $modelData) ? $modelData['path'] : $this->path;
+
+                
+
+                $this->path = $this->validatePath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property path
+             */
+            protected function validatePath($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('path', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'path',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'path',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3c05a.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3c05a.php
@@ -1,0 +1,566 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3c05a
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3c05a implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string The step identifier. */
+        protected $step;
+    
+        /** @var string The PHP code to run. */
+        protected $code;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3c05a constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processCode($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'code',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c05a',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * The step identifier.
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step The step identifier.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'runPHP') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'runPHP',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of code.
+             *
+             * The PHP code to run.
+             *
+             * @return string
+             */
+            public function getCode()
+                : string
+            {
+                
+
+                return $this->code;
+            }
+
+            
+                /**
+                 * Set the value of code.
+                 *
+                 * @param string $code The PHP code to run.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setCode(
+                    string $code
+                ): self {
+                    if ($this->code === $code) {
+                        return $this;
+                    }
+
+                    $value = $modelData['code'] = $code;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateCode($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->code = $value;
+                    $this->_rawModelDataInput['code'] = $code;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property code
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processCode(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('code', $modelData) ? $modelData['code'] : $this->code;
+
+                
+
+                $this->code = $this->validateCode($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property code
+             */
+            protected function validateCode($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('code', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'code',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'code',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3c092.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3c092.php
@@ -1,0 +1,592 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3c092
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3c092 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var Schema_Options65d4b00f3c0b3 */
+        protected $options;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3c092 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processOptions($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'options',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c092',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'runWpInstallationWizard') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'runWpInstallationWizard',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of options.
+             *
+             * 
+             *
+             * @return Schema_Options65d4b00f3c0b3
+             */
+            public function getOptions()
+                : Schema_Options65d4b00f3c0b3
+            {
+                
+
+                return $this->options;
+            }
+
+            
+                /**
+                 * Set the value of options.
+                 *
+                 * @param Schema_Options65d4b00f3c0b3 $options
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setOptions(
+                    Schema_Options65d4b00f3c0b3 $options
+                ): self {
+                    if ($this->options === $options) {
+                        return $this;
+                    }
+
+                    $value = $modelData['options'] = $options;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateOptions($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->options = $value;
+                    $this->_rawModelDataInput['options'] = $options;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property options
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processOptions(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('options', $modelData) ? $modelData['options'] : $this->options;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Options65d4b00f3c0b3($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'options',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->options = $this->validateOptions($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property options
+             */
+            protected function validateOptions($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('options', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'options',
+)));
+}
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'options',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Options65d4b00f3c0b3)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'options',
+  1 => 'Schema_Options65d4b00f3c0b3',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3c0e9.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3c0e9.php
@@ -1,0 +1,551 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3c0e9
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3c0e9 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string The step identifier. */
+        protected $step;
+    
+        /** @var string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null */
+        protected $sql;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3c0e9 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processSql($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'sql',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c0e9',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * The step identifier.
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step The step identifier.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'runSql') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'runSql',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of sql.
+             *
+             * 
+             *
+             * @return string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null
+             */
+            public function getSql()
+                
+            {
+                
+
+                return $this->sql;
+            }
+
+            
+                /**
+                 * Set the value of sql.
+                 *
+                 * @param string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c $sql
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setSql(
+                     $sql
+                ): self {
+                    if ($this->sql === $sql) {
+                        return $this;
+                    }
+
+                    $value = $modelData['sql'] = $sql;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSql($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->sql = $value;
+                    $this->_rawModelDataInput['sql'] = $sql;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property sql
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processSql(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('sql', $modelData) && $this->sql === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('sql', $modelData) ? $modelData['sql'] : $this->sql;
+
+                
+
+                $this->sql = $this->validateSql($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property sql
+             */
+            protected function validateSql($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3c123.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3c123.php
@@ -1,0 +1,592 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3c123
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3c123 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string The name of the step. Must be "setSiteOptions". */
+        protected $step;
+    
+        /** @var Schema_Consts65d4b00f3bde0 The options to set on the site. */
+        protected $options;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3c123 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processOptions($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'options',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c123',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * The name of the step. Must be "setSiteOptions".
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step The name of the step. Must be "setSiteOptions".
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'setSiteOptions') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'setSiteOptions',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of options.
+             *
+             * The options to set on the site.
+             *
+             * @return Schema_Consts65d4b00f3bde0
+             */
+            public function getOptions()
+                : Schema_Consts65d4b00f3bde0
+            {
+                
+
+                return $this->options;
+            }
+
+            
+                /**
+                 * Set the value of options.
+                 *
+                 * @param Schema_Consts65d4b00f3bde0 $options The options to set on the site.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setOptions(
+                    Schema_Consts65d4b00f3bde0 $options
+                ): self {
+                    if ($this->options === $options) {
+                        return $this;
+                    }
+
+                    $value = $modelData['options'] = $options;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateOptions($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->options = $value;
+                    $this->_rawModelDataInput['options'] = $options;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property options
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processOptions(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('options', $modelData) ? $modelData['options'] : $this->options;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Consts65d4b00f3bde0($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'options',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->options = $this->validateOptions($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property options
+             */
+            protected function validateOptions($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('options', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'options',
+)));
+}
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'options',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Consts65d4b00f3bde0)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'options',
+  1 => 'Schema_Consts65d4b00f3bde0',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3c166.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3c166.php
@@ -1,0 +1,778 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3c166
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3c166 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null */
+        protected $zipFile;
+    
+        /** @var string|null The path of the zip file to extract */
+        protected $zipPath;
+    
+        /** @var string The path to extract the zip file to */
+        protected $extractToPath;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3c166 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processZipFile($rawModelDataInput);
+            
+        
+            
+                $this->processZipPath($rawModelDataInput);
+            
+        
+            
+                $this->processExtractToPath($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'zipFile',
+   'zipPath',
+   'extractToPath',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c166',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'unzip') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'unzip',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of zipFile.
+             *
+             * 
+             *
+             * @return string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null
+             */
+            public function getZipFile()
+                
+            {
+                
+
+                return $this->zipFile;
+            }
+
+            
+                /**
+                 * Set the value of zipFile.
+                 *
+                 * @param string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c $zipFile
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setZipFile(
+                     $zipFile
+                ): self {
+                    if ($this->zipFile === $zipFile) {
+                        return $this;
+                    }
+
+                    $value = $modelData['zipFile'] = $zipFile;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateZipFile($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->zipFile = $value;
+                    $this->_rawModelDataInput['zipFile'] = $zipFile;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property zipFile
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processZipFile(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('zipFile', $modelData) && $this->zipFile === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('zipFile', $modelData) ? $modelData['zipFile'] : $this->zipFile;
+
+                
+
+                $this->zipFile = $this->validateZipFile($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property zipFile
+             */
+            protected function validateZipFile($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of zipPath.
+             *
+             * The path of the zip file to extract
+             *
+             * @return string|null
+             */
+            public function getZipPath()
+                : ?string
+            {
+                
+
+                return $this->zipPath;
+            }
+
+            
+                /**
+                 * Set the value of zipPath.
+                 *
+                 * @param string $zipPath The path of the zip file to extract
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setZipPath(
+                    string $zipPath
+                ): self {
+                    if ($this->zipPath === $zipPath) {
+                        return $this;
+                    }
+
+                    $value = $modelData['zipPath'] = $zipPath;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateZipPath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->zipPath = $value;
+                    $this->_rawModelDataInput['zipPath'] = $zipPath;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property zipPath
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processZipPath(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('zipPath', $modelData) && $this->zipPath === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('zipPath', $modelData) ? $modelData['zipPath'] : $this->zipPath;
+
+                
+
+                $this->zipPath = $this->validateZipPath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property zipPath
+             */
+            protected function validateZipPath($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'zipPath',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of extractToPath.
+             *
+             * The path to extract the zip file to
+             *
+             * @return string
+             */
+            public function getExtractToPath()
+                : string
+            {
+                
+
+                return $this->extractToPath;
+            }
+
+            
+                /**
+                 * Set the value of extractToPath.
+                 *
+                 * @param string $extractToPath The path to extract the zip file to
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setExtractToPath(
+                    string $extractToPath
+                ): self {
+                    if ($this->extractToPath === $extractToPath) {
+                        return $this;
+                    }
+
+                    $value = $modelData['extractToPath'] = $extractToPath;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateExtractToPath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->extractToPath = $value;
+                    $this->_rawModelDataInput['extractToPath'] = $extractToPath;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property extractToPath
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processExtractToPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('extractToPath', $modelData) ? $modelData['extractToPath'] : $this->extractToPath;
+
+                
+
+                $this->extractToPath = $this->validateExtractToPath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property extractToPath
+             */
+            protected function validateExtractToPath($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('extractToPath', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'extractToPath',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'extractToPath',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3c1ae.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3c1ae.php
@@ -1,0 +1,844 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3c1ae
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3c1ae implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string */
+        protected $step;
+    
+        /** @var string The path of the file to write to */
+        protected $path;
+    
+        /** @var string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null The data to write */
+        protected $data;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3c1ae constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processPath($rawModelDataInput);
+            
+        
+            
+                $this->processData($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'path',
+   'data',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c1ae',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'writeFile') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'writeFile',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of path.
+             *
+             * The path of the file to write to
+             *
+             * @return string
+             */
+            public function getPath()
+                : string
+            {
+                
+
+                return $this->path;
+            }
+
+            
+                /**
+                 * Set the value of path.
+                 *
+                 * @param string $path The path of the file to write to
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPath(
+                    string $path
+                ): self {
+                    if ($this->path === $path) {
+                        return $this;
+                    }
+
+                    $value = $modelData['path'] = $path;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->path = $value;
+                    $this->_rawModelDataInput['path'] = $path;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property path
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('path', $modelData) ? $modelData['path'] : $this->path;
+
+                
+
+                $this->path = $this->validatePath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property path
+             */
+            protected function validatePath($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('path', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'path',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'path',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of data.
+             *
+             * The data to write
+             *
+             * @return string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null
+             */
+            public function getData()
+                : ?string
+            {
+                
+
+                return $this->data;
+            }
+
+            
+                /**
+                 * Set the value of data.
+                 *
+                 * @param string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null $data The data to write
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setData(
+                    ?string $data
+                ): self {
+                    if ($this->data === $data) {
+                        return $this;
+                    }
+
+                    $value = $modelData['data'] = $data;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateData($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->data = $value;
+                    $this->_rawModelDataInput['data'] = $data;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property data
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processData(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('data', $modelData) ? $modelData['data'] : $this->data;
+
+                
+
+                $this->data = $this->validateData($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property data
+             */
+            protected function validateData($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('data', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'data',
+)));
+}
+
+                
+                    $this->validateData_ComposedProperty_65d4b00f3c1f8($value);
+                
+
+                return $value;
+            }
+        
+    
+
+    private function validateData_ComposedProperty_65d4b00f3c1f8(&$value): void {
+                    
+            $succeededCompositionElements = 0;
+            $compositionErrorCollection = [];
+        
+                    
+                    if (
+(function (&$value) use (
+    &$modelData,
+    &$modifiedModelData,
+    &$compositionErrorCollection,
+    &$succeededCompositionElements,
+    &$validatorIndex
+) {
+    $succeededCompositionElements = 2;
+    $validatorComponentIndex = 0;
+    $originalModelData = $value;
+    $proposedValue = null;
+    $modifiedValues = [];
+
+    
+
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_c6562($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'data',
+  1 => 'string',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_c6562($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+
+    
+        $value = $proposedValue;
+    
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    $result = !($succeededCompositionElements > 0);
+
+    
+
+    return $result;
+})($value)
+) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\ComposedValue\AnyOfException($value ?? null, ...array (
+  0 => 'data',
+  1 => $succeededCompositionElements,
+  2 => $compositionErrorCollection,
+)));
+                    }
+                }
+
+
+                        private function _getModifiedValues_c6562(array $originalModelData, object $nestedCompositionObject): array {
+                            $modifiedValues = [];
+                            $defaultValueMap = array (
+);
+    
+                            foreach (array (
+) as $key => $accessor) {
+                                if ((isset($originalModelData[$key]) || in_array($key, $defaultValueMap))
+                                    && method_exists($nestedCompositionObject, $accessor)
+                                    && ($modifiedValue = $nestedCompositionObject->$accessor()) !== ($originalModelData[$key] ?? !$modifiedValue)
+                                ) {
+                                    $modifiedValues[$key] = $modifiedValue;
+                                }
+                            }
+    
+                            return $modifiedValues;
+                        }
+
+
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3c217.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3c217.php
@@ -1,0 +1,739 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3c217
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3c217 implements JSONModelInterface
+{
+    
+
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string The step identifier. */
+        protected $step;
+    
+        /** @var string[] The WP CLI command to run. */
+        protected $command;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3c217 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processCommand($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'progress',
+   'continueOnError',
+   'step',
+   'command',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c217',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool $continueOnError
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'continueOnError',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * The step identifier.
+             *
+             * @return string
+             */
+            public function getStep()
+                : string
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param string $step The step identifier.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                    string $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if ($value !== 'wp-cli') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'step',
+  1 => 'wp-cli',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of command.
+             *
+             * The WP CLI command to run.
+             *
+             * @return string[]
+             */
+            public function getCommand()
+                : array
+            {
+                
+
+                return $this->command;
+            }
+
+            
+                /**
+                 * Set the value of command.
+                 *
+                 * @param string[] $command The WP CLI command to run.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setCommand(
+                    array $command
+                ): self {
+                    if ($this->command === $command) {
+                        return $this;
+                    }
+
+                    $value = $modelData['command'] = $command;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateCommand($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->command = $value;
+                    $this->_rawModelDataInput['command'] = $command;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property command
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processCommand(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('command', $modelData) ? $modelData['command'] : $this->command;
+
+                
+
+                $this->command = $this->validateCommand($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property command
+             */
+            protected function validateCommand($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('command', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'command',
+)));
+}
+
+                
+                    $this->validateCommand_ComposedProperty_65d4b00f3c25c($value);
+                
+
+                return $value;
+            }
+        
+    
+
+    private function validateCommand_ComposedProperty_65d4b00f3c25c(&$value): void {
+                    
+            $succeededCompositionElements = 0;
+            $compositionErrorCollection = [];
+        
+                    
+                    if (
+(function (&$value) use (
+    &$modelData,
+    &$modifiedModelData,
+    &$compositionErrorCollection,
+    &$succeededCompositionElements,
+    &$validatorIndex
+) {
+    $succeededCompositionElements = 1;
+    $validatorComponentIndex = 0;
+    $originalModelData = $value;
+    $proposedValue = null;
+    $modifiedValues = [];
+
+    
+
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if (!is_array($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'command',
+  1 => 'array',
+)));
+}
+
+                
+                    $this->validateCommand_ArrayItem_65d4b00f3c250($value);
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_33543($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+
+    
+        $value = $proposedValue;
+    
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    $result = !($succeededCompositionElements > 0);
+
+    
+
+    return $result;
+})($value)
+) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\ComposedValue\AnyOfException($value ?? null, ...array (
+  0 => 'command',
+  1 => $succeededCompositionElements,
+  2 => $compositionErrorCollection,
+)));
+                    }
+                }
+
+
+                        private function _getModifiedValues_33543(array $originalModelData, object $nestedCompositionObject): array {
+                            $modifiedValues = [];
+                            $defaultValueMap = array (
+);
+    
+                            foreach (array (
+) as $key => $accessor) {
+                                if ((isset($originalModelData[$key]) || in_array($key, $defaultValueMap))
+                                    && method_exists($nestedCompositionObject, $accessor)
+                                    && ($modifiedValue = $nestedCompositionObject->$accessor()) !== ($originalModelData[$key] ?? !$modifiedValue)
+                                ) {
+                                    $modifiedValues[$key] = $modifiedValue;
+                                }
+                            }
+    
+                            return $modifiedValues;
+                        }
+
+private function validateCommand_ArrayItem_65d4b00f3c250(&$value): void {
+                    $invalidItems_b5d3f8742cf5838dfe73097d04a820bc = [];
+                    
+                    if (is_array($value) && (function (&$items) use (&$invalidItems_b5d3f8742cf5838dfe73097d04a820bc) {
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    foreach ($items as $index => &$value) {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        try {
+            
+
+            
+                
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'item of array command',
+  1 => 'string',
+)));
+}
+
+            
+
+            
+                if ($this->_errorRegistry->getErrors()) {
+                    $invalidItems_b5d3f8742cf5838dfe73097d04a820bc[$index] = $this->_errorRegistry->getErrors();
+                }
+            
+        } catch (\Exception $e) {
+            // collect all errors concerning invalid items
+            isset($invalidItems_b5d3f8742cf5838dfe73097d04a820bc[$index])
+                ? $invalidItems_b5d3f8742cf5838dfe73097d04a820bc[$index][] = $e
+                : $invalidItems_b5d3f8742cf5838dfe73097d04a820bc[$index] = [$e];
+        }
+    }
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    return !empty($invalidItems_b5d3f8742cf5838dfe73097d04a820bc);
+})($value)) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Arrays\InvalidItemException($value ?? null, ...array (
+  0 => 'command',
+  1 => $invalidItems_b5d3f8742cf5838dfe73097d04a820bc,
+)));
+                    }
+                }
+
+
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Itemofarraysteps65d4b00f3c28b.php
+++ b/result/Schema_Itemofarraysteps65d4b00f3c28b.php
@@ -1,0 +1,4886 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Itemofarraysteps65d4b00f3c28b
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Itemofarraysteps65d4b00f3c28b implements JSONModelInterface
+{
+    
+
+    
+        /** @var mixed */
+        protected $step;
+    
+        /** @var Schema_Progress65d4b00f3bc38|null */
+        protected $progress;
+    
+        /** @var bool|null */
+        protected $continueOnError;
+    
+        /** @var string|null Plugin slug, like 'gutenberg' or 'hello-dolly'. */
+        protected $slug;
+    
+        /** @var string|null Source path */
+        protected $fromPath;
+    
+        /** @var string|null Target path */
+        protected $toPath;
+    
+        /** @var Schema_Consts65d4b00f3bde0|null The constants to define */
+        protected $consts;
+    
+        /** @var string|null The URL */
+        protected $siteUrl;
+    
+        /** @var string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null */
+        protected $itemOfArrayPlugins;
+    
+        /** @var Schema_Options65d4b00f3beeb|null */
+        protected $options;
+    
+        /** @var string|null The path of the directory you want to create */
+        protected $path;
+    
+        /** @var string|null The PHP code to run. */
+        protected $code;
+    
+        /** @var string|null The path of the zip file to extract */
+        protected $zipPath;
+    
+        /** @var string|null The path to extract the zip file to */
+        protected $extractToPath;
+    
+        /** @var string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null The data to write */
+        protected $data;
+    
+        /** @var string[]|null The WP CLI command to run. */
+        protected $command;
+    
+        /** @var array Track the internal validation state of composed validations */
+        private $_propertyValidationState = array (
+  0 => 
+  array (
+  ),
+);
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Itemofarraysteps65d4b00f3c28b constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processStep($rawModelDataInput);
+            
+        
+            
+                $this->processProgress($rawModelDataInput);
+            
+        
+            
+                $this->processContinueOnError($rawModelDataInput);
+            
+        
+            
+                $this->processSlug($rawModelDataInput);
+            
+        
+            
+                $this->processFromPath($rawModelDataInput);
+            
+        
+            
+                $this->processToPath($rawModelDataInput);
+            
+        
+            
+                $this->processConsts($rawModelDataInput);
+            
+        
+            
+                $this->processSiteUrl($rawModelDataInput);
+            
+        
+            
+                $this->processItemOfArrayPlugins($rawModelDataInput);
+            
+        
+            
+                $this->processOptions($rawModelDataInput);
+            
+        
+            
+                $this->processPath($rawModelDataInput);
+            
+        
+            
+                $this->processCode($rawModelDataInput);
+            
+        
+            
+                $this->processZipPath($rawModelDataInput);
+            
+        
+            
+                $this->processExtractToPath($rawModelDataInput);
+            
+        
+            
+                $this->processData($rawModelDataInput);
+            
+        
+            
+                $this->processCommand($rawModelDataInput);
+            
+        
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+
+            
+                $this->validateComposition_0($modelData);
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of step.
+             *
+             * 
+             *
+             * @return mixed
+             */
+            public function getStep()
+                
+            {
+                
+
+                return $this->step;
+            }
+
+            
+                /**
+                 * Set the value of step.
+                 *
+                 * @param mixed $step
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setStep(
+                     $step
+                ): self {
+                    if ($this->step === $step) {
+                        return $this;
+                    }
+
+                    $value = $modelData['step'] = $step;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateStep($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->step = $value;
+                    $this->_rawModelDataInput['step'] = $step;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property step
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processStep(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('step', $modelData) ? $modelData['step'] : $this->step;
+
+                
+
+                $this->step = $this->validateStep($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property step
+             */
+            protected function validateStep($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('step', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'step',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of progress.
+             *
+             * 
+             *
+             * @return Schema_Progress65d4b00f3bc38|null
+             */
+            public function getProgress()
+                : ?Schema_Progress65d4b00f3bc38
+            {
+                
+
+                return $this->progress;
+            }
+
+            
+                /**
+                 * Set the value of progress.
+                 *
+                 * @param Schema_Progress65d4b00f3bc38|null $progress
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setProgress(
+                    ?Schema_Progress65d4b00f3bc38 $progress
+                ): self {
+                    if ($this->progress === $progress) {
+                        return $this;
+                    }
+
+                    $value = $modelData['progress'] = $progress;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateProgress($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->progress = $value;
+                    $this->_rawModelDataInput['progress'] = $progress;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property progress
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processProgress(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('progress', $modelData) && $this->progress === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('progress', $modelData) ? $modelData['progress'] : $this->progress;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Progress65d4b00f3bc38($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'progress',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->progress = $this->validateProgress($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property progress
+             */
+            protected function validateProgress($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of continueOnError.
+             *
+             * 
+             *
+             * @return bool|null
+             */
+            public function getContinueOnError()
+                : ?bool
+            {
+                
+
+                return $this->continueOnError;
+            }
+
+            
+                /**
+                 * Set the value of continueOnError.
+                 *
+                 * @param bool|null $continueOnError
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setContinueOnError(
+                    ?bool $continueOnError
+                ): self {
+                    if ($this->continueOnError === $continueOnError) {
+                        return $this;
+                    }
+
+                    $value = $modelData['continueOnError'] = $continueOnError;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateContinueOnError($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->continueOnError = $value;
+                    $this->_rawModelDataInput['continueOnError'] = $continueOnError;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property continueOnError
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processContinueOnError(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('continueOnError', $modelData) && $this->continueOnError === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('continueOnError', $modelData) ? $modelData['continueOnError'] : $this->continueOnError;
+
+                
+
+                $this->continueOnError = $this->validateContinueOnError($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property continueOnError
+             */
+            protected function validateContinueOnError($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of slug.
+             *
+             * Plugin slug, like 'gutenberg' or 'hello-dolly'.
+             *
+             * @return string|null
+             */
+            public function getSlug()
+                : ?string
+            {
+                
+
+                return $this->slug;
+            }
+
+            
+                /**
+                 * Set the value of slug.
+                 *
+                 * @param string|null $slug Plugin slug, like 'gutenberg' or 'hello-dolly'.
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setSlug(
+                    ?string $slug
+                ): self {
+                    if ($this->slug === $slug) {
+                        return $this;
+                    }
+
+                    $value = $modelData['slug'] = $slug;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateSlug($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->slug = $value;
+                    $this->_rawModelDataInput['slug'] = $slug;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property slug
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processSlug(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('slug', $modelData) && $this->slug === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('slug', $modelData) ? $modelData['slug'] : $this->slug;
+
+                
+
+                $this->slug = $this->validateSlug($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property slug
+             */
+            protected function validateSlug($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of fromPath.
+             *
+             * Source path
+             *
+             * @return string|null
+             */
+            public function getFromPath()
+                : ?string
+            {
+                
+
+                return $this->fromPath;
+            }
+
+            
+                /**
+                 * Set the value of fromPath.
+                 *
+                 * @param string|null $fromPath Source path
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setFromPath(
+                    ?string $fromPath
+                ): self {
+                    if ($this->fromPath === $fromPath) {
+                        return $this;
+                    }
+
+                    $value = $modelData['fromPath'] = $fromPath;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateFromPath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->fromPath = $value;
+                    $this->_rawModelDataInput['fromPath'] = $fromPath;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property fromPath
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processFromPath(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('fromPath', $modelData) && $this->fromPath === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('fromPath', $modelData) ? $modelData['fromPath'] : $this->fromPath;
+
+                
+
+                $this->fromPath = $this->validateFromPath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property fromPath
+             */
+            protected function validateFromPath($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of toPath.
+             *
+             * Target path
+             *
+             * @return string|null
+             */
+            public function getToPath()
+                : ?string
+            {
+                
+
+                return $this->toPath;
+            }
+
+            
+                /**
+                 * Set the value of toPath.
+                 *
+                 * @param string|null $toPath Target path
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setToPath(
+                    ?string $toPath
+                ): self {
+                    if ($this->toPath === $toPath) {
+                        return $this;
+                    }
+
+                    $value = $modelData['toPath'] = $toPath;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateToPath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->toPath = $value;
+                    $this->_rawModelDataInput['toPath'] = $toPath;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property toPath
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processToPath(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('toPath', $modelData) && $this->toPath === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('toPath', $modelData) ? $modelData['toPath'] : $this->toPath;
+
+                
+
+                $this->toPath = $this->validateToPath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property toPath
+             */
+            protected function validateToPath($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of consts.
+             *
+             * The constants to define
+             *
+             * @return Schema_Consts65d4b00f3bde0|null
+             */
+            public function getConsts()
+                : ?Schema_Consts65d4b00f3bde0
+            {
+                
+
+                return $this->consts;
+            }
+
+            
+                /**
+                 * Set the value of consts.
+                 *
+                 * @param Schema_Consts65d4b00f3bde0|null $consts The constants to define
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setConsts(
+                    ?Schema_Consts65d4b00f3bde0 $consts
+                ): self {
+                    if ($this->consts === $consts) {
+                        return $this;
+                    }
+
+                    $value = $modelData['consts'] = $consts;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateConsts($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->consts = $value;
+                    $this->_rawModelDataInput['consts'] = $consts;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property consts
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processConsts(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('consts', $modelData) && $this->consts === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('consts', $modelData) ? $modelData['consts'] : $this->consts;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Consts65d4b00f3bde0($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'consts',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->consts = $this->validateConsts($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property consts
+             */
+            protected function validateConsts($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of siteUrl.
+             *
+             * The URL
+             *
+             * @return string|null
+             */
+            public function getSiteUrl()
+                : ?string
+            {
+                
+
+                return $this->siteUrl;
+            }
+
+            
+                /**
+                 * Set the value of siteUrl.
+                 *
+                 * @param string|null $siteUrl The URL
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setSiteUrl(
+                    ?string $siteUrl
+                ): self {
+                    if ($this->siteUrl === $siteUrl) {
+                        return $this;
+                    }
+
+                    $value = $modelData['siteUrl'] = $siteUrl;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateSiteUrl($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->siteUrl = $value;
+                    $this->_rawModelDataInput['siteUrl'] = $siteUrl;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property siteUrl
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processSiteUrl(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('siteUrl', $modelData) && $this->siteUrl === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('siteUrl', $modelData) ? $modelData['siteUrl'] : $this->siteUrl;
+
+                
+
+                $this->siteUrl = $this->validateSiteUrl($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property siteUrl
+             */
+            protected function validateSiteUrl($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of item of array plugins.
+             *
+             * 
+             *
+             * @return string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null
+             */
+            public function getItemOfArrayPlugins()
+                
+            {
+                
+
+                return $this->itemOfArrayPlugins;
+            }
+
+            
+                /**
+                 * Set the value of item of array plugins.
+                 *
+                 * @param string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c $itemOfArrayPlugins
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setItemOfArrayPlugins(
+                     $itemOfArrayPlugins
+                ): self {
+                    if ($this->itemOfArrayPlugins === $itemOfArrayPlugins) {
+                        return $this;
+                    }
+
+                    $value = $modelData['item of array plugins'] = $itemOfArrayPlugins;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+
+
+                    $value = $this->validateItemOfArrayPlugins($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->itemOfArrayPlugins = $value;
+                    $this->_rawModelDataInput['item of array plugins'] = $itemOfArrayPlugins;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property itemOfArrayPlugins
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processItemOfArrayPlugins(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('item of array plugins', $modelData) && $this->itemOfArrayPlugins === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('item of array plugins', $modelData) ? $modelData['item of array plugins'] : $this->itemOfArrayPlugins;
+
+                
+
+                $this->itemOfArrayPlugins = $this->validateItemOfArrayPlugins($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property itemOfArrayPlugins
+             */
+            protected function validateItemOfArrayPlugins($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of options.
+             *
+             * 
+             *
+             * @return Schema_Options65d4b00f3beeb|null
+             */
+            public function getOptions()
+                : ?Schema_Options65d4b00f3beeb
+            {
+                
+
+                return $this->options;
+            }
+
+            
+                /**
+                 * Set the value of options.
+                 *
+                 * @param Schema_Options65d4b00f3beeb|null $options
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setOptions(
+                    ?Schema_Options65d4b00f3beeb $options
+                ): self {
+                    if ($this->options === $options) {
+                        return $this;
+                    }
+
+                    $value = $modelData['options'] = $options;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateOptions($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->options = $value;
+                    $this->_rawModelDataInput['options'] = $options;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property options
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processOptions(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('options', $modelData) && $this->options === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('options', $modelData) ? $modelData['options'] : $this->options;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Options65d4b00f3beeb($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'options',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->options = $this->validateOptions($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property options
+             */
+            protected function validateOptions($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of path.
+             *
+             * The path of the directory you want to create
+             *
+             * @return string|null
+             */
+            public function getPath()
+                : ?string
+            {
+                
+
+                return $this->path;
+            }
+
+            
+                /**
+                 * Set the value of path.
+                 *
+                 * @param string|null $path The path of the directory you want to create
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setPath(
+                    ?string $path
+                ): self {
+                    if ($this->path === $path) {
+                        return $this;
+                    }
+
+                    $value = $modelData['path'] = $path;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validatePath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->path = $value;
+                    $this->_rawModelDataInput['path'] = $path;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property path
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processPath(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('path', $modelData) && $this->path === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('path', $modelData) ? $modelData['path'] : $this->path;
+
+                
+
+                $this->path = $this->validatePath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property path
+             */
+            protected function validatePath($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of code.
+             *
+             * The PHP code to run.
+             *
+             * @return string|null
+             */
+            public function getCode()
+                : ?string
+            {
+                
+
+                return $this->code;
+            }
+
+            
+                /**
+                 * Set the value of code.
+                 *
+                 * @param string|null $code The PHP code to run.
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setCode(
+                    ?string $code
+                ): self {
+                    if ($this->code === $code) {
+                        return $this;
+                    }
+
+                    $value = $modelData['code'] = $code;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateCode($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->code = $value;
+                    $this->_rawModelDataInput['code'] = $code;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property code
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processCode(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('code', $modelData) && $this->code === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('code', $modelData) ? $modelData['code'] : $this->code;
+
+                
+
+                $this->code = $this->validateCode($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property code
+             */
+            protected function validateCode($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of zipPath.
+             *
+             * The path of the zip file to extract
+             *
+             * @return string|null
+             */
+            public function getZipPath()
+                : ?string
+            {
+                
+
+                return $this->zipPath;
+            }
+
+            
+                /**
+                 * Set the value of zipPath.
+                 *
+                 * @param string|null $zipPath The path of the zip file to extract
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setZipPath(
+                    ?string $zipPath
+                ): self {
+                    if ($this->zipPath === $zipPath) {
+                        return $this;
+                    }
+
+                    $value = $modelData['zipPath'] = $zipPath;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateZipPath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->zipPath = $value;
+                    $this->_rawModelDataInput['zipPath'] = $zipPath;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property zipPath
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processZipPath(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('zipPath', $modelData) && $this->zipPath === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('zipPath', $modelData) ? $modelData['zipPath'] : $this->zipPath;
+
+                
+
+                $this->zipPath = $this->validateZipPath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property zipPath
+             */
+            protected function validateZipPath($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of extractToPath.
+             *
+             * The path to extract the zip file to
+             *
+             * @return string|null
+             */
+            public function getExtractToPath()
+                : ?string
+            {
+                
+
+                return $this->extractToPath;
+            }
+
+            
+                /**
+                 * Set the value of extractToPath.
+                 *
+                 * @param string|null $extractToPath The path to extract the zip file to
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setExtractToPath(
+                    ?string $extractToPath
+                ): self {
+                    if ($this->extractToPath === $extractToPath) {
+                        return $this;
+                    }
+
+                    $value = $modelData['extractToPath'] = $extractToPath;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateExtractToPath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->extractToPath = $value;
+                    $this->_rawModelDataInput['extractToPath'] = $extractToPath;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property extractToPath
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processExtractToPath(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('extractToPath', $modelData) && $this->extractToPath === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('extractToPath', $modelData) ? $modelData['extractToPath'] : $this->extractToPath;
+
+                
+
+                $this->extractToPath = $this->validateExtractToPath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property extractToPath
+             */
+            protected function validateExtractToPath($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of data.
+             *
+             * The data to write
+             *
+             * @return string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null
+             */
+            public function getData()
+                : ?string
+            {
+                
+
+                return $this->data;
+            }
+
+            
+                /**
+                 * Set the value of data.
+                 *
+                 * @param string|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c|null $data The data to write
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setData(
+                    ?string $data
+                ): self {
+                    if ($this->data === $data) {
+                        return $this;
+                    }
+
+                    $value = $modelData['data'] = $data;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateData($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->data = $value;
+                    $this->_rawModelDataInput['data'] = $data;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property data
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processData(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('data', $modelData) && $this->data === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('data', $modelData) ? $modelData['data'] : $this->data;
+
+                
+
+                $this->data = $this->validateData($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property data
+             */
+            protected function validateData($value, array $modelData)
+            {
+                
+                    $this->validateData_ComposedProperty_65d4b00f3c1f8($value);
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of command.
+             *
+             * The WP CLI command to run.
+             *
+             * @return string[]|null
+             */
+            public function getCommand()
+                : ?array
+            {
+                
+
+                return $this->command;
+            }
+
+            
+                /**
+                 * Set the value of command.
+                 *
+                 * @param string[]|null $command The WP CLI command to run.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setCommand(
+                    ?array $command
+                ): self {
+                    if ($this->command === $command) {
+                        return $this;
+                    }
+
+                    $value = $modelData['command'] = $command;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    $this->validateComposition_0($modelData);
+
+
+
+                    $value = $this->validateCommand($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->command = $value;
+                    $this->_rawModelDataInput['command'] = $command;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property command
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processCommand(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('command', $modelData) && $this->command === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('command', $modelData) ? $modelData['command'] : $this->command;
+
+                
+
+                $this->command = $this->validateCommand($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property command
+             */
+            protected function validateCommand($value, array $modelData)
+            {
+                
+                    $this->validateCommand_ComposedProperty_65d4b00f3c25c($value);
+                
+
+                return $value;
+            }
+        
+    
+        
+    
+
+    /**
+ * Validate updated properties which are part of a composition validation
+ *
+ * @param array $modifiedModelData An array containing all updated data as key-value pairs
+ *
+ * 
+ */
+private function validateComposition_0(array &$modifiedModelData): void
+{
+    $validatorIndex = 0;
+    $value = $modelData = array_merge($this->_rawModelDataInput, $modifiedModelData);
+
+    
+            $succeededCompositionElements = 0;
+            $compositionErrorCollection = [];
+        
+    if (
+(function (&$value) use (
+    &$modelData,
+    &$modifiedModelData,
+    &$compositionErrorCollection,
+    &$succeededCompositionElements,
+    &$validatorIndex
+) {
+    $succeededCompositionElements = 20;
+    $validatorComponentIndex = 0;
+    $originalModelData = $value;
+    $proposedValue = null;
+    $modifiedValues = [];
+
+    
+        $originalPropertyValidationState = $this->_propertyValidationState ?? [];
+    
+
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'slug',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3bc1a($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3bc1a)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3bc1a',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['slug'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'slug',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3bd2b($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3bd2b)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3bd2b',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['slug'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'fromPath',
+                            
+                                'toPath',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3bd71($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3bd71)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3bd71',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['fromPath'] = null;
+            
+                $modelData['toPath'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'consts',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3bdb9($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3bdb9)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3bdb9',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['consts'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'siteUrl',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3be19($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3be19)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3be19',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['siteUrl'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3be55($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3be55)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3be55',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'file',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3be88($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3be88)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3be88',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['file'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'pluginZipFile',
+                            
+                                'options',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3bec0($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3bec0)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3bec0',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['pluginZipFile'] = null;
+            
+                $modelData['options'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'themeZipFile',
+                            
+                                'options',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3bf1f($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3bf1f)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3bf1f',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['themeZipFile'] = null;
+            
+                $modelData['options'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'path',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3bf77($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3bf77)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3bf77',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['path'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'fromPath',
+                            
+                                'toPath',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3bfac($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3bfac)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3bfac',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['fromPath'] = null;
+            
+                $modelData['toPath'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'path',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3bfed($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3bfed)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3bfed',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['path'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'path',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c026($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3c026)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3c026',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['path'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'code',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c05a($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3c05a)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3c05a',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['code'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'options',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c092($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3c092)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3c092',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['options'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'sql',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c0e9($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3c0e9)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3c0e9',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['sql'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'options',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c123($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3c123)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3c123',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['options'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'zipFile',
+                            
+                                'zipPath',
+                            
+                                'extractToPath',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c166($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3c166)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3c166',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['zipFile'] = null;
+            
+                $modelData['zipPath'] = null;
+            
+                $modelData['extractToPath'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'path',
+                            
+                                'data',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c1ae($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3c1ae)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3c1ae',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['path'] = null;
+            
+                $modelData['data'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+                // check if the state of the validator is already known.
+                // If none of the properties affected by the validator are changed the validator must not be re-evaluated
+                if (isset($validatorIndex) &&
+                    isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
+                    !array_intersect(
+                        array_keys($modifiedModelData),
+                        [
+                            
+                                'progress',
+                            
+                                'continueOnError',
+                            
+                                'step',
+                            
+                                'command',
+                            
+                        ]
+                    )
+                ) {
+                    
+                        $compositionErrorCollection[] = $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex];
+                    
+
+                    if (
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]->getErrors()
+                        
+                    ) {
+                        throw new \Exception();
+                    }
+                } else {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c217($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3c217)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => 'Schema_Itemofarraysteps65d4b00f3c217',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+                        if (isset($validatorIndex)) {
+                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+                        }
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_b96fb($originalModelData, $value));
+                }
+            
+                
+            }
+            
+        } catch (\Exception $e) {
+            
+                
+            
+
+            
+                $modelData['progress'] = null;
+            
+                $modelData['continueOnError'] = null;
+            
+                $modelData['step'] = null;
+            
+                $modelData['command'] = null;
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+
+    
+        $value = $proposedValue;
+    
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    $result = !($succeededCompositionElements === 1);
+
+    
+        if ($result) {
+            $this->_propertyValidationState = $originalPropertyValidationState;
+        }
+    
+
+    return $result;
+})($value)
+) {
+        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\ComposedValue\OneOfException($value ?? null, ...array (
+  0 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+  1 => $succeededCompositionElements,
+  2 => $compositionErrorCollection,
+)));
+    }
+
+    foreach (array_keys($modifiedModelData) as $property) {
+        $modifiedModelData[$property] = $modelData[$property];
+    }
+}
+
+
+private function validateData_ComposedProperty_65d4b00f3c1f8(&$value): void {
+                    
+            $succeededCompositionElements = 0;
+            $compositionErrorCollection = [];
+        
+                    
+                    if (
+(function (&$value) use (
+    &$modelData,
+    &$modifiedModelData,
+    &$compositionErrorCollection,
+    &$succeededCompositionElements,
+    &$validatorIndex
+) {
+    $succeededCompositionElements = 2;
+    $validatorComponentIndex = 0;
+    $originalModelData = $value;
+    $proposedValue = null;
+    $modifiedValues = [];
+
+    
+
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_c6562($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'data',
+  1 => 'string',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_c6562($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+
+    
+        $value = $proposedValue;
+    
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    $result = !($succeededCompositionElements > 0);
+
+    
+
+    return $result;
+})($value)
+) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\ComposedValue\AnyOfException($value ?? null, ...array (
+  0 => 'data',
+  1 => $succeededCompositionElements,
+  2 => $compositionErrorCollection,
+)));
+                    }
+                }
+
+private function validateCommand_ComposedProperty_65d4b00f3c25c(&$value): void {
+                    
+            $succeededCompositionElements = 0;
+            $compositionErrorCollection = [];
+        
+                    
+                    if (
+(function (&$value) use (
+    &$modelData,
+    &$modifiedModelData,
+    &$compositionErrorCollection,
+    &$succeededCompositionElements,
+    &$validatorIndex
+) {
+    $succeededCompositionElements = 1;
+    $validatorComponentIndex = 0;
+    $originalModelData = $value;
+    $proposedValue = null;
+    $modifiedValues = [];
+
+    
+
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if (!is_array($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'command',
+  1 => 'array',
+)));
+}
+
+                
+                    $this->validateCommand_ArrayItem_65d4b00f3c250($value);
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_33543($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+
+    
+        $value = $proposedValue;
+    
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    $result = !($succeededCompositionElements > 0);
+
+    
+
+    return $result;
+})($value)
+) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\ComposedValue\AnyOfException($value ?? null, ...array (
+  0 => 'command',
+  1 => $succeededCompositionElements,
+  2 => $compositionErrorCollection,
+)));
+                    }
+                }
+
+
+                        private function _getModifiedValues_b96fb(array $originalModelData, object $nestedCompositionObject): array {
+                            $modifiedValues = [];
+                            $defaultValueMap = array (
+);
+    
+                            foreach (array (
+  'progress' => 'getProgress',
+  'continueOnError' => 'getContinueOnError',
+  'step' => 'getStep',
+  'slug' => 'getSlug',
+  'fromPath' => 'getFromPath',
+  'toPath' => 'getToPath',
+  'consts' => 'getConsts',
+  'siteUrl' => 'getSiteUrl',
+  'file' => 'getFile',
+  'pluginZipFile' => 'getPluginZipFile',
+  'options' => 'getOptions',
+  'themeZipFile' => 'getThemeZipFile',
+  'path' => 'getPath',
+  'code' => 'getCode',
+  'sql' => 'getSql',
+  'zipFile' => 'getZipFile',
+  'zipPath' => 'getZipPath',
+  'extractToPath' => 'getExtractToPath',
+  'data' => 'getData',
+  'command' => 'getCommand',
+) as $key => $accessor) {
+                                if ((isset($originalModelData[$key]) || in_array($key, $defaultValueMap))
+                                    && method_exists($nestedCompositionObject, $accessor)
+                                    && ($modifiedValue = $nestedCompositionObject->$accessor()) !== ($originalModelData[$key] ?? !$modifiedValue)
+                                ) {
+                                    $modifiedValues[$key] = $modifiedValue;
+                                }
+                            }
+    
+                            return $modifiedValues;
+                        }
+
+
+                        private function _getModifiedValues_c6562(array $originalModelData, object $nestedCompositionObject): array {
+                            $modifiedValues = [];
+                            $defaultValueMap = array (
+);
+    
+                            foreach (array (
+) as $key => $accessor) {
+                                if ((isset($originalModelData[$key]) || in_array($key, $defaultValueMap))
+                                    && method_exists($nestedCompositionObject, $accessor)
+                                    && ($modifiedValue = $nestedCompositionObject->$accessor()) !== ($originalModelData[$key] ?? !$modifiedValue)
+                                ) {
+                                    $modifiedValues[$key] = $modifiedValue;
+                                }
+                            }
+    
+                            return $modifiedValues;
+                        }
+
+
+                        private function _getModifiedValues_33543(array $originalModelData, object $nestedCompositionObject): array {
+                            $modifiedValues = [];
+                            $defaultValueMap = array (
+);
+    
+                            foreach (array (
+) as $key => $accessor) {
+                                if ((isset($originalModelData[$key]) || in_array($key, $defaultValueMap))
+                                    && method_exists($nestedCompositionObject, $accessor)
+                                    && ($modifiedValue = $nestedCompositionObject->$accessor()) !== ($originalModelData[$key] ?? !$modifiedValue)
+                                ) {
+                                    $modifiedValues[$key] = $modifiedValue;
+                                }
+                            }
+    
+                            return $modifiedValues;
+                        }
+
+private function validateCommand_ArrayItem_65d4b00f3c250(&$value): void {
+                    $invalidItems_b5d3f8742cf5838dfe73097d04a820bc = [];
+                    
+                    if (is_array($value) && (function (&$items) use (&$invalidItems_b5d3f8742cf5838dfe73097d04a820bc) {
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    foreach ($items as $index => &$value) {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        try {
+            
+
+            
+                
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'item of array command',
+  1 => 'string',
+)));
+}
+
+            
+
+            
+                if ($this->_errorRegistry->getErrors()) {
+                    $invalidItems_b5d3f8742cf5838dfe73097d04a820bc[$index] = $this->_errorRegistry->getErrors();
+                }
+            
+        } catch (\Exception $e) {
+            // collect all errors concerning invalid items
+            isset($invalidItems_b5d3f8742cf5838dfe73097d04a820bc[$index])
+                ? $invalidItems_b5d3f8742cf5838dfe73097d04a820bc[$index][] = $e
+                : $invalidItems_b5d3f8742cf5838dfe73097d04a820bc[$index] = [$e];
+        }
+    }
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    return !empty($invalidItems_b5d3f8742cf5838dfe73097d04a820bc);
+})($value)) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Arrays\InvalidItemException($value ?? null, ...array (
+  0 => 'command',
+  1 => $invalidItems_b5d3f8742cf5838dfe73097d04a820bc,
+)));
+                    }
+                }
+
+
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Merged_Itemofarrayplugins65d4b00f3ba2c.php
+++ b/result/Schema_Merged_Itemofarrayplugins65d4b00f3ba2c.php
@@ -1,0 +1,667 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Merged_Itemofarrayplugins65d4b00f3ba2c
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Merged_Itemofarrayplugins65d4b00f3ba2c implements JSONModelInterface
+{
+    
+
+    
+        /** @var string Identifies the file resource as Virtual File System (VFS) */
+        protected $resource;
+    
+        /** @var string The path to the file in the VFS */
+        protected $path;
+    
+        /** @var string The contents of the file */
+        protected $contents;
+    
+        /** @var string The slug of the WordPress Core theme */
+        protected $slug;
+    
+        /** @var string The URL of the file */
+        protected $url;
+    
+        /** @var string|null Optional caption for displaying a progress message */
+        protected $caption;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Merged_Itemofarrayplugins65d4b00f3ba2c constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+
+        
+            
+                $this->processResource($rawModelDataInput);
+            
+        
+            
+                $this->processPath($rawModelDataInput);
+            
+        
+            
+                $this->processContents($rawModelDataInput);
+            
+        
+            
+                $this->processSlug($rawModelDataInput);
+            
+        
+            
+                $this->processUrl($rawModelDataInput);
+            
+        
+            
+                $this->processCaption($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of resource.
+             *
+             * Identifies the file resource as Virtual File System (VFS)
+             *
+             * @return string
+             */
+            public function getResource()
+                : string
+            {
+                
+
+                return $this->resource;
+            }
+
+            
+                /**
+                 * Set the value of resource.
+                 *
+                 * @param string $resource Identifies the file resource as Virtual File System (VFS)
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setResource(
+                    string $resource
+                ): self {
+                    if ($this->resource === $resource) {
+                        return $this;
+                    }
+
+                    $value = $modelData['resource'] = $resource;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateResource($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->resource = $value;
+                    $this->_rawModelDataInput['resource'] = $resource;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property resource
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processResource(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('resource', $modelData) ? $modelData['resource'] : $this->resource;
+
+                
+
+                $this->resource = $this->validateResource($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property resource
+             */
+            protected function validateResource($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of path.
+             *
+             * The path to the file in the VFS
+             *
+             * @return string
+             */
+            public function getPath()
+                : string
+            {
+                
+
+                return $this->path;
+            }
+
+            
+                /**
+                 * Set the value of path.
+                 *
+                 * @param string $path The path to the file in the VFS
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setPath(
+                    string $path
+                ): self {
+                    if ($this->path === $path) {
+                        return $this;
+                    }
+
+                    $value = $modelData['path'] = $path;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePath($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->path = $value;
+                    $this->_rawModelDataInput['path'] = $path;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property path
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processPath(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('path', $modelData) ? $modelData['path'] : $this->path;
+
+                
+
+                $this->path = $this->validatePath($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property path
+             */
+            protected function validatePath($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of contents.
+             *
+             * The contents of the file
+             *
+             * @return string
+             */
+            public function getContents()
+                : string
+            {
+                
+
+                return $this->contents;
+            }
+
+            
+                /**
+                 * Set the value of contents.
+                 *
+                 * @param string $contents The contents of the file
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setContents(
+                    string $contents
+                ): self {
+                    if ($this->contents === $contents) {
+                        return $this;
+                    }
+
+                    $value = $modelData['contents'] = $contents;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateContents($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->contents = $value;
+                    $this->_rawModelDataInput['contents'] = $contents;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property contents
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processContents(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('contents', $modelData) ? $modelData['contents'] : $this->contents;
+
+                
+
+                $this->contents = $this->validateContents($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property contents
+             */
+            protected function validateContents($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of slug.
+             *
+             * The slug of the WordPress Core theme
+             *
+             * @return string
+             */
+            public function getSlug()
+                : string
+            {
+                
+
+                return $this->slug;
+            }
+
+            
+                /**
+                 * Set the value of slug.
+                 *
+                 * @param string $slug The slug of the WordPress Core theme
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setSlug(
+                    string $slug
+                ): self {
+                    if ($this->slug === $slug) {
+                        return $this;
+                    }
+
+                    $value = $modelData['slug'] = $slug;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSlug($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->slug = $value;
+                    $this->_rawModelDataInput['slug'] = $slug;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property slug
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processSlug(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('slug', $modelData) ? $modelData['slug'] : $this->slug;
+
+                
+
+                $this->slug = $this->validateSlug($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property slug
+             */
+            protected function validateSlug($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of url.
+             *
+             * The URL of the file
+             *
+             * @return string
+             */
+            public function getUrl()
+                : string
+            {
+                
+
+                return $this->url;
+            }
+
+            
+                /**
+                 * Set the value of url.
+                 *
+                 * @param string $url The URL of the file
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setUrl(
+                    string $url
+                ): self {
+                    if ($this->url === $url) {
+                        return $this;
+                    }
+
+                    $value = $modelData['url'] = $url;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateUrl($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->url = $value;
+                    $this->_rawModelDataInput['url'] = $url;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property url
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processUrl(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('url', $modelData) ? $modelData['url'] : $this->url;
+
+                
+
+                $this->url = $this->validateUrl($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property url
+             */
+            protected function validateUrl($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of caption.
+             *
+             * Optional caption for displaying a progress message
+             *
+             * @return string|null
+             */
+            public function getCaption()
+                : ?string
+            {
+                
+
+                return $this->caption;
+            }
+
+            
+                /**
+                 * Set the value of caption.
+                 *
+                 * @param string $caption Optional caption for displaying a progress message
+                 *
+                 * 
+                 *
+                 * @return self
+                 */
+                public function setCaption(
+                    string $caption
+                ): self {
+                    if ($this->caption === $caption) {
+                        return $this;
+                    }
+
+                    $value = $modelData['caption'] = $caption;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateCaption($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->caption = $value;
+                    $this->_rawModelDataInput['caption'] = $caption;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property caption
+             *
+             * @param array $modelData
+             *
+             * 
+             */
+            protected function processCaption(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('caption', $modelData) && $this->caption === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('caption', $modelData) ? $modelData['caption'] : $this->caption;
+
+                
+
+                $this->caption = $this->validateCaption($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property caption
+             */
+            protected function validateCaption($value, array $modelData)
+            {
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Options65d4b00f3beeb.php
+++ b/result/Schema_Options65d4b00f3beeb.php
@@ -1,0 +1,226 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Options65d4b00f3beeb
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Options65d4b00f3beeb implements JSONModelInterface
+{
+    
+
+    
+        /** @var bool|null Whether to activate the plugin after installing it. */
+        protected $activate;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Options65d4b00f3beeb constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processActivate($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'activate',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Options65d4b00f3beeb',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of activate.
+             *
+             * Whether to activate the plugin after installing it.
+             *
+             * @return bool|null
+             */
+            public function getActivate()
+                : ?bool
+            {
+                
+
+                return $this->activate;
+            }
+
+            
+                /**
+                 * Set the value of activate.
+                 *
+                 * @param bool $activate Whether to activate the plugin after installing it.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setActivate(
+                    bool $activate
+                ): self {
+                    if ($this->activate === $activate) {
+                        return $this;
+                    }
+
+                    $value = $modelData['activate'] = $activate;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateActivate($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->activate = $value;
+                    $this->_rawModelDataInput['activate'] = $activate;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property activate
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processActivate(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('activate', $modelData) && $this->activate === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('activate', $modelData) ? $modelData['activate'] : $this->activate;
+
+                
+
+                $this->activate = $this->validateActivate($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property activate
+             */
+            protected function validateActivate($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'activate',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Options65d4b00f3bf49.php
+++ b/result/Schema_Options65d4b00f3bf49.php
@@ -1,0 +1,227 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Options65d4b00f3bf49
+ * @package MyApp\Model 
+ *
+ * Optional installation options.
+ *
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Options65d4b00f3bf49 implements JSONModelInterface
+{
+    
+
+    
+        /** @var bool|null Whether to activate the theme after installing it. */
+        protected $activate;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Options65d4b00f3bf49 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processActivate($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'activate',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Options65d4b00f3bf49',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of activate.
+             *
+             * Whether to activate the theme after installing it.
+             *
+             * @return bool|null
+             */
+            public function getActivate()
+                : ?bool
+            {
+                
+
+                return $this->activate;
+            }
+
+            
+                /**
+                 * Set the value of activate.
+                 *
+                 * @param bool $activate Whether to activate the theme after installing it.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setActivate(
+                    bool $activate
+                ): self {
+                    if ($this->activate === $activate) {
+                        return $this;
+                    }
+
+                    $value = $modelData['activate'] = $activate;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateActivate($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->activate = $value;
+                    $this->_rawModelDataInput['activate'] = $activate;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property activate
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processActivate(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('activate', $modelData) && $this->activate === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('activate', $modelData) ? $modelData['activate'] : $this->activate;
+
+                
+
+                $this->activate = $this->validateActivate($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property activate
+             */
+            protected function validateActivate($value, array $modelData)
+            {
+                
+                    
+
+if (!is_bool($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'activate',
+  1 => 'bool',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Options65d4b00f3c0b3.php
+++ b/result/Schema_Options65d4b00f3c0b3.php
@@ -1,0 +1,337 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Options65d4b00f3c0b3
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Options65d4b00f3c0b3 implements JSONModelInterface
+{
+    
+
+    
+        /** @var string|null */
+        protected $adminUsername;
+    
+        /** @var string|null */
+        protected $adminPassword;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Options65d4b00f3c0b3 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processAdminUsername($rawModelDataInput);
+            
+        
+            
+                $this->processAdminPassword($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'adminUsername',
+   'adminPassword',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Options65d4b00f3c0b3',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of adminUsername.
+             *
+             * 
+             *
+             * @return string|null
+             */
+            public function getAdminUsername()
+                : ?string
+            {
+                
+
+                return $this->adminUsername;
+            }
+
+            
+                /**
+                 * Set the value of adminUsername.
+                 *
+                 * @param string $adminUsername
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setAdminUsername(
+                    string $adminUsername
+                ): self {
+                    if ($this->adminUsername === $adminUsername) {
+                        return $this;
+                    }
+
+                    $value = $modelData['adminUsername'] = $adminUsername;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateAdminUsername($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->adminUsername = $value;
+                    $this->_rawModelDataInput['adminUsername'] = $adminUsername;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property adminUsername
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processAdminUsername(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('adminUsername', $modelData) && $this->adminUsername === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('adminUsername', $modelData) ? $modelData['adminUsername'] : $this->adminUsername;
+
+                
+
+                $this->adminUsername = $this->validateAdminUsername($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property adminUsername
+             */
+            protected function validateAdminUsername($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'adminUsername',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of adminPassword.
+             *
+             * 
+             *
+             * @return string|null
+             */
+            public function getAdminPassword()
+                : ?string
+            {
+                
+
+                return $this->adminPassword;
+            }
+
+            
+                /**
+                 * Set the value of adminPassword.
+                 *
+                 * @param string $adminPassword
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setAdminPassword(
+                    string $adminPassword
+                ): self {
+                    if ($this->adminPassword === $adminPassword) {
+                        return $this;
+                    }
+
+                    $value = $modelData['adminPassword'] = $adminPassword;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateAdminPassword($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->adminPassword = $value;
+                    $this->_rawModelDataInput['adminPassword'] = $adminPassword;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property adminPassword
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processAdminPassword(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('adminPassword', $modelData) && $this->adminPassword === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('adminPassword', $modelData) ? $modelData['adminPassword'] : $this->adminPassword;
+
+                
+
+                $this->adminPassword = $this->validateAdminPassword($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property adminPassword
+             */
+            protected function validateAdminPassword($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'adminPassword',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_PreferredVersions65d4b00f3b0f0.php
+++ b/result/Schema_PreferredVersions65d4b00f3b0f0.php
@@ -1,0 +1,348 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_PreferredVersions65d4b00f3b0f0
+ * @package MyApp\Model 
+ *
+ * The preferred PHP and WordPress versions to use.
+ *
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_PreferredVersions65d4b00f3b0f0 implements JSONModelInterface
+{
+    
+
+    
+        /** @var string The preferred PHP version to use. If not specified, the latest supported version will be used */
+        protected $php;
+    
+        /** @var string The preferred WordPress version to use. If not specified, the latest supported version will be used */
+        protected $wp;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_PreferredVersions65d4b00f3b0f0 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processPhp($rawModelDataInput);
+            
+        
+            
+                $this->processWp($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'php',
+   'wp',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_PreferredVersions65d4b00f3b0f0',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of php.
+             *
+             * The preferred PHP version to use. If not specified, the latest supported version will be used
+             *
+             * @return string
+             */
+            public function getPhp()
+                : string
+            {
+                
+
+                return $this->php;
+            }
+
+            
+                /**
+                 * Set the value of php.
+                 *
+                 * @param string $php The preferred PHP version to use. If not specified, the latest supported version will be used
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPhp(
+                    string $php
+                ): self {
+                    if ($this->php === $php) {
+                        return $this;
+                    }
+
+                    $value = $modelData['php'] = $php;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePhp($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->php = $value;
+                    $this->_rawModelDataInput['php'] = $php;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property php
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPhp(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('php', $modelData) ? $modelData['php'] : $this->php;
+
+                
+
+                $this->php = $this->validatePhp($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property php
+             */
+            protected function validatePhp($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('php', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'php',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'php',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of wp.
+             *
+             * The preferred WordPress version to use. If not specified, the latest supported version will be used
+             *
+             * @return string
+             */
+            public function getWp()
+                : string
+            {
+                
+
+                return $this->wp;
+            }
+
+            
+                /**
+                 * Set the value of wp.
+                 *
+                 * @param string $wp The preferred WordPress version to use. If not specified, the latest supported version will be used
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setWp(
+                    string $wp
+                ): self {
+                    if ($this->wp === $wp) {
+                        return $this;
+                    }
+
+                    $value = $modelData['wp'] = $wp;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateWp($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->wp = $value;
+                    $this->_rawModelDataInput['wp'] = $wp;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property wp
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processWp(array $modelData): void
+            {
+                
+                    
+                
+
+                $value = array_key_exists('wp', $modelData) ? $modelData['wp'] : $this->wp;
+
+                
+
+                $this->wp = $this->validateWp($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property wp
+             */
+            protected function validateWp($value, array $modelData)
+            {
+                
+                    
+
+if (!array_key_exists('wp', $modelData)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\RequiredValueException($value ?? null, ...array (
+  0 => 'wp',
+)));
+}
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'wp',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Progress65d4b00f3bc38.php
+++ b/result/Schema_Progress65d4b00f3bc38.php
@@ -1,0 +1,337 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Progress65d4b00f3bc38
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Progress65d4b00f3bc38 implements JSONModelInterface
+{
+    
+
+    
+        /** @var float|null */
+        protected $weight;
+    
+        /** @var string|null */
+        protected $caption;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Progress65d4b00f3bc38 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processWeight($rawModelDataInput);
+            
+        
+            
+                $this->processCaption($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'weight',
+   'caption',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Progress65d4b00f3bc38',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of weight.
+             *
+             * 
+             *
+             * @return float|null
+             */
+            public function getWeight()
+                : ?float
+            {
+                
+
+                return $this->weight;
+            }
+
+            
+                /**
+                 * Set the value of weight.
+                 *
+                 * @param float $weight
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setWeight(
+                    float $weight
+                ): self {
+                    if ($this->weight === $weight) {
+                        return $this;
+                    }
+
+                    $value = $modelData['weight'] = $weight;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateWeight($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->weight = $value;
+                    $this->_rawModelDataInput['weight'] = $weight;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property weight
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processWeight(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('weight', $modelData) && $this->weight === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('weight', $modelData) ? $modelData['weight'] : $this->weight;
+
+                $value = is_int($value) ? (float) $value : $value;
+
+                $this->weight = $this->validateWeight($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property weight
+             */
+            protected function validateWeight($value, array $modelData)
+            {
+                
+                    
+
+if (!is_float($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'weight',
+  1 => 'float',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of caption.
+             *
+             * 
+             *
+             * @return string|null
+             */
+            public function getCaption()
+                : ?string
+            {
+                
+
+                return $this->caption;
+            }
+
+            
+                /**
+                 * Set the value of caption.
+                 *
+                 * @param string $caption
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setCaption(
+                    string $caption
+                ): self {
+                    if ($this->caption === $caption) {
+                        return $this;
+                    }
+
+                    $value = $modelData['caption'] = $caption;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateCaption($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->caption = $value;
+                    $this->_rawModelDataInput['caption'] = $caption;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property caption
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processCaption(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('caption', $modelData) && $this->caption === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('caption', $modelData) ? $modelData['caption'] : $this->caption;
+
+                
+
+                $this->caption = $this->validateCaption($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property caption
+             */
+            protected function validateCaption($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'caption',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_Schema65d4b00f3af34.php
+++ b/result/Schema_Schema65d4b00f3af34.php
@@ -1,0 +1,2056 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_Schema65d4b00f3af34
+ * @package MyApp\Model 
+ *
+
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_Schema65d4b00f3af34 implements JSONModelInterface
+{
+    
+
+    
+        /** @var string|null The URL to navigate to after the blueprint has been run. */
+        protected $landingPage;
+    
+        /** @var string|null Optional description. It doesn't do anything but is exposed as a courtesy to developers who may want to document which blueprint file does what. */
+        protected $description;
+    
+        /** @var Schema_PreferredVersions65d4b00f3b0f0|null The preferred PHP and WordPress versions to use. */
+        protected $preferredVersions;
+    
+        /** @var Schema_Features65d4b00f3b44e|null */
+        protected $features;
+    
+        /** @var Schema_Constants65d4b00f3b4a2|null PHP Constants to define on every request */
+        protected $constants;
+    
+        /** @var string[]|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c[]|null WordPress plugins to install and activate */
+        protected $plugins;
+    
+        /** @var Schema_SiteOptions65d4b00f3bb76|null WordPress site options to define */
+        protected $siteOptions;
+    
+        /** @var string[]|null The PHP extensions to use. */
+        protected $phpExtensionBundles;
+    
+        /** @var string[]|mixed[]|bool[]|null[]|Schema_Itemofarraysteps65d4b00f3bc1a[]|Schema_Itemofarraysteps65d4b00f3bd2b[]|Schema_Itemofarraysteps65d4b00f3bd71[]|Schema_Itemofarraysteps65d4b00f3bdb9[]|Schema_Itemofarraysteps65d4b00f3be19[]|Schema_Itemofarraysteps65d4b00f3be55[]|Schema_Itemofarraysteps65d4b00f3be88[]|Schema_Itemofarraysteps65d4b00f3bec0[]|Schema_Itemofarraysteps65d4b00f3bf1f[]|Schema_Itemofarraysteps65d4b00f3bf77[]|Schema_Itemofarraysteps65d4b00f3bfac[]|Schema_Itemofarraysteps65d4b00f3bfed[]|Schema_Itemofarraysteps65d4b00f3c026[]|Schema_Itemofarraysteps65d4b00f3c05a[]|Schema_Itemofarraysteps65d4b00f3c092[]|Schema_Itemofarraysteps65d4b00f3c0e9[]|Schema_Itemofarraysteps65d4b00f3c123[]|Schema_Itemofarraysteps65d4b00f3c166[]|Schema_Itemofarraysteps65d4b00f3c1ae[]|Schema_Itemofarraysteps65d4b00f3c217[] The steps to run after every other operation in this Blueprint was executed. */
+        protected $steps;
+    
+        /** @var string|null */
+        protected $schema;
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_Schema65d4b00f3af34 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processLandingPage($rawModelDataInput);
+            
+        
+            
+                $this->processDescription($rawModelDataInput);
+            
+        
+            
+                $this->processPreferredVersions($rawModelDataInput);
+            
+        
+            
+                $this->processFeatures($rawModelDataInput);
+            
+        
+            
+                $this->processConstants($rawModelDataInput);
+            
+        
+            
+                $this->processPlugins($rawModelDataInput);
+            
+        
+            
+                $this->processSiteOptions($rawModelDataInput);
+            
+        
+            
+                $this->processPhpExtensionBundles($rawModelDataInput);
+            
+        
+            
+                $this->processSteps($rawModelDataInput);
+            
+        
+            
+                $this->processSchema($rawModelDataInput);
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+if ($additionalProperties =  (static function () use ($modelData): array {
+    $additionalProperties = array_diff(array_keys($modelData), array (
+   'landingPage',
+   'description',
+   'preferredVersions',
+   'features',
+   'constants',
+   'plugins',
+   'siteOptions',
+   'phpExtensionBundles',
+   'steps',
+   '$schema',
+));
+
+    
+
+    return $additionalProperties;
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\AdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_Schema65d4b00f3af34',
+  1 => $additionalProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of landingPage.
+             *
+             * The URL to navigate to after the blueprint has been run.
+             *
+             * @return string|null
+             */
+            public function getLandingPage()
+                : ?string
+            {
+                
+
+                return $this->landingPage;
+            }
+
+            
+                /**
+                 * Set the value of landingPage.
+                 *
+                 * @param string $landingPage The URL to navigate to after the blueprint has been run.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setLandingPage(
+                    string $landingPage
+                ): self {
+                    if ($this->landingPage === $landingPage) {
+                        return $this;
+                    }
+
+                    $value = $modelData['landingPage'] = $landingPage;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateLandingPage($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->landingPage = $value;
+                    $this->_rawModelDataInput['landingPage'] = $landingPage;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property landingPage
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processLandingPage(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('landingPage', $modelData) && $this->landingPage === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('landingPage', $modelData) ? $modelData['landingPage'] : $this->landingPage;
+
+                
+
+                $this->landingPage = $this->validateLandingPage($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property landingPage
+             */
+            protected function validateLandingPage($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'landingPage',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of description.
+             *
+             * Optional description. It doesn't do anything but is exposed as a courtesy to developers who may want to document which blueprint file does what.
+             *
+             * @return string|null
+             */
+            public function getDescription()
+                : ?string
+            {
+                
+
+                return $this->description;
+            }
+
+            
+                /**
+                 * Set the value of description.
+                 *
+                 * @param string $description Optional description. It doesn't do anything but is exposed as a courtesy to developers who may want to document which blueprint file does what.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setDescription(
+                    string $description
+                ): self {
+                    if ($this->description === $description) {
+                        return $this;
+                    }
+
+                    $value = $modelData['description'] = $description;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateDescription($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->description = $value;
+                    $this->_rawModelDataInput['description'] = $description;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property description
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processDescription(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('description', $modelData) && $this->description === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('description', $modelData) ? $modelData['description'] : $this->description;
+
+                
+
+                $this->description = $this->validateDescription($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property description
+             */
+            protected function validateDescription($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'description',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of preferredVersions.
+             *
+             * The preferred PHP and WordPress versions to use.
+             *
+             * @return Schema_PreferredVersions65d4b00f3b0f0|null
+             */
+            public function getPreferredVersions()
+                : ?Schema_PreferredVersions65d4b00f3b0f0
+            {
+                
+
+                return $this->preferredVersions;
+            }
+
+            
+                /**
+                 * Set the value of preferredVersions.
+                 *
+                 * @param Schema_PreferredVersions65d4b00f3b0f0 $preferredVersions The preferred PHP and WordPress versions to use.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPreferredVersions(
+                    Schema_PreferredVersions65d4b00f3b0f0 $preferredVersions
+                ): self {
+                    if ($this->preferredVersions === $preferredVersions) {
+                        return $this;
+                    }
+
+                    $value = $modelData['preferredVersions'] = $preferredVersions;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePreferredVersions($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->preferredVersions = $value;
+                    $this->_rawModelDataInput['preferredVersions'] = $preferredVersions;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property preferredVersions
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPreferredVersions(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('preferredVersions', $modelData) && $this->preferredVersions === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('preferredVersions', $modelData) ? $modelData['preferredVersions'] : $this->preferredVersions;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_PreferredVersions65d4b00f3b0f0($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'preferredVersions',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->preferredVersions = $this->validatePreferredVersions($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property preferredVersions
+             */
+            protected function validatePreferredVersions($value, array $modelData)
+            {
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'preferredVersions',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_PreferredVersions65d4b00f3b0f0)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'preferredVersions',
+  1 => 'Schema_PreferredVersions65d4b00f3b0f0',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of features.
+             *
+             * 
+             *
+             * @return Schema_Features65d4b00f3b44e|null
+             */
+            public function getFeatures()
+                : ?Schema_Features65d4b00f3b44e
+            {
+                
+
+                return $this->features;
+            }
+
+            
+                /**
+                 * Set the value of features.
+                 *
+                 * @param Schema_Features65d4b00f3b44e $features
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setFeatures(
+                    Schema_Features65d4b00f3b44e $features
+                ): self {
+                    if ($this->features === $features) {
+                        return $this;
+                    }
+
+                    $value = $modelData['features'] = $features;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateFeatures($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->features = $value;
+                    $this->_rawModelDataInput['features'] = $features;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property features
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processFeatures(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('features', $modelData) && $this->features === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('features', $modelData) ? $modelData['features'] : $this->features;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Features65d4b00f3b44e($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'features',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->features = $this->validateFeatures($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property features
+             */
+            protected function validateFeatures($value, array $modelData)
+            {
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'features',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Features65d4b00f3b44e)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'features',
+  1 => 'Schema_Features65d4b00f3b44e',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of constants.
+             *
+             * PHP Constants to define on every request
+             *
+             * @return Schema_Constants65d4b00f3b4a2|null
+             */
+            public function getConstants()
+                : ?Schema_Constants65d4b00f3b4a2
+            {
+                
+
+                return $this->constants;
+            }
+
+            
+                /**
+                 * Set the value of constants.
+                 *
+                 * @param Schema_Constants65d4b00f3b4a2 $constants PHP Constants to define on every request
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setConstants(
+                    Schema_Constants65d4b00f3b4a2 $constants
+                ): self {
+                    if ($this->constants === $constants) {
+                        return $this;
+                    }
+
+                    $value = $modelData['constants'] = $constants;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateConstants($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->constants = $value;
+                    $this->_rawModelDataInput['constants'] = $constants;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property constants
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processConstants(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('constants', $modelData) && $this->constants === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('constants', $modelData) ? $modelData['constants'] : $this->constants;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Constants65d4b00f3b4a2($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'constants',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->constants = $this->validateConstants($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property constants
+             */
+            protected function validateConstants($value, array $modelData)
+            {
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'constants',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Constants65d4b00f3b4a2)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'constants',
+  1 => 'Schema_Constants65d4b00f3b4a2',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of plugins.
+             *
+             * WordPress plugins to install and activate
+             *
+             * @return string[]|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c[]|null
+             */
+            public function getPlugins()
+                : ?array
+            {
+                
+
+                return $this->plugins;
+            }
+
+            
+                /**
+                 * Set the value of plugins.
+                 *
+                 * @param string[]|Schema_Merged_Itemofarrayplugins65d4b00f3ba2c[] $plugins WordPress plugins to install and activate
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPlugins(
+                    array $plugins
+                ): self {
+                    if ($this->plugins === $plugins) {
+                        return $this;
+                    }
+
+                    $value = $modelData['plugins'] = $plugins;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePlugins($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->plugins = $value;
+                    $this->_rawModelDataInput['plugins'] = $plugins;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property plugins
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPlugins(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('plugins', $modelData) && $this->plugins === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('plugins', $modelData) ? $modelData['plugins'] : $this->plugins;
+
+                
+
+                $this->plugins = $this->validatePlugins($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property plugins
+             */
+            protected function validatePlugins($value, array $modelData)
+            {
+                
+                    
+
+if (!is_array($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'plugins',
+  1 => 'array',
+)));
+}
+
+                
+                    $this->validatePlugins_ArrayItem_65d4b00f3bb68($value);
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of siteOptions.
+             *
+             * WordPress site options to define
+             *
+             * @return Schema_SiteOptions65d4b00f3bb76|null
+             */
+            public function getSiteOptions()
+                : ?Schema_SiteOptions65d4b00f3bb76
+            {
+                
+
+                return $this->siteOptions;
+            }
+
+            
+                /**
+                 * Set the value of siteOptions.
+                 *
+                 * @param Schema_SiteOptions65d4b00f3bb76 $siteOptions WordPress site options to define
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSiteOptions(
+                    Schema_SiteOptions65d4b00f3bb76 $siteOptions
+                ): self {
+                    if ($this->siteOptions === $siteOptions) {
+                        return $this;
+                    }
+
+                    $value = $modelData['siteOptions'] = $siteOptions;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSiteOptions($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->siteOptions = $value;
+                    $this->_rawModelDataInput['siteOptions'] = $siteOptions;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property siteOptions
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSiteOptions(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('siteOptions', $modelData) && $this->siteOptions === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('siteOptions', $modelData) ? $modelData['siteOptions'] : $this->siteOptions;
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_SiteOptions65d4b00f3bb76($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\NestedObjectException($value ?? null, ...array (
+  0 => 'siteOptions',
+  1 => $instantiationException,
+)));
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                $this->siteOptions = $this->validateSiteOptions($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property siteOptions
+             */
+            protected function validateSiteOptions($value, array $modelData)
+            {
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'siteOptions',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_SiteOptions65d4b00f3bb76)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'siteOptions',
+  1 => 'Schema_SiteOptions65d4b00f3bb76',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of phpExtensionBundles.
+             *
+             * The PHP extensions to use.
+             *
+             * @return string[]|null
+             */
+            public function getPhpExtensionBundles()
+                : ?array
+            {
+                
+
+                return $this->phpExtensionBundles;
+            }
+
+            
+                /**
+                 * Set the value of phpExtensionBundles.
+                 *
+                 * @param string[] $phpExtensionBundles The PHP extensions to use.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setPhpExtensionBundles(
+                    array $phpExtensionBundles
+                ): self {
+                    if ($this->phpExtensionBundles === $phpExtensionBundles) {
+                        return $this;
+                    }
+
+                    $value = $modelData['phpExtensionBundles'] = $phpExtensionBundles;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validatePhpExtensionBundles($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->phpExtensionBundles = $value;
+                    $this->_rawModelDataInput['phpExtensionBundles'] = $phpExtensionBundles;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property phpExtensionBundles
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processPhpExtensionBundles(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('phpExtensionBundles', $modelData) && $this->phpExtensionBundles === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('phpExtensionBundles', $modelData) ? $modelData['phpExtensionBundles'] : $this->phpExtensionBundles;
+
+                
+
+                $this->phpExtensionBundles = $this->validatePhpExtensionBundles($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property phpExtensionBundles
+             */
+            protected function validatePhpExtensionBundles($value, array $modelData)
+            {
+                
+                    
+
+if (!is_array($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'phpExtensionBundles',
+  1 => 'array',
+)));
+}
+
+                
+                    $this->validatePhpExtensionBundles_ArrayItem_65d4b00f3bbc1($value);
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of steps.
+             *
+             * The steps to run after every other operation in this Blueprint was executed.
+             *
+             * @return string[]|mixed[]|bool[]|null[]|Schema_Itemofarraysteps65d4b00f3bc1a[]|Schema_Itemofarraysteps65d4b00f3bd2b[]|Schema_Itemofarraysteps65d4b00f3bd71[]|Schema_Itemofarraysteps65d4b00f3bdb9[]|Schema_Itemofarraysteps65d4b00f3be19[]|Schema_Itemofarraysteps65d4b00f3be55[]|Schema_Itemofarraysteps65d4b00f3be88[]|Schema_Itemofarraysteps65d4b00f3bec0[]|Schema_Itemofarraysteps65d4b00f3bf1f[]|Schema_Itemofarraysteps65d4b00f3bf77[]|Schema_Itemofarraysteps65d4b00f3bfac[]|Schema_Itemofarraysteps65d4b00f3bfed[]|Schema_Itemofarraysteps65d4b00f3c026[]|Schema_Itemofarraysteps65d4b00f3c05a[]|Schema_Itemofarraysteps65d4b00f3c092[]|Schema_Itemofarraysteps65d4b00f3c0e9[]|Schema_Itemofarraysteps65d4b00f3c123[]|Schema_Itemofarraysteps65d4b00f3c166[]|Schema_Itemofarraysteps65d4b00f3c1ae[]|Schema_Itemofarraysteps65d4b00f3c217[]
+             */
+            public function getSteps()
+                : ?array
+            {
+                
+
+                return $this->steps;
+            }
+
+            
+                /**
+                 * Set the value of steps.
+                 *
+                 * @param string[]|mixed[]|bool[]|null[]|Schema_Itemofarraysteps65d4b00f3bc1a[]|Schema_Itemofarraysteps65d4b00f3bd2b[]|Schema_Itemofarraysteps65d4b00f3bd71[]|Schema_Itemofarraysteps65d4b00f3bdb9[]|Schema_Itemofarraysteps65d4b00f3be19[]|Schema_Itemofarraysteps65d4b00f3be55[]|Schema_Itemofarraysteps65d4b00f3be88[]|Schema_Itemofarraysteps65d4b00f3bec0[]|Schema_Itemofarraysteps65d4b00f3bf1f[]|Schema_Itemofarraysteps65d4b00f3bf77[]|Schema_Itemofarraysteps65d4b00f3bfac[]|Schema_Itemofarraysteps65d4b00f3bfed[]|Schema_Itemofarraysteps65d4b00f3c026[]|Schema_Itemofarraysteps65d4b00f3c05a[]|Schema_Itemofarraysteps65d4b00f3c092[]|Schema_Itemofarraysteps65d4b00f3c0e9[]|Schema_Itemofarraysteps65d4b00f3c123[]|Schema_Itemofarraysteps65d4b00f3c166[]|Schema_Itemofarraysteps65d4b00f3c1ae[]|Schema_Itemofarraysteps65d4b00f3c217[] $steps The steps to run after every other operation in this Blueprint was executed.
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSteps(
+                    array $steps
+                ): self {
+                    if ($this->steps === $steps) {
+                        return $this;
+                    }
+
+                    $value = $modelData['steps'] = $steps;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSteps($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->steps = $value;
+                    $this->_rawModelDataInput['steps'] = $steps;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property steps
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSteps(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('steps', $modelData) && $this->steps === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('steps', $modelData) ? $modelData['steps'] : $this->steps;
+
+                
+
+                $this->steps = $this->validateSteps($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property steps
+             */
+            protected function validateSteps($value, array $modelData)
+            {
+                
+                    
+
+if (!is_array($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'steps',
+  1 => 'array',
+)));
+}
+
+                
+                    $this->validateSteps_ArrayItem_65d4b00f3c505($value);
+                
+
+                return $value;
+            }
+        
+    
+        
+            /**
+             * Get the value of $schema.
+             *
+             * 
+             *
+             * @return string|null
+             */
+            public function getSchema()
+                : ?string
+            {
+                
+
+                return $this->schema;
+            }
+
+            
+                /**
+                 * Set the value of $schema.
+                 *
+                 * @param string $schema
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setSchema(
+                    string $schema
+                ): self {
+                    if ($this->schema === $schema) {
+                        return $this;
+                    }
+
+                    $value = $modelData['$schema'] = $schema;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateSchema($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->schema = $value;
+                    $this->_rawModelDataInput['$schema'] = $schema;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property schema
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processSchema(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('$schema', $modelData) && $this->schema === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('$schema', $modelData) ? $modelData['$schema'] : $this->schema;
+
+                
+
+                $this->schema = $this->validateSchema($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property schema
+             */
+            protected function validateSchema($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => '$schema',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+
+    private function validatePlugins_ArrayItem_65d4b00f3bb68(&$value): void {
+                    $invalidItems_632057b18481b76cbe71c78b86275801 = [];
+                    
+                    if (is_array($value) && (function (&$items) use (&$invalidItems_632057b18481b76cbe71c78b86275801) {
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    foreach ($items as $index => &$value) {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        try {
+            
+
+            
+                $this->validateItemOfArrayPlugins_ComposedProperty_65d4b00f3bb2c($value);
+            
+
+            
+                if ($this->_errorRegistry->getErrors()) {
+                    $invalidItems_632057b18481b76cbe71c78b86275801[$index] = $this->_errorRegistry->getErrors();
+                }
+            
+        } catch (\Exception $e) {
+            // collect all errors concerning invalid items
+            isset($invalidItems_632057b18481b76cbe71c78b86275801[$index])
+                ? $invalidItems_632057b18481b76cbe71c78b86275801[$index][] = $e
+                : $invalidItems_632057b18481b76cbe71c78b86275801[$index] = [$e];
+        }
+    }
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    return !empty($invalidItems_632057b18481b76cbe71c78b86275801);
+})($value)) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Arrays\InvalidItemException($value ?? null, ...array (
+  0 => 'plugins',
+  1 => $invalidItems_632057b18481b76cbe71c78b86275801,
+)));
+                    }
+                }
+
+private function validatePhpExtensionBundles_ArrayItem_65d4b00f3bbc1(&$value): void {
+                    $invalidItems_18533bc0ecb84ac2004c095f11545d3d = [];
+                    
+                    if (is_array($value) && (function (&$items) use (&$invalidItems_18533bc0ecb84ac2004c095f11545d3d) {
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    foreach ($items as $index => &$value) {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        try {
+            
+
+            
+                
+
+if ($value !== 'kitchen-sink') {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'item of array phpExtensionBundles',
+  1 => 'kitchen-sink',
+)));
+}
+
+            
+
+            
+                if ($this->_errorRegistry->getErrors()) {
+                    $invalidItems_18533bc0ecb84ac2004c095f11545d3d[$index] = $this->_errorRegistry->getErrors();
+                }
+            
+        } catch (\Exception $e) {
+            // collect all errors concerning invalid items
+            isset($invalidItems_18533bc0ecb84ac2004c095f11545d3d[$index])
+                ? $invalidItems_18533bc0ecb84ac2004c095f11545d3d[$index][] = $e
+                : $invalidItems_18533bc0ecb84ac2004c095f11545d3d[$index] = [$e];
+        }
+    }
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    return !empty($invalidItems_18533bc0ecb84ac2004c095f11545d3d);
+})($value)) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Arrays\InvalidItemException($value ?? null, ...array (
+  0 => 'phpExtensionBundles',
+  1 => $invalidItems_18533bc0ecb84ac2004c095f11545d3d,
+)));
+                    }
+                }
+
+private function validateSteps_ArrayItem_65d4b00f3c505(&$value): void {
+                    $invalidItems_26bac3b864e3e68291033f71170da9a3 = [];
+                    
+                    if (is_array($value) && (function (&$items) use (&$invalidItems_26bac3b864e3e68291033f71170da9a3) {
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    foreach ($items as $index => &$value) {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        try {
+            
+
+            
+                $this->validateItemOfArraySteps_ComposedProperty_65d4b00f3c500($value);
+            
+
+            
+                if ($this->_errorRegistry->getErrors()) {
+                    $invalidItems_26bac3b864e3e68291033f71170da9a3[$index] = $this->_errorRegistry->getErrors();
+                }
+            
+        } catch (\Exception $e) {
+            // collect all errors concerning invalid items
+            isset($invalidItems_26bac3b864e3e68291033f71170da9a3[$index])
+                ? $invalidItems_26bac3b864e3e68291033f71170da9a3[$index][] = $e
+                : $invalidItems_26bac3b864e3e68291033f71170da9a3[$index] = [$e];
+        }
+    }
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    return !empty($invalidItems_26bac3b864e3e68291033f71170da9a3);
+})($value)) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Arrays\InvalidItemException($value ?? null, ...array (
+  0 => 'steps',
+  1 => $invalidItems_26bac3b864e3e68291033f71170da9a3,
+)));
+                    }
+                }
+
+private function validateItemOfArrayPlugins_ComposedProperty_65d4b00f3bb2c(&$value): void {
+                    
+            $succeededCompositionElements = 0;
+            $compositionErrorCollection = [];
+        
+                    
+                    if (
+(function (&$value) use (
+    &$modelData,
+    &$modifiedModelData,
+    &$compositionErrorCollection,
+    &$succeededCompositionElements,
+    &$validatorIndex
+) {
+    $succeededCompositionElements = 2;
+    $validatorComponentIndex = 0;
+    $originalModelData = $value;
+    $proposedValue = null;
+    $modifiedValues = [];
+
+    
+
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'item of array plugins',
+  1 => 'string',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_2c62e($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_2c62e($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+
+    
+        $value = $proposedValue;
+    
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    $result = !($succeededCompositionElements > 0);
+
+    
+
+    return $result;
+})($value)
+) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\ComposedValue\AnyOfException($value ?? null, ...array (
+  0 => 'item of array plugins',
+  1 => $succeededCompositionElements,
+  2 => $compositionErrorCollection,
+)));
+                    }
+                }
+
+private function validateItemOfArraySteps_ComposedProperty_65d4b00f3c500(&$value): void {
+                    
+            $succeededCompositionElements = 0;
+            $compositionErrorCollection = [];
+        
+                    
+                    if (
+(function (&$value) use (
+    &$modelData,
+    &$modifiedModelData,
+    &$compositionErrorCollection,
+    &$succeededCompositionElements,
+    &$validatorIndex
+) {
+    $succeededCompositionElements = 5;
+    $validatorComponentIndex = 0;
+    $originalModelData = $value;
+    $proposedValue = null;
+    $modifiedValues = [];
+
+    
+
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c28b($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+
+                
+                    
+
+if (!is_object($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => 'object',
+)));
+}
+
+                
+                    
+
+if (is_object($value) && !($value instanceof \Exception) && !($value instanceof Schema_Itemofarraysteps65d4b00f3c28b)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidInstanceOfException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => 'Schema_Itemofarraysteps65d4b00f3c28b',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_a60e8($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => 'string',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_a60e8($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_a60e8($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if ($value !== false) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidConstException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => false,
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_a60e8($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+        try {
+            
+
+                
+                    // collect errors for each composition element
+                    $this->_errorRegistry = new ErrorRegistryException();
+                
+
+                
+
+                
+
+                
+                    
+
+if (!is_null($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => 'null',
+)));
+}
+
+                
+
+                
+                    $compositionErrorCollection[] = $this->_errorRegistry;
+
+                    
+
+                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                    // composition item
+                    if ($this->_errorRegistry->getErrors()) {
+                        throw new \Exception();
+                    }
+                
+
+                
+                    $proposedValue = $proposedValue ?? $value;
+                
+
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues_a60e8($originalModelData, $value));
+                }
+            
+        } catch (\Exception $e) {
+            
+
+            
+
+            $succeededCompositionElements--;
+        }
+
+        $value = $originalModelData;
+        $validatorComponentIndex++;
+    
+
+    
+        if (is_object($proposedValue)) {
+            if ($modifiedValues) {
+                $value = array_merge($value, $modifiedValues);
+            }
+
+            $value = (function ($value) {
+    try {
+        return is_array($value) ? new Schema_Itemofarraysteps65d4b00f3c28b($value) : $value;
+    } catch (\Exception $instantiationException) {
+        
+            
+                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                    $this->_errorRegistry->addError($nestedValidationError);
+                }
+            
+        
+
+        
+            return $instantiationException;
+        
+    }
+})($value)
+;
+        } else {
+            $value = $proposedValue;
+        }
+    
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    $result = !($succeededCompositionElements > 0);
+
+    
+
+    return $result;
+})($value)
+) {
+                        $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\ComposedValue\AnyOfException($value ?? null, ...array (
+  0 => 'item of array steps',
+  1 => $succeededCompositionElements,
+  2 => $compositionErrorCollection,
+)));
+                    }
+                }
+
+
+                        private function _getModifiedValues_2c62e(array $originalModelData, object $nestedCompositionObject): array {
+                            $modifiedValues = [];
+                            $defaultValueMap = array (
+);
+    
+                            foreach (array (
+) as $key => $accessor) {
+                                if ((isset($originalModelData[$key]) || in_array($key, $defaultValueMap))
+                                    && method_exists($nestedCompositionObject, $accessor)
+                                    && ($modifiedValue = $nestedCompositionObject->$accessor()) !== ($originalModelData[$key] ?? !$modifiedValue)
+                                ) {
+                                    $modifiedValues[$key] = $modifiedValue;
+                                }
+                            }
+    
+                            return $modifiedValues;
+                        }
+
+
+                        private function _getModifiedValues_a60e8(array $originalModelData, object $nestedCompositionObject): array {
+                            $modifiedValues = [];
+                            $defaultValueMap = array (
+  0 => 'propertyValidationState',
+);
+    
+                            foreach (array (
+  'step' => 'getStep',
+  'progress' => 'getProgress',
+  'continueOnError' => 'getContinueOnError',
+  'slug' => 'getSlug',
+  'fromPath' => 'getFromPath',
+  'toPath' => 'getToPath',
+  'consts' => 'getConsts',
+  'siteUrl' => 'getSiteUrl',
+  'item of array plugins' => 'getItemOfArrayPlugins',
+  'options' => 'getOptions',
+  'path' => 'getPath',
+  'code' => 'getCode',
+  'zipPath' => 'getZipPath',
+  'extractToPath' => 'getExtractToPath',
+  'data' => 'getData',
+  'command' => 'getCommand',
+  'propertyValidationState' => 'get_propertyValidationState',
+) as $key => $accessor) {
+                                if ((isset($originalModelData[$key]) || in_array($key, $defaultValueMap))
+                                    && method_exists($nestedCompositionObject, $accessor)
+                                    && ($modifiedValue = $nestedCompositionObject->$accessor()) !== ($originalModelData[$key] ?? !$modifiedValue)
+                                ) {
+                                    $modifiedValues[$key] = $modifiedValue;
+                                }
+                            }
+    
+                            return $modifiedValues;
+                        }
+
+
+}
+
+// @codeCoverageIgnoreEnd

--- a/result/Schema_SiteOptions65d4b00f3bb76.php
+++ b/result/Schema_SiteOptions65d4b00f3bb76.php
@@ -1,0 +1,292 @@
+<?php
+
+// @codingStandardsIgnoreFile
+// @codeCoverageIgnoreStart
+
+declare(strict_types = 1);
+
+
+    namespace MyApp\Model;
+
+
+
+    use PHPModelGenerator\Interfaces\JSONModelInterface;
+
+    use PHPModelGenerator\Exception\ErrorRegistryException;
+
+
+/**
+ * Class Schema_SiteOptions65d4b00f3bb76
+ * @package MyApp\Model 
+ *
+ * WordPress site options to define
+ *
+ * This is an auto-implemented class implemented by the php-json-schema-model-generator.
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
+ * are re-generated.
+ */
+class Schema_SiteOptions65d4b00f3bb76 implements JSONModelInterface
+{
+    
+
+    
+        /** @var string|null The site title */
+        protected $blogname;
+    
+        /** @var string[] Collect all additional properties provided to the schema */
+        private $_additionalProperties = array (
+);
+    
+    /** @var array */
+    protected $_rawModelDataInput = [];
+
+    
+        /** @var ErrorRegistryException Collect all validation errors */
+        protected $_errorRegistry;
+    
+
+    /**
+     * Schema_SiteOptions65d4b00f3bb76 constructor.
+     *
+     * @param array $rawModelDataInput
+     *
+     * @throws ErrorRegistryException
+     */
+    public function __construct(array $rawModelDataInput = [])
+    {
+        
+            $this->_errorRegistry = new ErrorRegistryException();
+        
+
+        
+
+        
+            $this->executeBaseValidators($rawModelDataInput);
+        
+
+        
+            
+                $this->processBlogname($rawModelDataInput);
+            
+        
+            
+        
+
+        
+            if (count($this->_errorRegistry->getErrors())) {
+                throw $this->_errorRegistry;
+            }
+        
+
+        $this->_rawModelDataInput = $rawModelDataInput;
+
+        
+    }
+
+    
+        protected function executeBaseValidators(array &$modelData): void
+        {
+            $value = &$modelData;
+
+            
+                
+
+            $properties = $value;
+            $invalidProperties = [];
+        
+if ((function () use ($properties, &$invalidProperties) {
+    
+        $originalErrorRegistry = $this->_errorRegistry;
+    
+    
+        $rollbackValues = $this->_additionalProperties;
+    
+
+    foreach (array_diff(array_keys($properties), array (
+   'blogname',
+)) as $propertyKey) {
+        
+
+        try {
+            $value = $properties[$propertyKey];
+
+            
+                $this->_errorRegistry = new ErrorRegistryException();
+            
+
+            
+
+            
+                
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'additional property',
+  1 => 'string',
+)));
+}
+
+            
+
+            
+                if ($this->_errorRegistry->getErrors()) {
+                    $invalidProperties[$propertyKey] = $this->_errorRegistry->getErrors();
+                }
+            
+
+            
+                $this->_additionalProperties[$propertyKey] = $value;
+            
+        } catch (\Exception $e) {
+            // collect all errors concerning invalid additional properties
+            isset($invalidProperties[$propertyKey])
+                ? $invalidProperties[$propertyKey][] = $e
+                : $invalidProperties[$propertyKey] = [$e];
+        }
+    }
+
+    
+        $this->_errorRegistry = $originalErrorRegistry;
+    
+
+    
+        if (!empty($invalidProperties)) {
+            $this->_additionalProperties = $rollbackValues;
+        }
+    
+
+    return !empty($invalidProperties);
+})()) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Object\InvalidAdditionalPropertiesException($value ?? null, ...array (
+  0 => 'Schema_SiteOptions65d4b00f3bb76',
+  1 => $invalidProperties,
+)));
+}
+
+            
+
+            
+        }
+    
+
+    /**
+     * Get the raw input used to set up the model
+     *
+     * @return array
+     */
+    public function getRawModelDataInput(): array
+    {
+        return $this->_rawModelDataInput;
+    }
+
+    
+        
+            /**
+             * Get the value of blogname.
+             *
+             * The site title
+             *
+             * @return string|null
+             */
+            public function getBlogname()
+                : ?string
+            {
+                
+
+                return $this->blogname;
+            }
+
+            
+                /**
+                 * Set the value of blogname.
+                 *
+                 * @param string $blogname The site title
+                 *
+                 * @throws ErrorRegistryException
+                 *
+                 * @return self
+                 */
+                public function setBlogname(
+                    string $blogname
+                ): self {
+                    if ($this->blogname === $blogname) {
+                        return $this;
+                    }
+
+                    $value = $modelData['blogname'] = $blogname;
+
+                    
+                        $this->_errorRegistry = new ErrorRegistryException();
+                    
+
+                    
+
+                    $value = $this->validateBlogname($value, $modelData);
+
+                    
+                        if ($this->_errorRegistry->getErrors()) {
+                            throw $this->_errorRegistry;
+                        }
+                    
+
+                    $this->blogname = $value;
+                    $this->_rawModelDataInput['blogname'] = $blogname;
+
+                    
+
+                    return $this;
+                }
+            
+
+            /**
+             * Extract the value, perform validations and set the property blogname
+             *
+             * @param array $modelData
+             *
+             * @throws ErrorRegistryException
+             */
+            protected function processBlogname(array $modelData): void
+            {
+                
+                    
+                        if (!array_key_exists('blogname', $modelData) && $this->blogname === null) {
+                            return;
+                        }
+                    
+                
+
+                $value = array_key_exists('blogname', $modelData) ? $modelData['blogname'] : $this->blogname;
+
+                
+
+                $this->blogname = $this->validateBlogname($value, $modelData);
+            }
+
+            /**
+             * Execute all validators for the property blogname
+             */
+            protected function validateBlogname($value, array $modelData)
+            {
+                
+                    
+
+if (!is_string($value)) {
+    $this->_errorRegistry->addError(new \PHPModelGenerator\Exception\Generic\InvalidTypeException($value ?? null, ...array (
+  0 => 'blogname',
+  1 => 'string',
+)));
+}
+
+                
+
+                return $value;
+            }
+        
+    
+        
+    
+
+    
+}
+
+// @codeCoverageIgnoreEnd


### PR DESCRIPTION
Explores this library for generating and mapping models:

https://php-json-schema-model-generator.readthedocs.io/en/latest/gettingStarted.html#installation

The output isn't compelling:

* The names are mangled
* Models have a bunch of logic in them
* Setters attempt to validate the incoming data
* Validation is coupled and co-located with the data object

I don't think we'll go with this library