### PR TITLE
Update README to run tests with PHPUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ composer install
 Run tests with
 
 ```shell
-vendor/bin/pest
+vendor/bin/phpunit --testdox
 ```
 
 Regenerate models from JSON schema with


### PR DESCRIPTION
### What does this PR do?
Updates the shell command to run tests with PHPUnit.

--testdox flag makes test names display in a more readable format

![image](https://github.com/WordPress/blueprints/assets/30837295/b6d07f49-0746-490d-8668-7b8df5db5084)

