### PR TITLE
Progress events and progress bar support

### DIFF
--- a/blueprint_compiling.php
+++ b/blueprint_compiling.php
@@ -1,7 +1,14 @@
 <?php
 
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use WordPress\Blueprints\ContainerBuilder;
 use WordPress\Blueprints\Model\BlueprintBuilder;
+use WordPress\Blueprints\Progress\DoneEvent;
+use WordPress\Blueprints\Progress\ProgressEvent;
 use function WordPress\Blueprints\run_blueprint;
 
 if ( getenv( 'USE_PHAR' ) ) {
@@ -28,7 +35,7 @@ $blueprint = BlueprintBuilder::create()
 		'https://downloads.wordpress.org/plugin/gutenberg.17.7.0.zip',
 	] )
 	->withTheme( 'https://downloads.wordpress.org/theme/pendant.zip' )
-	->withContent( 'https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml' )
+//	->withContent( 'https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml' )
 	->withSiteUrl( 'http://localhost:8081' )
 	->andRunSQL( <<<'SQL'
 		CREATE TABLE `tmp_table` ( id INT );
@@ -39,7 +46,43 @@ $blueprint = BlueprintBuilder::create()
 	->withFile( 'wordpress.txt', 'Data' )
 	->toBlueprint();
 
+$subscriber = new class implements EventSubscriberInterface {
+	public static function getSubscribedEvents() {
+		return [
+			ProgressEvent::class => 'onProgress',
+			DoneEvent::class     => 'onDone',
+		];
+	}
 
-$results = run_blueprint( $blueprint, ContainerBuilder::ENVIRONMENT_NATIVE, __DIR__ . '/new-wp' );
+	protected ProgressBar $progress_bar;
 
-var_dump( $results );
+	public function __construct() {
+		ProgressBar::setFormatDefinition( 'custom', ' [%bar%] %current%/%max% -- %message% (%filename%)' );
+
+		$this->progress_bar = ( new SymfonyStyle( new StringInput( "" ), new ConsoleOutput() ) )->createProgressBar();
+		$this->progress_bar->setFormat( 'custom' );
+		$this->progress_bar->setMessage( 'Start' );
+		$this->progress_bar->start();
+	}
+
+	public function onProgress( ProgressEvent $event ) {
+		$this->progress_bar->setMessage( $event->caption );
+		$this->progress_bar->setProgress( (int) $event->progress );
+
+		// echo $event->progress . "% – " . $event->caption . "\n";
+	}
+
+	public function onDone( DoneEvent $event ) {
+//		echo "Steps done!\n";
+		$this->progress_bar->finish();
+	}
+};
+
+$results = run_blueprint(
+	$blueprint,
+	ContainerBuilder::ENVIRONMENT_NATIVE,
+	__DIR__ . '/new-wp',
+	$subscriber
+);
+
+//var_dump( $results );

--- a/blueprint_compiling.php
+++ b/blueprint_compiling.php
@@ -57,9 +57,10 @@ $subscriber = new class implements EventSubscriberInterface {
 	protected ProgressBar $progress_bar;
 
 	public function __construct() {
-		ProgressBar::setFormatDefinition( 'custom', ' [%bar%] %current%/%max% -- %message% (%filename%)' );
+		ProgressBar::setFormatDefinition( 'custom', ' [%bar%] %current%/%max% -- %message%' );
 
-		$this->progress_bar = ( new SymfonyStyle( new StringInput( "" ), new ConsoleOutput() ) )->createProgressBar();
+		$this->progress_bar = ( new SymfonyStyle( new StringInput( "" ),
+			new ConsoleOutput() ) )->createProgressBar( 100 );
 		$this->progress_bar->setFormat( 'custom' );
 		$this->progress_bar->setMessage( 'Start' );
 		$this->progress_bar->start();
@@ -68,21 +69,20 @@ $subscriber = new class implements EventSubscriberInterface {
 	public function onProgress( ProgressEvent $event ) {
 		$this->progress_bar->setMessage( $event->caption );
 		$this->progress_bar->setProgress( (int) $event->progress );
-
-		// echo $event->progress . "% – " . $event->caption . "\n";
 	}
 
 	public function onDone( DoneEvent $event ) {
-//		echo "Steps done!\n";
 		$this->progress_bar->finish();
 	}
 };
 
 $results = run_blueprint(
 	$blueprint,
-	ContainerBuilder::ENVIRONMENT_NATIVE,
-	__DIR__ . '/new-wp',
-	$subscriber
+	[
+		'environment'        => ContainerBuilder::ENVIRONMENT_NATIVE,
+		'documentRoot'       => __DIR__ . '/new-wp',
+		'progressSubscriber' => $subscriber,
+	]
 );
 
 //var_dump( $results );

--- a/src/WordPress/Blueprints/Compile/BlueprintCompiler.php
+++ b/src/WordPress/Blueprints/Compile/BlueprintCompiler.php
@@ -27,14 +27,15 @@ class BlueprintCompiler {
 	public function compile( Blueprint $blueprint ): CompiledBlueprint {
 		$blueprint->steps = array_merge( $this->expandShorthandsIntoSteps( $blueprint ), $blueprint->steps );
 
-		$progressTracker = new Tracker( [
-//			'caption' => 'Preparing WordPress',
-		] );
+		$progressTracker = new Tracker();
+		$stepsStage = $progressTracker->stage( 0.6 );
+		$resourcesStage = $progressTracker->stage( 0.4 );
 
 		return new CompiledBlueprint(
-			$this->compileSteps( $blueprint, $progressTracker->stage( 0.6 ) ),
-			$this->compileResources( $blueprint, $progressTracker->stage( 0.4 ) ),
-			$progressTracker
+			$this->compileSteps( $blueprint, $stepsStage ),
+			$this->compileResources( $blueprint, $resourcesStage ),
+			$progressTracker,
+			$stepsStage
 		);
 	}
 

--- a/src/WordPress/Blueprints/Compile/CompiledBlueprint.php
+++ b/src/WordPress/Blueprints/Compile/CompiledBlueprint.php
@@ -10,6 +10,7 @@ class CompiledBlueprint {
 		public array $compiledSteps,
 		public array $compiledResources,
 		public Tracker $progressTracker,
+		public Tracker $stepsProgressStage,
 	) {
 	}
 

--- a/src/WordPress/Blueprints/Compile/CompiledResource.php
+++ b/src/WordPress/Blueprints/Compile/CompiledResource.php
@@ -2,13 +2,14 @@
 
 namespace WordPress\Blueprints\Compile;
 
+use WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface;
 use WordPress\Blueprints\Progress\Tracker;
 
-class CompiledBlueprint {
+class CompiledResource {
 
 	public function __construct(
-		public array $compiledSteps,
-		public array $compiledResources,
+		public $declaration,
+		public ResourceDefinitionInterface $resource,
 		public Tracker $progressTracker,
 	) {
 	}

--- a/src/WordPress/Blueprints/Compile/CompiledStep.php
+++ b/src/WordPress/Blueprints/Compile/CompiledStep.php
@@ -3,13 +3,15 @@
 namespace WordPress\Blueprints\Compile;
 
 use WordPress\Blueprints\Model\DataClass\StepDefinitionInterface;
+use WordPress\Blueprints\Progress\Tracker;
 use WordPress\Blueprints\Runner\Step\StepRunnerInterface;
 
 class CompiledStep {
 
 	public function __construct(
 		public StepDefinitionInterface $step,
-		public StepRunnerInterface $runner
+		public StepRunnerInterface $runner,
+		public Tracker $progressTracker,
 	) {
 	}
 

--- a/src/WordPress/Blueprints/ContainerBuilder.php
+++ b/src/WordPress/Blueprints/ContainerBuilder.php
@@ -63,7 +63,7 @@ use WordPress\Blueprints\Runtime\Runtime;
 use WordPress\Blueprints\Runtime\RuntimeInterface;
 use WordPress\DataSource\FileSource;
 use WordPress\DataSource\PlaygroundFetchSource;
-use WordPress\DataSource\ProgressEvent;
+use WordPress\DataSource\DataSourceProgressEvent;
 use WordPress\DataSource\UrlSource;
 
 class ContainerBuilder {
@@ -98,7 +98,7 @@ class ContainerBuilder {
 				return HttpClient::create();
 			};
 			$container['progress_reporter'] = function ( $c ) {
-				return function ( ProgressEvent $event ) {
+				return function ( DataSourceProgressEvent $event ) {
 					echo $event->url . ' ' . $event->downloadedBytes . '/' . $event->totalBytes . "                         \r";
 				};
 			};
@@ -110,7 +110,7 @@ class ContainerBuilder {
 				return new UrlResourceResolver( $c['data_source.playground_fetch'] );
 			};
 			$container['progress_reporter'] = function ( $c ) {
-				return function ( ProgressEvent $event ) {
+				return function ( DataSourceProgressEvent $event ) {
 					echo $event->url . ' ' . $event->downloadedBytes . '/' . $event->totalBytes . "                         \r";
 				};
 			};
@@ -277,18 +277,18 @@ class ContainerBuilder {
 		};
 
 		// Add a progress listener to all data sources
-		foreach ( $container->keys() as $key ) {
-			if ( str_starts_with( $key, 'data_source.' ) ) {
-				$container->extend( $key, function ( $urlSource, $c ) {
-					$urlSource->events->addListener(
-						ProgressEvent::class,
-						$c['progress_reporter']
-					);
-
-					return $urlSource;
-				} );
-			}
-		}
+//		foreach ( $container->keys() as $key ) {
+//			if ( str_starts_with( $key, 'data_source.' ) ) {
+//				$container->extend( $key, function ( $urlSource, $c ) {
+//					$urlSource->events->addListener(
+//						ProgressEvent::class,
+//						$c['progress_reporter']
+//					);
+//
+//					return $urlSource;
+//				} );
+//			}
+//		}
 
 		return $container;
 	}

--- a/src/WordPress/Blueprints/Engine.php
+++ b/src/WordPress/Blueprints/Engine.php
@@ -2,6 +2,7 @@
 
 namespace WordPress\Blueprints;
 
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use WordPress\Blueprints\Compile\BlueprintCompiler;
 use WordPress\Blueprints\Runner\Blueprint\BlueprintRunner;
 
@@ -10,13 +11,14 @@ class Engine {
 	public function __construct(
 		protected BlueprintParser $parser,
 		protected BlueprintCompiler $compiler,
-		protected BlueprintRunner $runner
+		public readonly BlueprintRunner $runner
 	) {
 	}
 
-	public function runBlueprint( string|object $rawBlueprint ) {
+	public function runBlueprint( string|object $rawBlueprint, EventSubscriberInterface $progressSubscriber = null ) {
 		$blueprint = $this->parser->parse( $rawBlueprint );
 		$compiled = $this->compiler->compile( $blueprint );
+		$compiled->progressTracker->events->addSubscriber( $progressSubscriber );
 
 		return $this->runner->run( $compiled );
 	}

--- a/src/WordPress/Blueprints/Engine.php
+++ b/src/WordPress/Blueprints/Engine.php
@@ -4,6 +4,7 @@ namespace WordPress\Blueprints;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use WordPress\Blueprints\Compile\BlueprintCompiler;
+use WordPress\Blueprints\Compile\CompiledBlueprint;
 use WordPress\Blueprints\Runner\Blueprint\BlueprintRunner;
 
 class Engine {
@@ -15,12 +16,14 @@ class Engine {
 	) {
 	}
 
-	public function runBlueprint( string|object $rawBlueprint, EventSubscriberInterface $progressSubscriber = null ) {
+	public function parseAndCompile( string|object $rawBlueprint ) {
 		$blueprint = $this->parser->parse( $rawBlueprint );
-		$compiled = $this->compiler->compile( $blueprint );
-		$compiled->progressTracker->events->addSubscriber( $progressSubscriber );
 
-		return $this->runner->run( $compiled );
+		return $this->compiler->compile( $blueprint );
+	}
+
+	public function run( CompiledBlueprint $compiledBlueprint ) {
+		return $this->runner->run( $compiledBlueprint );
 	}
 
 }

--- a/src/WordPress/Blueprints/Model/DataClass/ResourceDefinitionInterface.php
+++ b/src/WordPress/Blueprints/Model/DataClass/ResourceDefinitionInterface.php
@@ -2,6 +2,5 @@
 
 namespace WordPress\Blueprints\Model\DataClass;
 
-interface ResourceDefinitionInterface
-{
+interface ResourceDefinitionInterface {
 }

--- a/src/WordPress/Blueprints/Model/DataClass/UrlResource.php
+++ b/src/WordPress/Blueprints/Model/DataClass/UrlResource.php
@@ -2,8 +2,7 @@
 
 namespace WordPress\Blueprints\Model\DataClass;
 
-class UrlResource implements ResourceDefinitionInterface
-{
+class UrlResource implements ResourceDefinitionInterface {
 	public const DISCRIMINATOR = 'url';
 
 	/**
@@ -25,23 +24,26 @@ class UrlResource implements ResourceDefinitionInterface
 	public $caption;
 
 
-	public function setResource(string $resource)
-	{
+	public function setResource( string $resource ) {
 		$this->resource = $resource;
+
 		return $this;
 	}
 
 
-	public function setUrl(string $url)
-	{
+	public function setUrl( string $url ) {
 		$this->url = $url;
+		if ( ! $this->caption ) {
+			$this->caption = 'Downloading ' . $url;
+		}
+
 		return $this;
 	}
 
 
-	public function setCaption(string $caption)
-	{
+	public function setCaption( string $caption ) {
 		$this->caption = $caption;
+
 		return $this;
 	}
 }

--- a/src/WordPress/Blueprints/Resource/Resolver/FilesystemResourceResolver.php
+++ b/src/WordPress/Blueprints/Resource/Resolver/FilesystemResourceResolver.php
@@ -2,9 +2,9 @@
 
 namespace WordPress\Blueprints\Resource\Resolver;
 
-use WordPress\Blueprints\Model\Builder\FilesystemResourceBuilder;
 use WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface;
 use WordPress\Blueprints\Model\DataClass\FilesystemResource;
+use WordPress\Blueprints\Progress\Tracker;
 
 class FilesystemResourceResolver implements ResourceResolverInterface {
 
@@ -13,7 +13,7 @@ class FilesystemResourceResolver implements ResourceResolverInterface {
 			return false;
 		}
 
-		return ( new FilesystemResourceBuilder() )->setPath( $url );
+		return ( new FilesystemResource() )->setPath( $url );
 	}
 
 	static public function getResourceClass(): string {
@@ -24,10 +24,12 @@ class FilesystemResourceResolver implements ResourceResolverInterface {
 		return $resource instanceof FilesystemResource;
 	}
 
-	public function stream( ResourceDefinitionInterface $resource ) {
+	public function stream( ResourceDefinitionInterface $resource, Tracker $progressTracker ) {
 		if ( ! $this->supports( $resource ) ) {
 			throw new \InvalidArgumentException( 'Resource ' . get_class( $resource ) . ' unsupported' );
 		}
+
+		$progressTracker->finish();
 
 		/** @var $resource FilesystemResource */
 		return fopen( $resource->path, 'r' );

--- a/src/WordPress/Blueprints/Resource/Resolver/InlineResourceResolver.php
+++ b/src/WordPress/Blueprints/Resource/Resolver/InlineResourceResolver.php
@@ -5,6 +5,7 @@ namespace WordPress\Blueprints\Resource\Resolver;
 use WordPress\Blueprints\Model\Builder\InlineResourceBuilder;
 use WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface;
 use WordPress\Blueprints\Model\DataClass\InlineResource;
+use WordPress\Blueprints\Progress\Tracker;
 
 class InlineResourceResolver implements ResourceResolverInterface {
 
@@ -25,10 +26,12 @@ class InlineResourceResolver implements ResourceResolverInterface {
 		return $resource instanceof InlineResource;
 	}
 
-	public function stream( ResourceDefinitionInterface $resource ) {
+	public function stream( ResourceDefinitionInterface $resource, Tracker $progressTracker ) {
 		if ( ! $this->supports( $resource ) ) {
 			throw new \InvalidArgumentException( 'Resource ' . get_class( $resource ) . ' unsupported' );
 		}
+		$progressTracker->finish();
+
 		/** @var $resource InlineResource */
 		$fp = fopen( "php://temp", 'r+' );
 		fwrite( $fp, $resource->contents );

--- a/src/WordPress/Blueprints/Resource/Resolver/ResourceResolverCollection.php
+++ b/src/WordPress/Blueprints/Resource/Resolver/ResourceResolverCollection.php
@@ -3,6 +3,7 @@
 namespace WordPress\Blueprints\Resource\Resolver;
 
 use WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface;
+use WordPress\Blueprints\Progress\Tracker;
 
 class ResourceResolverCollection implements ResourceResolverInterface {
 
@@ -37,10 +38,10 @@ class ResourceResolverCollection implements ResourceResolverInterface {
 		return false;
 	}
 
-	public function stream( ResourceDefinitionInterface $resource ) {
+	public function stream( ResourceDefinitionInterface $resource, Tracker $progressTracker ) {
 		foreach ( $this->ResourceResolvers as $handler ) {
 			if ( $handler->supports( $resource ) ) {
-				return $handler->stream( $resource );
+				return $handler->stream( $resource, $progressTracker );
 			}
 		}
 

--- a/src/WordPress/Blueprints/Resource/Resolver/ResourceResolverInterface.php
+++ b/src/WordPress/Blueprints/Resource/Resolver/ResourceResolverInterface.php
@@ -3,6 +3,7 @@
 namespace WordPress\Blueprints\Resource\Resolver;
 
 use WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface;
+use WordPress\Blueprints\Progress\Tracker;
 
 interface ResourceResolverInterface {
 	public function parseUrl( string $url ): ResourceDefinitionInterface|false;
@@ -11,5 +12,5 @@ interface ResourceResolverInterface {
 
 	static public function getResourceClass(): string;
 
-	public function stream( ResourceDefinitionInterface $resource );
+	public function stream( ResourceDefinitionInterface $resource, Tracker $progressTracker );
 }

--- a/src/WordPress/Blueprints/Resource/ResourceManager.php
+++ b/src/WordPress/Blueprints/Resource/ResourceManager.php
@@ -3,6 +3,7 @@
 namespace WordPress\Blueprints\Resource;
 
 use Symfony\Component\Filesystem\Filesystem;
+use WordPress\Blueprints\Compile\CompiledResource;
 use WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface;
 use WordPress\Blueprints\Resource\Resolver\ResourceResolverInterface;
 
@@ -18,9 +19,13 @@ class ResourceManager {
 		$this->map = new ResourceMap();
 	}
 
-	public function enqueue( array $resourceDeclarations ) {
-		foreach ( $resourceDeclarations as [$originalInput, $resource] ) {
-			$this->map[ $originalInput ] = $this->resourceResolver->stream( $resource );
+	public function enqueue( array $compiledResources ) {
+		foreach ( $compiledResources as $compiled ) {
+			/** @var CompiledResource $compiled */
+			$this->map[ $compiled->declaration ] = $this->resourceResolver->stream(
+				$compiled->resource,
+				$compiled->progressTracker
+			);
 		}
 	}
 

--- a/src/WordPress/Blueprints/Runner/Blueprint/BlueprintRunner.php
+++ b/src/WordPress/Blueprints/Runner/Blueprint/BlueprintRunner.php
@@ -2,6 +2,7 @@
 
 namespace WordPress\Blueprints\Runner\Blueprint;
 
+use Composer\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use WordPress\Blueprints\Compile\CompiledBlueprint;
 use WordPress\Blueprints\Compile\CompiledStep;
@@ -30,7 +31,6 @@ class BlueprintRunner {
 			$compiledStep->runner->setRuntime( $this->runtime );
 			$compiledStep->runner->setResourceManager( $resourceManager );
 		}
-
 		// Run, store results
 		$results = [];
 		foreach ( $blueprint->compiledSteps as $k => $compiledStep ) {
@@ -38,8 +38,12 @@ class BlueprintRunner {
 			try {
 				$results[ $k ] = new StepSuccess(
 					$compiledStep->step,
-					$compiledStep->runner->run( $compiledStep->step, new Tracker() )
+					$compiledStep->runner->run(
+						$compiledStep->step,
+						$compiledStep->progressTracker
+					)
 				);
+				$compiledStep->progressTracker->finish();
 			} catch ( \Exception $e ) {
 				$results[ $k ] = $e;
 				if ( $compiledStep->step->continueOnError !== true ) {

--- a/src/WordPress/Blueprints/Runner/Step/ActivatePluginStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/ActivatePluginStepRunner.php
@@ -30,4 +30,8 @@ class ActivatePluginStepRunner extends BaseStepRunner {
 //			]
 //		);
 	}
+
+	public function getDefaultCaption( $input ): null|string {
+		return "Activating plugin";
+	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/ActivateThemeStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/ActivateThemeStepRunner.php
@@ -18,7 +18,7 @@ class ActivateThemeStepRunner extends BaseStepRunner {
 	/**
 	 * @param ActivateThemeStep $input
 	 */
-	protected function getDefaultCaption( $input ): string|null {
+	public function getDefaultCaption( $input ): string|null {
 		return "Activating theme " . $input->slug;
 	}
 

--- a/src/WordPress/Blueprints/Runner/Step/BaseStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/BaseStepRunner.php
@@ -27,7 +27,7 @@ abstract class BaseStepRunner implements StepRunnerInterface {
 		return $this->runtime;
 	}
 
-	protected function getDefaultCaption( $input ): string|null {
+	public function getDefaultCaption( $input ): string|null {
 		return null;
 	}
 

--- a/src/WordPress/Blueprints/Runner/Step/DefineSiteUrlStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/DefineSiteUrlStepRunner.php
@@ -20,4 +20,8 @@ class DefineSiteUrlStepRunner extends BaseStepRunner {
 			->setConsts( [ 'WP_HOME' => $input->siteUrl, 'WP_SITEURL' => $input->siteUrl ] )
 		);
 	}
+
+	public function getDefaultCaption( $input ): null|string {
+		return "Defining site URL";
+	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/DefineWpConfigConstsStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/DefineWpConfigConstsStepRunner.php
@@ -23,4 +23,8 @@ PHP,
 			]
 		);
 	}
+
+	public function getDefaultCaption( $input ): null|string {
+		return "Defining wp-config constants";
+	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/DownloadWordPressStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/DownloadWordPressStepRunner.php
@@ -9,10 +9,8 @@ class DownloadWordPressStepRunner extends InstallAssetStepRunner {
 
 	public function run(
 		DownloadWordPressStep $input,
-		Tracker $progress = null
+		Tracker $progress
 	) {
-		$progress?->set( 10, 'Extracting WordPress...' );
-
 		$this->unzipAssetTo( $input->wordPressZip, $this->getRuntime()->getDocumentRoot() );
 
 		$cofigSample = $this->getRuntime()->resolvePath( 'wp-config-sample.php' );
@@ -20,6 +18,10 @@ class DownloadWordPressStepRunner extends InstallAssetStepRunner {
 		if ( file_exists( $cofigSample ) && ! file_exists( $cofig ) ) {
 			copy( $cofigSample, $cofig );
 		}
+	}
+
+	public function getDefaultCaption( $input ): null|string {
+		return "Extracting WordPress";
 	}
 
 }

--- a/src/WordPress/Blueprints/Runner/Step/InstallPluginStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/InstallPluginStepRunner.php
@@ -9,8 +9,6 @@ use WordPress\Blueprints\Progress\Tracker;
 class InstallPluginStepRunner extends InstallAssetStepRunner {
 
 	function run( InstallPluginStep $input, Tracker $tracker ) {
-		$tracker->setCaption( $input->progress->caption ?? "Installing plugin" );
-
 		// @TODO: inject this information into this step
 		$pluginDir = 'plugin' . rand( 0, 1000 );
 		$targetPath = $this->getRuntime()->resolvePath( 'wp-content/plugins/' . $pluginDir );
@@ -26,5 +24,9 @@ class InstallPluginStepRunner extends InstallAssetStepRunner {
 				]
 			);
 		}
+	}
+
+	public function getDefaultCaption( $input ): null|string {
+		return "Installing plugin " . $input->pluginZipFile;
 	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/InstallSqliteIntegrationStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/InstallSqliteIntegrationStepRunner.php
@@ -32,4 +32,9 @@ class InstallSqliteIntegrationStepRunner extends InstallAssetStepRunner {
 		file_put_contents( $this->getRuntime()->resolvePath( 'wp-content/mu-plugins/0-sqlite.php' ),
 			'<?php require_once __DIR__ . "/sqlite-database-integration/load.php"; ' );
 	}
+
+	public function getDefaultCaption( $input ): null|string {
+		return "Installing SQLite integration plugin";
+	}
+
 }

--- a/src/WordPress/Blueprints/Runner/Step/InstallThemeStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/InstallThemeStepRunner.php
@@ -14,8 +14,6 @@ class InstallThemeStepRunner extends InstallAssetStepRunner {
 	 * @param InstallThemeStep $input
 	 */
 	function run( InstallThemeStep $input, Tracker $tracker ) {
-		$tracker?->setCaption( $input->progress->caption ?? "Installing theme" );
-
 		// @TODO: inject this information into this step
 		$themeDir = 'theme' . rand( 0, 1000 );
 		$targetPath = $this->getRuntime()->resolvePath( 'wp-content/themes/' . $themeDir );
@@ -32,4 +30,9 @@ class InstallThemeStepRunner extends InstallAssetStepRunner {
 			);
 		}
 	}
+
+	public function getDefaultCaption( $input ): null|string {
+		return "Installing theme " . $input->themeZipFile;
+	}
+
 }

--- a/src/WordPress/Blueprints/Runner/Step/RunSQLStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/RunSQLStepRunner.php
@@ -17,8 +17,6 @@ class RunSQLStepRunner extends BaseStepRunner {
 		RunSQLStep $input,
 		Tracker $progress = null
 	) {
-		$progress?->setCaption( $input->progress->caption ?? "Running SQL queries" );
-
 		return $this->getRuntime()->evalPhpInSubProcess( <<<'CODE'
 <?php
 		require_once getenv("DOCROOT") . '/wp-load.php';
@@ -42,5 +40,9 @@ CODE,
 			null,
 			$this->getResource( $input->sql )
 		);
+	}
+
+	public function getDefaultCaption( $input ): null|string {
+		return "Running SQL queries";
 	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/RunWordPressInstallerStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/RunWordPressInstallerStepRunner.php
@@ -7,8 +7,6 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class RunWordPressInstallerStepRunner extends BaseStepRunner {
 	function run( RunWordPressInstallerStep $input, Tracker $tracker ) {
-		$tracker?->setCaption( "Setting site options" );
-
 		return $this->getRuntime()->runShellCommand(
 			[
 				'php',
@@ -24,4 +22,9 @@ class RunWordPressInstallerStepRunner extends BaseStepRunner {
 			$this->getRuntime()->getDocumentRoot()
 		);
 	}
+
+	public function getDefaultCaption( $input ): null|string {
+		return "Installing WordPress";
+	}
+	
 }

--- a/src/WordPress/Blueprints/Runner/Step/SetSiteOptionsStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/SetSiteOptionsStepRunner.php
@@ -11,8 +11,6 @@ class SetSiteOptionsStepRunner extends BaseStepRunner {
 	 * @param SetSiteOptionsStep $input
 	 */
 	function run( SetSiteOptionsStep $input, Tracker $tracker ) {
-		$tracker?->setCaption( "Setting site options" );
-
 		// Running a custom PHP script is much faster than setting each option
 		// with a separate wp-cli command.
 		return $this->getRuntime()->evalPhpInSubProcess( <<<'CODE'
@@ -28,4 +26,9 @@ CODE,
 			]
 		);
 	}
+
+	public function getDefaultCaption( $input ): null|string {
+		return "Setting site options";
+	}
+
 }

--- a/src/WordPress/Blueprints/Runner/Step/WriteFileStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/WriteFileStepRunner.php
@@ -25,4 +25,8 @@ class WriteFileStepRunner extends BaseStepRunner {
 		fclose( $fp2 );
 	}
 
+	public function getDefaultCaption( $input ): null|string {
+		return "Writing file " . $input->path;
+	}
+
 }

--- a/src/WordPress/Blueprints/functions.php
+++ b/src/WordPress/Blueprints/functions.php
@@ -2,22 +2,33 @@
 
 namespace WordPress\Blueprints;
 
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
-use WordPress\Blueprints\Progress\DoneEvent;
-use WordPress\Blueprints\Progress\ProgressEvent;
 use WordPress\Blueprints\Runtime\Runtime;
 
-function run_blueprint( $json, $environment, $documentRoot = '/wordpress', $progressSubscriber = null ) {
+function run_blueprint( $json, $options = [] ) {
+	$environment = $options['environment'] ?? ContainerBuilder::ENVIRONMENT_NATIVE;
+	$documentRoot = $options['documentRoot'] ?? '/wordpress';
+	$progressSubscriber = $options['progressSubscriber'] ?? null;
+	$progressType = $options['progressType'] ?? 'all';
+
 	$c = ( new ContainerBuilder() )->build(
 		$environment,
 		new Runtime( $documentRoot )
 	);
 
 	$engine = $c['blueprint.engine'];
-
+	$compiledBlueprint = $engine->parseAndCompile( $json );
+	
 	/** @var $engine Engine */
-	return $engine->runBlueprint( $json, $progressSubscriber );
+	if ( $progressSubscriber ) {
+		if ( $progressType === 'steps' ) {
+			$compiledBlueprint->stepsProgressStage->events->addSubscriber( $progressSubscriber );
+		} else {
+			$compiledBlueprint->progressTracker->events->addSubscriber( $progressSubscriber );
+		}
+	}
+
+	return $engine->run( $compiledBlueprint );
 }
 
 function list_files( string $path, $omitDotFiles = false ): array {

--- a/src/WordPress/Blueprints/functions.php
+++ b/src/WordPress/Blueprints/functions.php
@@ -2,16 +2,22 @@
 
 namespace WordPress\Blueprints;
 
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
+use WordPress\Blueprints\Progress\DoneEvent;
+use WordPress\Blueprints\Progress\ProgressEvent;
 use WordPress\Blueprints\Runtime\Runtime;
 
-function run_blueprint( $json, $environment, $documentRoot = '/wordpress' ) {
+function run_blueprint( $json, $environment, $documentRoot = '/wordpress', $progressSubscriber = null ) {
 	$c = ( new ContainerBuilder() )->build(
 		$environment,
 		new Runtime( $documentRoot )
 	);
 
-	return $c['blueprint.engine']->runBlueprint( $json );
+	$engine = $c['blueprint.engine'];
+
+	/** @var $engine Engine */
+	return $engine->runBlueprint( $json, $progressSubscriber );
 }
 
 function list_files( string $path, $omitDotFiles = false ): array {

--- a/src/WordPress/DataSource/DataSourceProgressEvent.php
+++ b/src/WordPress/DataSource/DataSourceProgressEvent.php
@@ -4,7 +4,7 @@ namespace WordPress\DataSource;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-class ProgressEvent extends Event {
+class DataSourceProgressEvent extends Event {
 	public function __construct(
 		public string $url,
 		public int $downloadedBytes,

--- a/src/WordPress/DataSource/UrlSource.php
+++ b/src/WordPress/DataSource/UrlSource.php
@@ -39,7 +39,7 @@ class UrlSource extends BaseDataSource {
 			// @TODO: Stream directly from the cache
 			$cached = $this->cache->get( $url );
 			$data_size = strlen( $cached );
-			$this->events->dispatch( new ProgressEvent(
+			$this->events->dispatch( new DataSourceProgressEvent(
 				$url,
 				$data_size,
 				$data_size
@@ -53,7 +53,7 @@ class UrlSource extends BaseDataSource {
 
 		$response = $this->client->request( 'GET', $url, [
 			'on_progress' => function ( int $dlNow, int $dlSize, array $info ) use ( $url ): void {
-				$this->events->dispatch( new ProgressEvent(
+				$this->events->dispatch( new DataSourceProgressEvent(
 					$url,
 					$dlNow,
 					$dlSize
@@ -111,7 +111,7 @@ class UrlSource extends BaseDataSource {
 		$response = new AsyncResponse( $this->client, 'GET', $url, [
 			'timeout'     => 60000,
 			'on_progress' => function ( int $dlNow, int $dlSize, array $info ) use ( $url ): void {
-				$this->events->dispatch( new ProgressEvent(
+				$this->events->dispatch( new DataSourceProgressEvent(
 					$url,
 					$dlNow,
 					$dlSize


### PR DESCRIPTION
## Description

Exposes details about the progress of the Blueprint execution:

https://github.com/WordPress/blueprints/assets/205419/064ac339-7cca-4dd2-b413-b4a421336b01

<img src="https://github.com/WordPress/blueprints/assets/205419/c76dd8d2-8844-44ef-bf9b-b89cb3c16458" width="300">

## Implementation

The `Engine` class no longer exposes a single `run()` method. Instead, the flow is split into two stages: 1. Parsing&compiling, 2. Running:

```php
$compiledBlueprint = $engine->parseAndCompile( $json );
// Now we can register any progress listeners and subscribers
$compiledBlueprint->progressTracker->events->addSubscriber( $progressSubscriber );
$result = $engine->run( $compiledBlueprint );
```

The `CompiledBlueprint` object exposes two progress trackers:

1. `progressTracker` with the joint progress information about steps and resources
2. `stepsProgressStage` with information only about the Blueprint steps – Playground will use that one as it will start pre-fetching any URL-based resources before PHP is even loaded.

The `progressTracker->event->addSubscriber` method accepts an `EventSubscriberInterface $progressSubscriber` argument that can subscribe to "progress" and "done" events. This enables implementing custom progress reporters, like the one showcased in the video above:

```php
class CLIProgressBarProgressReporter {
	public static function getSubscribedEvents() {
		return [
			ProgressEvent::class => 'onProgress',
			DoneEvent::class     => 'onDone',
		];
	}

	// ...initialize $this->progress_bar in the constructor...

	public function onProgress( ProgressEvent $event ) {
		$this->progress_bar->setMessage( $event->caption );
		$this->progress_bar->setProgress( (int) $event->progress );
	}

	public function onDone( DoneEvent $event ) {
		$this->progress_bar->finish();
	}
}
```

## Related resources

* Related Playground PR: https://github.com/WordPress/wordpress-playground/pull/1077

## Follow-up work

* Define the home for generic progress reporters. My current thinking is that the Blueprint package will **not** actually ship any environment-specific progress reporters, as they would get bundled with `blueprints.phar` and bring CLI-specific libraries into the library that's supposed to be lightweight and environment-agnostic. Instead, exploring environment-specific packages like `Blueprints/CLI` or `Blueprints/Playground` might make more sense. Or perhaps Playground OR each runtime should even ship its own PHP bindings in its own repo? That's TBD.

## Testing instructions

Run `rm -rf new-wp/*; php blueprint_compiling.php` and confirm the entire Blueprint gets executed.