### PR TITLE
Add new Blueprint examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ composer install
 vendor/bin/phpunit --testdox
 ```
 
-### Run Blueprint in a variety of forms
+### Run Blueprints in a variety of ways
 
-#### from PHP:
+#### using the PHP Blueprint builder:
 
 ```shell
  php examples/blueprint_compiling.php
 ```
 
-#### from JSON as string:
+#### using a string containg a Blueprint (in JSON):
 
 ```shell
  php examples/json_string_compiling.php

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ composer install
 vendor/bin/phpunit --testdox
 ```
 
-### Run Blueprint in a variety forms
+### Run Blueprint in a variety of forms
 
 #### from PHP:
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,18 @@ composer install
 vendor/bin/phpunit --testdox
 ```
 
-### Run a Blueprint with
+### Run Blueprint in a variety forms
+
+#### from PHP:
 
 ```shell
-php blueprint_compiling.php
+ php examples/blueprint_compiling.php
+```
+
+#### from JSON as string:
+
+```shell
+ php examples/json_string_compiling.php
 ```
 
 ### Regenerate models files from JSON schema with

--- a/examples/blueprint_compiling.php
+++ b/examples/blueprint_compiling.php
@@ -38,10 +38,10 @@ $blueprint = BlueprintBuilder::create()
 //	->withContent( 'https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml' )
 	->withSiteUrl( 'http://localhost:8081' )
 	->andRunSQL( <<<'SQL'
-		CREATE TABLE `tmp_table` ( id INT );
-		INSERT INTO `tmp_table` VALUES (1);
-		INSERT INTO `tmp_table` VALUES (2);
-		SQL
+CREATE TABLE `tmp_table` ( id INT );
+INSERT INTO `tmp_table` VALUES (1);
+INSERT INTO `tmp_table` VALUES (2);
+SQL
 	)
 	->withFile( 'wordpress.txt', 'Data' )
 	->toBlueprint();
@@ -54,7 +54,7 @@ $subscriber = new class implements EventSubscriberInterface {
 		];
 	}
 
-	protected ProgressBar $progress_bar;
+	protected $progress_bar;
 
 	public function __construct() {
 		ProgressBar::setFormatDefinition( 'custom', ' [%bar%] %current%/%max% -- %message%' );
@@ -84,5 +84,3 @@ $results = run_blueprint(
 		'progressSubscriber' => $subscriber,
 	]
 );
-
-//var_dump( $results );

--- a/examples/json_string_compiling.php
+++ b/examples/json_string_compiling.php
@@ -1,0 +1,60 @@
+<?php
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use WordPress\Blueprints\ContainerBuilder;
+use WordPress\Blueprints\Progress\DoneEvent;
+use WordPress\Blueprints\Progress\ProgressEvent;
+use function WordPress\Blueprints\run_blueprint;
+
+if ( getenv( 'USE_PHAR' ) ) {
+	require __DIR__ . '/dist/blueprints.phar';
+} else {
+	require 'vendor/autoload.php';
+}
+
+$blueprint = '{"WordPressVersion":"https://wordpress.org/latest.zip","steps":[{"step":"mkdir","path":"dir"},{"step": "rm","path": "dir"}]}';
+
+$subscriber = new class() implements EventSubscriberInterface {
+	public static function getSubscribedEvents() {
+		return array(
+			ProgressEvent::class => 'onProgress',
+			DoneEvent::class     => 'onDone',
+		);
+	}
+
+	protected $progress_bar;
+
+	public function __construct() {
+		ProgressBar::setFormatDefinition( 'custom', ' [%bar%] %current%/%max% -- %message%' );
+
+		$this->progress_bar = ( new SymfonyStyle(
+			new StringInput( '' ),
+			new ConsoleOutput()
+		) )->createProgressBar( 100 );
+		$this->progress_bar->setFormat( 'custom' );
+		$this->progress_bar->setMessage( 'Start' );
+		$this->progress_bar->start();
+	}
+
+	public function onProgress( ProgressEvent $event ) {
+		$this->progress_bar->setMessage( $event->caption );
+		$this->progress_bar->setProgress( (int) $event->progress );
+	}
+
+	public function onDone( DoneEvent $event ) {
+		$this->progress_bar->finish();
+	}
+};
+
+$results = run_blueprint(
+	$blueprint,
+	array(
+		'environment'        => ContainerBuilder::ENVIRONMENT_NATIVE,
+		'documentRoot'       => __DIR__ . '/new-wp',
+		'progressSubscriber' => $subscriber,
+	)
+);


### PR DESCRIPTION
- Adds a script - json_string_compiling.php running the Blueprint from a string containing a JSON.
- Creates the 'examples' directory to group all nonessential scrips added to showcase the lib's capabilities.
- Moves the blueprint_compiling.php script to the 'examples' directory.
- Fixes scrips to run with PHP >= 7.0.