### PR TITLE
Fix types and PHP version-related issues

### DIFF
--- a/blueprint_compiling.php
+++ b/blueprint_compiling.php
@@ -35,7 +35,7 @@ $blueprint = BlueprintBuilder::create()
 		'https://downloads.wordpress.org/plugin/gutenberg.17.7.0.zip',
 	] )
 	->withTheme( 'https://downloads.wordpress.org/theme/pendant.zip' )
-	->withContent( 'https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml' )
+//	->withContent( 'https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml' )
 	->withSiteUrl( 'http://localhost:8081' )
 	->andRunSQL( <<<'SQL'
 		CREATE TABLE `tmp_table` ( id INT );

--- a/blueprint_compiling.php
+++ b/blueprint_compiling.php
@@ -35,7 +35,7 @@ $blueprint = BlueprintBuilder::create()
 		'https://downloads.wordpress.org/plugin/gutenberg.17.7.0.zip',
 	] )
 	->withTheme( 'https://downloads.wordpress.org/theme/pendant.zip' )
-//	->withContent( 'https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml' )
+	->withContent( 'https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml' )
 	->withSiteUrl( 'http://localhost:8081' )
 	->andRunSQL( <<<'SQL'
 		CREATE TABLE `tmp_table` ( id INT );

--- a/src/WordPress/Blueprints/Resources/Resolver/FilesystemResourceResolver.php
+++ b/src/WordPress/Blueprints/Resources/Resolver/FilesystemResourceResolver.php
@@ -8,9 +8,9 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class FilesystemResourceResolver implements ResourceResolverInterface {
 
-	public function parseUrl( string $url ): ResourceDefinitionInterface|false {
+	public function parseUrl( string $url ): ?ResourceDefinitionInterface {
 		if ( ! str_starts_with( $url, 'file://' ) ) {
-			return false;
+			return null;
 		}
 
 		return ( new FilesystemResource() )->setPath( $url );
@@ -24,12 +24,12 @@ class FilesystemResourceResolver implements ResourceResolverInterface {
 		return $resource instanceof FilesystemResource;
 	}
 
-	public function stream( ResourceDefinitionInterface $resource, Tracker $progressTracker ) {
+	public function stream( ResourceDefinitionInterface $resource, Tracker $progress_tracker ) {
 		if ( ! $this->supports( $resource ) ) {
 			throw new \InvalidArgumentException( 'Resource ' . get_class( $resource ) . ' unsupported' );
 		}
 
-		$progressTracker->finish();
+		$progress_tracker->finish();
 
 		/** @var $resource FilesystemResource */
 		return fopen( $resource->path, 'r' );

--- a/src/WordPress/Blueprints/Resources/Resolver/InlineResourceResolver.php
+++ b/src/WordPress/Blueprints/Resources/Resolver/InlineResourceResolver.php
@@ -9,10 +9,10 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class InlineResourceResolver implements ResourceResolverInterface {
 
-	public function parseUrl( string $url ): ResourceDefinitionInterface|false {
+	public function parseUrl( string $url ): ?ResourceDefinitionInterface {
 		// If url starts with "protocol://" then we assume it's not inline raw data
 		if ( 0 !== preg_match( '#^[a-z_+]+://#', $url ) ) {
-			return false;
+			return null;
 		}
 
 		return ( new InlineResource() )->setContents( $url );
@@ -26,11 +26,11 @@ class InlineResourceResolver implements ResourceResolverInterface {
 		return $resource instanceof InlineResource;
 	}
 
-	public function stream( ResourceDefinitionInterface $resource, Tracker $progressTracker ) {
+	public function stream( ResourceDefinitionInterface $resource, Tracker $progress_tracker ) {
 		if ( ! $this->supports( $resource ) ) {
 			throw new \InvalidArgumentException( 'Resource ' . get_class( $resource ) . ' unsupported' );
 		}
-		$progressTracker->finish();
+		$progress_tracker->finish();
 
 		/** @var $resource InlineResource */
 		$fp = fopen( "php://temp", 'r+' );

--- a/src/WordPress/Blueprints/Resources/Resolver/ResourceResolverInterface.php
+++ b/src/WordPress/Blueprints/Resources/Resolver/ResourceResolverInterface.php
@@ -6,11 +6,11 @@ use WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface;
 use WordPress\Blueprints\Progress\Tracker;
 
 interface ResourceResolverInterface {
-	public function parseUrl( string $url ): ResourceDefinitionInterface|false;
+	public function parseUrl( string $url ): ?ResourceDefinitionInterface;
 
 	public function supports( ResourceDefinitionInterface $resource ): bool;
 
 	static public function getResourceClass(): string;
 
-	public function stream( ResourceDefinitionInterface $resource, Tracker $progressTracker );
+	public function stream( ResourceDefinitionInterface $resource, Tracker $progress_tracker );
 }

--- a/src/WordPress/Blueprints/Resources/ResourceManager.php
+++ b/src/WordPress/Blueprints/Resources/ResourceManager.php
@@ -4,17 +4,18 @@ namespace WordPress\Blueprints\Resources;
 
 use Symfony\Component\Filesystem\Filesystem;
 use WordPress\Blueprints\Compile\CompiledResource;
-use WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface;
-use WordPress\Blueprints\Resource\Resolver\ResourceResolverInterface;
+use WordPress\Blueprints\Resources\Resolver\ResourceResolverCollection;
 
 class ResourceManager {
 
 	protected Filesystem $fs;
 	protected ResourceMap $map;
+	protected ResourceResolverCollection $resource_resolvers;
 
 	public function __construct(
-		protected ResourceResolverInterface $resourceResolver
+		ResourceResolverCollection $resource_resolvers
 	) {
+		$this->resource_resolvers = $resource_resolvers;
 		$this->fs = new Filesystem();
 		$this->map = new ResourceMap();
 	}
@@ -22,7 +23,8 @@ class ResourceManager {
 	public function enqueue( array $compiledResources ) {
 		foreach ( $compiledResources as $compiled ) {
 			/** @var CompiledResource $compiled */
-			$this->map[ $compiled->declaration ] = $this->resourceResolver->stream(
+
+			$this->map[ $compiled->declaration ] = $this->resource_resolvers->stream(
 				$compiled->resource,
 				$compiled->progressTracker
 			);

--- a/src/WordPress/Blueprints/Runner/Blueprint/BlueprintRunner.php
+++ b/src/WordPress/Blueprints/Runner/Blueprint/BlueprintRunner.php
@@ -7,17 +7,20 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use WordPress\Blueprints\Compile\CompiledBlueprint;
 use WordPress\Blueprints\Compile\CompiledStep;
 use WordPress\Blueprints\Compile\StepSuccess;
-use WordPress\Blueprints\Progress\Tracker;
 use WordPress\Blueprints\Runtime\RuntimeInterface;
 
 class BlueprintRunner {
 
-	public readonly EventDispatcher $events;
+	public EventDispatcher $events;
+	protected RuntimeInterface $runtime;
+	protected $resourceManagerFactory;
 
 	public function __construct(
-		protected RuntimeInterface $runtime,
-		protected $resourceManagerFactory,
+		RuntimeInterface $runtime,
+		$resourceManagerFactory
 	) {
+		$this->resourceManagerFactory = $resourceManagerFactory;
+		$this->runtime = $runtime;
 		$this->events = new EventDispatcher();
 	}
 

--- a/src/WordPress/Blueprints/Runner/Step/BaseStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/BaseStepRunner.php
@@ -31,7 +31,7 @@ abstract class BaseStepRunner implements StepRunnerInterface
         return $this->runtime;
     }
 
-    protected function getDefaultCaption($input): ?string
+	public function getDefaultCaption($input): ?string
     {
         return null;
     }


### PR DESCRIPTION
### What does this PR do?

- Fixes an error where the Resource Resolver... Resolving process was erroneously typed and caused PHP to confuse itself. 
- Fixes types to match PHP 7.0 coding standards.
- Fixed some other small issues in affected classes that would cause coding standards to signal warnings.
- Fixed a member access issue caused by the Compiler.