### PR TITLE
Transpile to PHP 7.0 with Rector and manual replacements

### DIFF
--- a/src/WordPress/AsyncHttp/Client.php
+++ b/src/WordPress/AsyncHttp/Client.php
@@ -89,7 +89,7 @@ use function WordPress\Streams\streams_send_http_requests;
  */
 class Client {
 	protected $concurrency = 10;
-	protected Map $requests;
+	protected $requests;
 	protected $onProgress;
 	protected $queue_needs_processing = false;
 
@@ -150,7 +150,7 @@ class Client {
 	 *
 	 * @return resource
 	 */
-	public function get_stream( Request $request ) {
+	public function get_stream( $request ) {
 		if ( ! isset( $this->requests[ $request ] ) ) {
 			$this->enqueue_request( $request );
 		}
@@ -162,7 +162,10 @@ class Client {
 		return $this->requests[ $request ]->stream;
 	}
 
-	protected function enqueue_request( Request $request ) {
+	/**
+  * @param \WordPress\AsyncHttp\Request $request
+  */
+ protected function enqueue_request( $request ) {
 		$stream = StreamWrapper::create_resource(
 			new StreamData( $request, $this )
 		);
@@ -232,7 +235,7 @@ class Client {
 	 * @return false|string
 	 * @throws Exception
 	 */
-	public function read_bytes( Request $request, $length ) {
+	public function read_bytes( $request, $length ) {
 		if ( ! isset( $this->requests[ $request ] ) ) {
 			return false;
 		}

--- a/src/WordPress/AsyncHttp/Request.php
+++ b/src/WordPress/AsyncHttp/Request.php
@@ -4,7 +4,7 @@ namespace WordPress\AsyncHttp;
 
 class Request {
 
-	public string $url;
+	public $url;
 
 	/**
 	 * @param string $url

--- a/src/WordPress/AsyncHttp/StreamData.php
+++ b/src/WordPress/AsyncHttp/StreamData.php
@@ -6,8 +6,8 @@ use WordPress\Streams\VanillaStreamWrapperData;
 
 class StreamData extends VanillaStreamWrapperData {
 
-	public Request $request;
-	public Client $client;
+	public $request;
+	public $client;
 
 	public function __construct( Request $request, Client $group ) {
 		parent::__construct( null );

--- a/src/WordPress/AsyncHttp/StreamWrapper.php
+++ b/src/WordPress/AsyncHttp/StreamWrapper.php
@@ -30,7 +30,10 @@ class StreamWrapper extends VanillaStreamWrapper {
 		return true;
 	}
 
-	public function stream_cast( int $cast_as ) {
+	/**
+  * @param int $cast_as
+  */
+ public function stream_cast( $cast_as ) {
 		$this->initialize();
 
 		return parent::stream_cast( $cast_as );

--- a/src/WordPress/AsyncHttp/async_http_streams.php
+++ b/src/WordPress/AsyncHttp/async_http_streams.php
@@ -96,10 +96,13 @@ function streams_http_requests_send( $streams ) {
 	$remaining_streams = $streams;
 	while ( count( $remaining_streams ) ) {
 		$write = $remaining_streams;
-		$ready = @stream_select( $read, $write, $except, 0, 5000000 );
+		sleep( 2 );
+		$ready = @stream_select( $read, $write, $except, 5, 5000000 );
 		if ( $ready === false ) {
 			throw new Exception( "Error: " . error_get_last()['message'] );
 		} elseif ( $ready <= 0 ) {
+			var_dump( $ready );
+			die();
 			throw new Exception( "stream_select timed out" );
 		}
 
@@ -172,7 +175,7 @@ function parse_http_headers( string $headers ) {
 	];
 	$headers = [];
 	foreach ( $lines as $line ) {
-		if ( ! str_contains( $line, ': ' ) ) {
+		if ( strpos($line, ': ') === false ) {
 			continue;
 		}
 		$line = explode( ': ', $line );
@@ -231,7 +234,7 @@ function streams_http_response_await_headers( $streams ) {
 		}
 		foreach ( $bytes as $k => $byte ) {
 			$headers[ $k ] .= $byte;
-			if ( str_ends_with( $headers[ $k ], "\r\n\r\n" ) ) {
+			if ( substr_compare($headers[ $k ], "\r\n\r\n", -strlen("\r\n\r\n")) === 0 ) {
 				unset( $remaining_streams[ $k ] );
 			}
 		}

--- a/src/WordPress/Blueprints/BlueprintMapper.php
+++ b/src/WordPress/Blueprints/BlueprintMapper.php
@@ -34,7 +34,7 @@ class BlueprintMapper {
 	 *
 	 * @return Blueprint
 	 */
-	public function map( stdClass $blueprint ): Blueprint {
+	public function map( $blueprint ): Blueprint {
 		return $this->mapper->hydrate( $blueprint, Blueprint::class );
 	}
 

--- a/src/WordPress/Blueprints/BlueprintParser.php
+++ b/src/WordPress/Blueprints/BlueprintParser.php
@@ -55,7 +55,10 @@ class BlueprintParser {
 		);
 	}
 
-	public function fromObject( \stdClass $data ) {
+	/**
+  * @param \stdClass $data
+  */
+ public function fromObject( $data ) {
 		$result = $this->validator->validate( $data );
 		if ( ! $result->isValid() ) {
 			print_r( ( new ErrorFormatter() )->format( $result->error() ) );
@@ -64,7 +67,10 @@ class BlueprintParser {
 		return $this->mapper->map( $data );
 	}
 
-	public function fromBlueprint( Blueprint $blueprint ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Blueprint $blueprint
+  */
+ public function fromBlueprint( $blueprint ) {
 		$result = $this->validator->validate( $blueprint );
 		if ( ! $result->isValid() ) {
 			print_r( ( new ErrorFormatter() )->format( $result->error() ) );

--- a/src/WordPress/Blueprints/Cache/FileCache.php
+++ b/src/WordPress/Blueprints/Cache/FileCache.php
@@ -9,7 +9,10 @@ use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 class FileCache implements CacheInterface {
 	private $filesystem;
 
-	public function __construct( private string|null $cacheDirectory = null ) {
+	private $cacheDirectory;
+
+	public function __construct( $cacheDirectory = null ) {
+		$this->cacheDirectory = $cacheDirectory;
 		// initialize the Filesystem component
 		$this->filesystem = new Filesystem();
 
@@ -34,7 +37,10 @@ class FileCache implements CacheInterface {
 		}
 	}
 
-	public function get( $key, $default = null ): mixed {
+	/**
+  * @return mixed
+  */
+ public function get( $key, $default = null ) {
 		$filepath = $this->getFilePathForKey( $key );
 		if ( ! file_exists( $filepath ) ) {
 			return $default;
@@ -47,7 +53,7 @@ class FileCache implements CacheInterface {
 
 	public function set( $key, $value, $ttl = null ): bool {
 		$filepath = $this->getFilePathForKey( $key );
-		$data     = serialize( $value );
+		$data = serialize( $value );
 
 		return file_put_contents( $filepath, $data ) !== false;
 	}

--- a/src/WordPress/Blueprints/Compile/BlueprintCompiler.php
+++ b/src/WordPress/Blueprints/Compile/BlueprintCompiler.php
@@ -17,7 +17,7 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class BlueprintCompiler {
 	protected $stepRunnerFactory;
-	protected ResourceResolverInterface $resourceResolver;
+	protected $resourceResolver;
 
 	public function __construct(
 		$stepRunnerFactory,
@@ -27,7 +27,10 @@ class BlueprintCompiler {
 		$this->stepRunnerFactory = $stepRunnerFactory;
 	}
 
-	public function compile( Blueprint $blueprint ): CompiledBlueprint {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Blueprint $blueprint
+  */
+ public function compile( $blueprint ): CompiledBlueprint {
 		$blueprint->steps = array_merge( $this->expandShorthandsIntoSteps( $blueprint ), $blueprint->steps );
 
 		$progressTracker = new Tracker();
@@ -42,7 +45,10 @@ class BlueprintCompiler {
 		);
 	}
 
-	protected function expandShorthandsIntoSteps( Blueprint $blueprint ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Blueprint $blueprint
+  */
+ protected function expandShorthandsIntoSteps( $blueprint ) {
 		// @TODO: This duplicates the logic in BlueprintComposer.
 		//        It cannot be easily reused because of the dichotomy between the
 		//        Step and Step model classes. Let's alter the code generation
@@ -87,7 +93,11 @@ class BlueprintCompiler {
 		return $additional_steps;
 	}
 
-	protected function compileSteps( Blueprint $blueprint, Tracker $progress ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Blueprint $blueprint
+  * @param \WordPress\Blueprints\Progress\Tracker $progress
+  */
+ protected function compileSteps( $blueprint, $progress ) {
 		$stepRunnerFactory = $this->stepRunnerFactory;
 		// Compile, ensure all the runners may be created and configured
 		$totalProgressWeight = 0;
@@ -114,13 +124,17 @@ class BlueprintCompiler {
 		return $compiledSteps;
 	}
 
-	protected function compileResources( Blueprint $blueprint, Tracker $progress ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Blueprint $blueprint
+  * @param \WordPress\Blueprints\Progress\Tracker $progress
+  */
+ protected function compileResources( $blueprint, $progress ) {
 		$resources = [];
 		$this->findResources( $blueprint, $resources );
 
 		$totalProgressWeight = count( $resources );
 		$compiledResources = [];
-		foreach ( $resources as $path => [$declaration, $resource] ) {
+		foreach ( $resources as $path => list( $declaration, $resource ) ) {
 			/** @var $resource ResourceDefinitionInterface */
 			$compiledResources[ $path ] = new CompiledResource(
 				$declaration,
@@ -151,13 +165,14 @@ class BlueprintCompiler {
 			// Check if the @var annotation mentions a ResourceDefinitionInterface
 			foreach ( get_object_vars( $blueprintFragment ) as $key => $value ) {
 				$reflection = new \ReflectionProperty( $blueprintFragment, $key );
+    $reflection->setAccessible(true);
 				$docComment = $reflection->getDocComment();
 				$parseNestedUrls = false;
 				if ( preg_match( '/@var\s+([^\s]+)/', $docComment, $matches ) ) {
 					$className = $matches[1];
 					if (
-						str_contains( $className, 'string' ) &&
-						str_contains( $className, 'ResourceDefinitionInterface' )
+						false !== strpos( $className, 'string' ) &&
+						false !== strpos( $className, 'ResourceDefinitionInterface' )
 					) {
 						$parseNestedUrls = true;
 					}

--- a/src/WordPress/Blueprints/Compile/CompiledBlueprint.php
+++ b/src/WordPress/Blueprints/Compile/CompiledBlueprint.php
@@ -5,13 +5,23 @@ namespace WordPress\Blueprints\Compile;
 use WordPress\Blueprints\Progress\Tracker;
 
 class CompiledBlueprint {
+	public $compiledSteps;
+	public $compiledResources;
+	public $progressTracker;
+	public $stepsProgressStage;
 
-	public function __construct(
-		public array $compiledSteps,
-		public array $compiledResources,
-		public Tracker $progressTracker,
-		public Tracker $stepsProgressStage,
-	) {
+	/**
+	 * @param $compiledSteps
+	 * @param $compiledResources
+	 * @param $progressTracker
+	 * @param $stepsProgressStage
+	 */
+	public function __construct( $compiledSteps, $compiledResources, $progressTracker, $stepsProgressStage ) {
+		$this->compiledSteps = $compiledSteps;
+		$this->compiledResources = $compiledResources;
+		$this->progressTracker = $progressTracker;
+		$this->stepsProgressStage = $stepsProgressStage;
 	}
+
 
 }

--- a/src/WordPress/Blueprints/Compile/CompiledResource.php
+++ b/src/WordPress/Blueprints/Compile/CompiledResource.php
@@ -7,11 +7,18 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class CompiledResource {
 
+	public $declaration;
+	public $resource;
+	public $progressTracker;
+
 	public function __construct(
-		public $declaration,
-		public ResourceDefinitionInterface $resource,
-		public Tracker $progressTracker,
+		$declaration,
+		ResourceDefinitionInterface $resource,
+		Tracker $progressTracker
 	) {
+		$this->declaration = $declaration;
+		$this->resource = $resource;
+		$this->progressTracker = $progressTracker;
 	}
 
 }

--- a/src/WordPress/Blueprints/Compile/CompiledStep.php
+++ b/src/WordPress/Blueprints/Compile/CompiledStep.php
@@ -8,11 +8,18 @@ use WordPress\Blueprints\Runner\Step\StepRunnerInterface;
 
 class CompiledStep {
 
+	public $step;
+	public $runner;
+	public $progressTracker;
+
 	public function __construct(
-		public StepDefinitionInterface $step,
-		public StepRunnerInterface $runner,
-		public Tracker $progressTracker,
+		StepDefinitionInterface $step,
+		StepRunnerInterface $runner,
+		Tracker $progressTracker
 	) {
+		$this->step = $step;
+		$this->runner = $runner;
+		$this->progressTracker = $progressTracker;
 	}
 
 }

--- a/src/WordPress/Blueprints/Compile/StepFailure.php
+++ b/src/WordPress/Blueprints/Compile/StepFailure.php
@@ -7,10 +7,15 @@ use WordPress\Blueprints\Model\DataClass\StepDefinitionInterface;
 
 class StepFailure extends BlueprintException implements StepResultInterface {
 
-	public function __construct(
-		public StepDefinitionInterface $step,
+	/**
+  * @var \WordPress\Blueprints\Model\DataClass\StepDefinitionInterface
+  */
+ public $step;
+ public function __construct(
+		StepDefinitionInterface $step,
 		\Exception $cause
 	) {
-		parent::__construct( "Error when executing step $step->step", 0, $cause );
+		$this->step = $step;
+  parent::__construct( "Error when executing step $step->step", 0, $cause );
 	}
 }

--- a/src/WordPress/Blueprints/Compile/StepSuccess.php
+++ b/src/WordPress/Blueprints/Compile/StepSuccess.php
@@ -5,6 +5,11 @@ namespace WordPress\Blueprints\Compile;
 use WordPress\Blueprints\Model\DataClass\StepDefinitionInterface;
 
 class StepSuccess implements StepResultInterface {
-	public function __construct( public StepDefinitionInterface $step, public $result ) {
+	public $step;
+	public $result;
+
+	public function __construct( StepDefinitionInterface $step, $result ) {
+		$this->step = $step;
+		$this->result = $result;
 	}
 }

--- a/src/WordPress/Blueprints/ContainerBuilder.php
+++ b/src/WordPress/Blueprints/ContainerBuilder.php
@@ -80,7 +80,11 @@ class ContainerBuilder {
 	}
 
 
-	public function build( string $environment, RuntimeInterface $runtime ) {
+	/**
+  * @param string $environment
+  * @param \WordPress\Blueprints\Runtime\RuntimeInterface $runtime
+  */
+ public function build( $environment, $runtime ) {
 		$container = $this->container;
 		$container['runtime'] = function () use ( $runtime ) {
 			return $runtime;
@@ -230,7 +234,7 @@ class ContainerBuilder {
 		$container['resource.supported_resolvers'] = function ( $c ) {
 			$ResourceResolvers = array();
 			foreach ( $c->keys() as $key ) {
-				if ( str_starts_with( $key, 'resource.resolver.' ) ) {
+				if ( 0 === strpos( $key, 'resource.resolver.' ) ) {
 					$ResourceResolvers[] = $c[ $key ];
 				}
 			}

--- a/src/WordPress/Blueprints/Engine.php
+++ b/src/WordPress/Blueprints/Engine.php
@@ -39,7 +39,10 @@ class Engine {
 		return $this->compiler->compile( $blueprint );
 	}
 
-	public function run( CompiledBlueprint $compiled_blueprint ) {
+	/**
+  * @param \WordPress\Blueprints\Compile\CompiledBlueprint $compiled_blueprint
+  */
+ public function run( $compiled_blueprint ) {
 		return $this->runner->run( $compiled_blueprint );
 	}
 }

--- a/src/WordPress/Blueprints/Model/BlueprintBuilder.php
+++ b/src/WordPress/Blueprints/Model/BlueprintBuilder.php
@@ -47,13 +47,19 @@ class BlueprintBuilder {
 		return $this;
 	}
 
-	public function withSiteOptions( array $options ) {
+	/**
+  * @param mixed[] $options
+  */
+ public function withSiteOptions( $options ) {
 		$this->blueprint->setSiteOptions( $options );
 
 		return $this;
 	}
 
-	public function withWpConfigConstants( array $constants ) {
+	/**
+  * @param mixed[] $constants
+  */
+ public function withWpConfigConstants( $constants ) {
 		$this->blueprint->setConstants( $constants );
 
 		return $this;
@@ -177,7 +183,10 @@ class BlueprintBuilder {
 		return $this;
 	}
 
-	public function addStep( StepDefinitionInterface $builder ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\StepDefinitionInterface $builder
+  */
+ public function addStep( $builder ) {
 		array_push( $this->blueprint->steps, $builder );
 
 		return $this;

--- a/src/WordPress/Blueprints/Model/BlueprintSerializer.php
+++ b/src/WordPress/Blueprints/Model/BlueprintSerializer.php
@@ -7,7 +7,10 @@ use WordPress\Blueprints\Model\DataClass\Blueprint;
 
 class BlueprintSerializer {
 
-	public function toJson( Blueprint $blueprint ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Blueprint $blueprint
+  */
+ public function toJson( $blueprint ) {
 		return json_encode( $blueprint );
 	}
 

--- a/src/WordPress/Blueprints/Model/DataClass/ActivatePluginStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/ActivatePluginStep.php
@@ -22,28 +22,40 @@ class ActivatePluginStep implements StepDefinitionInterface
 	public $slug;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setSlug(string $slug)
+	/**
+  * @param string $slug
+  */
+ public function setSlug($slug)
 	{
 		$this->slug = $slug;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/ActivateThemeStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/ActivateThemeStep.php
@@ -22,28 +22,40 @@ class ActivateThemeStep implements StepDefinitionInterface
 	public $slug;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setSlug(string $slug)
+	/**
+  * @param string $slug
+  */
+ public function setSlug($slug)
 	{
 		$this->slug = $slug;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/Blueprint.php
+++ b/src/WordPress/Blueprints/Model/DataClass/Blueprint.php
@@ -2,8 +2,7 @@
 
 namespace WordPress\Blueprints\Model\DataClass;
 
-class Blueprint
-{
+class Blueprint {
 	/**
 	 * Optional description. It doesn't do anything but is exposed as a courtesy to developers who may want to document which blueprint file does what.
 	 * @var string
@@ -50,58 +49,73 @@ class Blueprint
 	public $steps = [];
 
 
-	public function setDescription(string $description)
-	{
+	/**
+  * @param string $description
+  */
+ public function setDescription( $description ) {
 		$this->description = $description;
+
 		return $this;
 	}
 
 
-	public function setWordPressVersion(string $WordPressVersion)
-	{
+	/**
+  * @param string $WordPressVersion
+  */
+ public function setWordPressVersion( $WordPressVersion ) {
 		$this->WordPressVersion = $WordPressVersion;
+
 		return $this;
 	}
 
 
-	public function setRuntime(iterable $runtime)
-	{
+	public function setRuntime( $runtime ) {
 		$this->runtime = $runtime;
+
 		return $this;
 	}
 
 
-	public function setOnBoot(BlueprintOnBoot $onBoot)
-	{
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\BlueprintOnBoot $onBoot
+  */
+ public function setOnBoot( $onBoot ) {
 		$this->onBoot = $onBoot;
+
 		return $this;
 	}
 
 
-	public function setConstants(iterable $constants)
-	{
+	public function setConstants( $constants ) {
 		$this->constants = $constants;
+
 		return $this;
 	}
 
 
-	public function setPlugins(array $plugins)
-	{
+	/**
+  * @param mixed[] $plugins
+  */
+ public function setPlugins( $plugins ) {
 		$this->plugins = $plugins;
+
 		return $this;
 	}
 
 
-	public function setSiteOptions(iterable $siteOptions)
-	{
+	public function setSiteOptions( $siteOptions ) {
 		$this->siteOptions = $siteOptions;
+
 		return $this;
 	}
 
 
-	public function setSteps(array $steps)
-	{
+	/**
+  * @param mixed[] $steps
+  */
+ public function setSteps( $steps ) {
 		$this->steps = $steps;
+
 		return $this;
 	}
 }

--- a/src/WordPress/Blueprints/Model/DataClass/BlueprintOnBoot.php
+++ b/src/WordPress/Blueprints/Model/DataClass/BlueprintOnBoot.php
@@ -14,14 +14,20 @@ class BlueprintOnBoot
 	public $login;
 
 
-	public function setOpenUrl(string $openUrl)
+	/**
+  * @param string $openUrl
+  */
+ public function setOpenUrl($openUrl)
 	{
 		$this->openUrl = $openUrl;
 		return $this;
 	}
 
 
-	public function setLogin(bool $login)
+	/**
+  * @param bool $login
+  */
+ public function setLogin($login)
 	{
 		$this->login = $login;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/CorePluginResource.php
+++ b/src/WordPress/Blueprints/Model/DataClass/CorePluginResource.php
@@ -19,14 +19,20 @@ class CorePluginResource implements ResourceDefinitionInterface
 	public $slug;
 
 
-	public function setResource(string $resource)
+	/**
+  * @param string $resource
+  */
+ public function setResource($resource)
 	{
 		$this->resource = $resource;
 		return $this;
 	}
 
 
-	public function setSlug(string $slug)
+	/**
+  * @param string $slug
+  */
+ public function setSlug($slug)
 	{
 		$this->slug = $slug;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/CoreThemeResource.php
+++ b/src/WordPress/Blueprints/Model/DataClass/CoreThemeResource.php
@@ -19,14 +19,20 @@ class CoreThemeResource implements ResourceDefinitionInterface
 	public $slug;
 
 
-	public function setResource(string $resource)
+	/**
+  * @param string $resource
+  */
+ public function setResource($resource)
 	{
 		$this->resource = $resource;
 		return $this;
 	}
 
 
-	public function setSlug(string $slug)
+	/**
+  * @param string $slug
+  */
+ public function setSlug($slug)
 	{
 		$this->slug = $slug;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/CpStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/CpStep.php
@@ -28,35 +28,50 @@ class CpStep implements StepDefinitionInterface
 	public $toPath;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setFromPath(string $fromPath)
+	/**
+  * @param string $fromPath
+  */
+ public function setFromPath($fromPath)
 	{
 		$this->fromPath = $fromPath;
 		return $this;
 	}
 
 
-	public function setToPath(string $toPath)
+	/**
+  * @param string $toPath
+  */
+ public function setToPath($toPath)
 	{
 		$this->toPath = $toPath;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/DefineSiteUrlStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/DefineSiteUrlStep.php
@@ -22,28 +22,40 @@ class DefineSiteUrlStep implements StepDefinitionInterface
 	public $siteUrl;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setSiteUrl(string $siteUrl)
+	/**
+  * @param string $siteUrl
+  */
+ public function setSiteUrl($siteUrl)
 	{
 		$this->siteUrl = $siteUrl;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/DefineWpConfigConstsStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/DefineWpConfigConstsStep.php
@@ -22,28 +22,40 @@ class DefineWpConfigConstsStep implements StepDefinitionInterface
 	public $consts;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setConsts(iterable $consts)
+	/**
+  * @param iterable $consts
+  */
+ public function setConsts($consts)
 	{
 		$this->consts = $consts;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/DownloadWordPressStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/DownloadWordPressStep.php
@@ -19,21 +19,30 @@ class DownloadWordPressStep implements StepDefinitionInterface
 	public $wordPressZip;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/EnableMultisiteStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/EnableMultisiteStep.php
@@ -16,21 +16,30 @@ class EnableMultisiteStep implements StepDefinitionInterface
 	public $step = 'enableMultisite';
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/EvalPHPCallbackStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/EvalPHPCallbackStep.php
@@ -25,21 +25,30 @@ class EvalPHPCallbackStep implements StepDefinitionInterface
 	public $callback;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/FileInfo.php
+++ b/src/WordPress/Blueprints/Model/DataClass/FileInfo.php
@@ -17,28 +17,40 @@ class FileInfo
 	public $data;
 
 
-	public function setKey(string $key)
+	/**
+  * @param string $key
+  */
+ public function setKey($key)
 	{
 		$this->key = $key;
 		return $this;
 	}
 
 
-	public function setName(string $name)
+	/**
+  * @param string $name
+  */
+ public function setName($name)
 	{
 		$this->name = $name;
 		return $this;
 	}
 
 
-	public function setType(string $type)
+	/**
+  * @param string $type
+  */
+ public function setType($type)
 	{
 		$this->type = $type;
 		return $this;
 	}
 
 
-	public function setData(FileInfoData $data)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\FileInfoData $data
+  */
+ public function setData($data)
 	{
 		$this->data = $data;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/FileInfoData.php
+++ b/src/WordPress/Blueprints/Model/DataClass/FileInfoData.php
@@ -20,35 +20,50 @@ class FileInfoData
 	public $length;
 
 
-	public function setBYTES_PER_ELEMENT(float $BYTES_PER_ELEMENT)
+	/**
+  * @param float $BYTES_PER_ELEMENT
+  */
+ public function setBYTES_PER_ELEMENT($BYTES_PER_ELEMENT)
 	{
 		$this->BYTES_PER_ELEMENT = $BYTES_PER_ELEMENT;
 		return $this;
 	}
 
 
-	public function setBuffer(FileInfoDataBuffer $buffer)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\FileInfoDataBuffer $buffer
+  */
+ public function setBuffer($buffer)
 	{
 		$this->buffer = $buffer;
 		return $this;
 	}
 
 
-	public function setByteLength(float $byteLength)
+	/**
+  * @param float $byteLength
+  */
+ public function setByteLength($byteLength)
 	{
 		$this->byteLength = $byteLength;
 		return $this;
 	}
 
 
-	public function setByteOffset(float $byteOffset)
+	/**
+  * @param float $byteOffset
+  */
+ public function setByteOffset($byteOffset)
 	{
 		$this->byteOffset = $byteOffset;
 		return $this;
 	}
 
 
-	public function setLength(float $length)
+	/**
+  * @param float $length
+  */
+ public function setLength($length)
 	{
 		$this->length = $length;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/FileInfoDataBuffer.php
+++ b/src/WordPress/Blueprints/Model/DataClass/FileInfoDataBuffer.php
@@ -8,7 +8,10 @@ class FileInfoDataBuffer
 	public $byteLength;
 
 
-	public function setByteLength(float $byteLength)
+	/**
+  * @param float $byteLength
+  */
+ public function setByteLength($byteLength)
 	{
 		$this->byteLength = $byteLength;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/FilesystemResource.php
+++ b/src/WordPress/Blueprints/Model/DataClass/FilesystemResource.php
@@ -19,14 +19,20 @@ class FilesystemResource implements ResourceDefinitionInterface
 	public $path;
 
 
-	public function setResource(string $resource)
+	/**
+  * @param string $resource
+  */
+ public function setResource($resource)
 	{
 		$this->resource = $resource;
 		return $this;
 	}
 
 
-	public function setPath(string $path)
+	/**
+  * @param string $path
+  */
+ public function setPath($path)
 	{
 		$this->path = $path;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/ImportFileStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/ImportFileStep.php
@@ -19,21 +19,30 @@ class ImportFileStep implements StepDefinitionInterface
 	public $file;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/InlineResource.php
+++ b/src/WordPress/Blueprints/Model/DataClass/InlineResource.php
@@ -19,14 +19,20 @@ class InlineResource implements ResourceDefinitionInterface
 	public $contents;
 
 
-	public function setResource(string $resource)
+	/**
+  * @param string $resource
+  */
+ public function setResource($resource)
 	{
 		$this->resource = $resource;
 		return $this;
 	}
 
 
-	public function setContents(string $contents)
+	/**
+  * @param string $contents
+  */
+ public function setContents($contents)
 	{
 		$this->contents = $contents;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/InstallPluginStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/InstallPluginStep.php
@@ -27,21 +27,30 @@ class InstallPluginStep implements StepDefinitionInterface {
 	public $activate = true;
 
 
-	public function setProgress( Progress $progress ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress( $progress ) {
 		$this->progress = $progress;
 
 		return $this;
 	}
 
 
-	public function setContinueOnError( bool $continueOnError ) {
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError( $continueOnError ) {
 		$this->continueOnError = $continueOnError;
 
 		return $this;
 	}
 
 
-	public function setStep( string $step ) {
+	/**
+  * @param string $step
+  */
+ public function setStep( $step ) {
 		$this->step = $step;
 
 		return $this;
@@ -55,7 +64,10 @@ class InstallPluginStep implements StepDefinitionInterface {
 	}
 
 
-	public function setActivate( bool $activate ) {
+	/**
+  * @param bool $activate
+  */
+ public function setActivate( $activate ) {
 		$this->activate = $activate;
 
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/InstallSqliteIntegrationStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/InstallSqliteIntegrationStep.php
@@ -19,21 +19,30 @@ class InstallSqliteIntegrationStep implements StepDefinitionInterface
 	public $sqlitePluginZip;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/InstallThemeStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/InstallThemeStep.php
@@ -28,21 +28,30 @@ class InstallThemeStep implements StepDefinitionInterface
 	public $activate = true;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
@@ -56,7 +65,10 @@ class InstallThemeStep implements StepDefinitionInterface
 	}
 
 
-	public function setActivate(bool $activate)
+	/**
+  * @param bool $activate
+  */
+ public function setActivate($activate)
 	{
 		$this->activate = $activate;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/MkdirStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/MkdirStep.php
@@ -22,28 +22,40 @@ class MkdirStep implements StepDefinitionInterface
 	public $path;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setPath(string $path)
+	/**
+  * @param string $path
+  */
+ public function setPath($path)
 	{
 		$this->path = $path;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/MvStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/MvStep.php
@@ -28,35 +28,50 @@ class MvStep implements StepDefinitionInterface
 	public $toPath;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setFromPath(string $fromPath)
+	/**
+  * @param string $fromPath
+  */
+ public function setFromPath($fromPath)
 	{
 		$this->fromPath = $fromPath;
 		return $this;
 	}
 
 
-	public function setToPath(string $toPath)
+	/**
+  * @param string $toPath
+  */
+ public function setToPath($toPath)
 	{
 		$this->toPath = $toPath;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/Progress.php
+++ b/src/WordPress/Blueprints/Model/DataClass/Progress.php
@@ -11,14 +11,20 @@ class Progress
 	public $caption;
 
 
-	public function setWeight(float $weight)
+	/**
+  * @param float $weight
+  */
+ public function setWeight($weight)
 	{
 		$this->weight = $weight;
 		return $this;
 	}
 
 
-	public function setCaption(string $caption)
+	/**
+  * @param string $caption
+  */
+ public function setCaption($caption)
 	{
 		$this->caption = $caption;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/RmStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/RmStep.php
@@ -22,28 +22,40 @@ class RmStep implements StepDefinitionInterface
 	public $path;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setPath(string $path)
+	/**
+  * @param string $path
+  */
+ public function setPath($path)
 	{
 		$this->path = $path;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/RunPHPStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/RunPHPStep.php
@@ -25,28 +25,40 @@ class RunPHPStep implements StepDefinitionInterface
 	public $code;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setCode(string $code)
+	/**
+  * @param string $code
+  */
+ public function setCode($code)
 	{
 		$this->code = $code;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/RunSQLStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/RunSQLStep.php
@@ -22,21 +22,30 @@ class RunSQLStep implements StepDefinitionInterface
 	public $sql;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/RunWordPressInstallerStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/RunWordPressInstallerStep.php
@@ -19,28 +19,40 @@ class RunWordPressInstallerStep implements StepDefinitionInterface
 	public $options;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setOptions(WordPressInstallationOptions $options)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\WordPressInstallationOptions $options
+  */
+ public function setOptions($options)
 	{
 		$this->options = $options;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/SetSiteOptionsStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/SetSiteOptionsStep.php
@@ -2,8 +2,7 @@
 
 namespace WordPress\Blueprints\Model\DataClass;
 
-class SetSiteOptionsStep implements StepDefinitionInterface
-{
+class SetSiteOptionsStep implements StepDefinitionInterface {
 	const DISCRIMINATOR = 'setSiteOptions';
 
 	/** @var Progress */
@@ -25,30 +24,39 @@ class SetSiteOptionsStep implements StepDefinitionInterface
 	public $options;
 
 
-	public function setProgress(Progress $progress)
-	{
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress( $progress ) {
 		$this->progress = $progress;
+
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
-	{
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError( $continueOnError ) {
 		$this->continueOnError = $continueOnError;
+
 		return $this;
 	}
 
 
-	public function setStep(string $step)
-	{
+	/**
+  * @param string $step
+  */
+ public function setStep( $step ) {
 		$this->step = $step;
+
 		return $this;
 	}
 
 
-	public function setOptions(iterable $options)
-	{
+	public function setOptions( $options ) {
 		$this->options = $options;
+
 		return $this;
 	}
 }

--- a/src/WordPress/Blueprints/Model/DataClass/UnzipStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/UnzipStep.php
@@ -25,21 +25,30 @@ class UnzipStep implements StepDefinitionInterface
 	public $extractToPath;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
@@ -53,7 +62,10 @@ class UnzipStep implements StepDefinitionInterface
 	}
 
 
-	public function setExtractToPath(string $extractToPath)
+	/**
+  * @param string $extractToPath
+  */
+ public function setExtractToPath($extractToPath)
 	{
 		$this->extractToPath = $extractToPath;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/UrlResource.php
+++ b/src/WordPress/Blueprints/Model/DataClass/UrlResource.php
@@ -25,21 +25,30 @@ class UrlResource implements ResourceDefinitionInterface
 	public $caption;
 
 
-	public function setResource(string $resource)
+	/**
+  * @param string $resource
+  */
+ public function setResource($resource)
 	{
 		$this->resource = $resource;
 		return $this;
 	}
 
 
-	public function setUrl(string $url)
+	/**
+  * @param string $url
+  */
+ public function setUrl($url)
 	{
 		$this->url = $url;
 		return $this;
 	}
 
 
-	public function setCaption(string $caption)
+	/**
+  * @param string $caption
+  */
+ public function setCaption($caption)
 	{
 		$this->caption = $caption;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/WPCLIStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/WPCLIStep.php
@@ -25,28 +25,40 @@ class WPCLIStep implements StepDefinitionInterface
 	public $command;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setCommand(array $command)
+	/**
+  * @param mixed[] $command
+  */
+ public function setCommand($command)
 	{
 		$this->command = $command;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/WordPressInstallationOptions.php
+++ b/src/WordPress/Blueprints/Model/DataClass/WordPressInstallationOptions.php
@@ -11,14 +11,20 @@ class WordPressInstallationOptions
 	public $adminPassword = 'admin';
 
 
-	public function setAdminUsername(string $adminUsername)
+	/**
+  * @param string $adminUsername
+  */
+ public function setAdminUsername($adminUsername)
 	{
 		$this->adminUsername = $adminUsername;
 		return $this;
 	}
 
 
-	public function setAdminPassword(string $adminPassword)
+	/**
+  * @param string $adminPassword
+  */
+ public function setAdminPassword($adminPassword)
 	{
 		$this->adminPassword = $adminPassword;
 		return $this;

--- a/src/WordPress/Blueprints/Model/DataClass/WriteFileStep.php
+++ b/src/WordPress/Blueprints/Model/DataClass/WriteFileStep.php
@@ -28,28 +28,40 @@ class WriteFileStep implements StepDefinitionInterface
 	public $data;
 
 
-	public function setProgress(Progress $progress)
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\Progress $progress
+  */
+ public function setProgress($progress)
 	{
 		$this->progress = $progress;
 		return $this;
 	}
 
 
-	public function setContinueOnError(bool $continueOnError)
+	/**
+  * @param bool $continueOnError
+  */
+ public function setContinueOnError($continueOnError)
 	{
 		$this->continueOnError = $continueOnError;
 		return $this;
 	}
 
 
-	public function setStep(string $step)
+	/**
+  * @param string $step
+  */
+ public function setStep($step)
 	{
 		$this->step = $step;
 		return $this;
 	}
 
 
-	public function setPath(string $path)
+	/**
+  * @param string $path
+  */
+ public function setPath($path)
 	{
 		$this->path = $path;
 		return $this;

--- a/src/WordPress/Blueprints/Progress/ProgressCaptionEvent.php
+++ b/src/WordPress/Blueprints/Progress/ProgressCaptionEvent.php
@@ -3,8 +3,12 @@
 namespace WordPress\Blueprints\Progress;
 
 class ProgressCaptionEvent extends \Symfony\Contracts\EventDispatcher\Event {
-	public function __construct(
-		public string $caption
-	) {
-	}
+	/**
+  * @var string
+  */
+ public $caption;
+ public function __construct(string $caption)
+ {
+     $this->caption = $caption;
+ }
 }

--- a/src/WordPress/Blueprints/Progress/ProgressEvent.php
+++ b/src/WordPress/Blueprints/Progress/ProgressEvent.php
@@ -13,20 +13,20 @@ class ProgressEvent extends Event {
 	 *
 	 * @var float $progress
 	 */
-	public float $progress;
+	public $progress;
 
 	/**
 	 * The caption to display during progress, a string.
 	 *
 	 * @var ?string $caption
 	 */
-	public ?string $caption;
+	public $caption;
 
 	public function __construct(
 		float $progress,
-		?string $caption
+		string $caption
 	) {
-		$this->caption  = $caption;
+		$this->caption = $caption;
 		$this->progress = $progress;
 	}
 }

--- a/src/WordPress/Blueprints/Progress/Tracker.php
+++ b/src/WordPress/Blueprints/Progress/Tracker.php
@@ -46,7 +46,7 @@ class Tracker {
 	private $weight;
 	private $subTrackers = [];
 
-	public EventDispatcher $events;
+	public $events;
 
 	public function __construct( $options = [] ) {
 		$this->weight = $options['weight'] ?? 1;
@@ -117,7 +117,11 @@ class Tracker {
 		return $subTracker;
 	}
 
-	public function set( float $value, ?string $caption = null ): void {
+	/**
+  * @param float $value
+  * @param string|null $caption
+  */
+ public function set( $value, $caption = null ) {
 		if ( $value < $this->selfProgress ) {
 			throw new \InvalidArgumentException( "Progress cannot go backwards (tried updating to $value when it already was $this->selfProgress)" );
 		}
@@ -181,7 +185,7 @@ class Tracker {
 		$this->events->dispatch(
 			new ProgressEvent(
 				$this->getProgress(),
-				$this->getCaption(),
+				$this->getCaption()
 			)
 		);
 	}

--- a/src/WordPress/Blueprints/Resources/Resolver/FilesystemResourceResolver.php
+++ b/src/WordPress/Blueprints/Resources/Resolver/FilesystemResourceResolver.php
@@ -8,8 +8,11 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class FilesystemResourceResolver implements ResourceResolverInterface {
 
-	public function parseUrl( string $url ): ?ResourceDefinitionInterface {
-		if ( ! str_starts_with( $url, 'file://' ) ) {
+	/**
+  * @param string $url
+  */
+ public function parseUrl( $url ) {
+		if ( strncmp($url, 'file://', strlen('file://')) !== 0 ) {
 			return null;
 		}
 
@@ -20,11 +23,18 @@ class FilesystemResourceResolver implements ResourceResolverInterface {
 		return FilesystemResource::class;
 	}
 
-	public function supports( ResourceDefinitionInterface $resource ): bool {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface $resource
+  */
+ public function supports( $resource ): bool {
 		return $resource instanceof FilesystemResource;
 	}
 
-	public function stream( ResourceDefinitionInterface $resource, Tracker $progress_tracker ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface $resource
+  * @param \WordPress\Blueprints\Progress\Tracker $progress_tracker
+  */
+ public function stream( $resource, $progress_tracker ) {
 		if ( ! $this->supports( $resource ) ) {
 			throw new \InvalidArgumentException( 'Resource ' . get_class( $resource ) . ' unsupported' );
 		}

--- a/src/WordPress/Blueprints/Resources/Resolver/InlineResourceResolver.php
+++ b/src/WordPress/Blueprints/Resources/Resolver/InlineResourceResolver.php
@@ -9,7 +9,10 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class InlineResourceResolver implements ResourceResolverInterface {
 
-	public function parseUrl( string $url ): ?ResourceDefinitionInterface {
+	/**
+  * @param string $url
+  */
+ public function parseUrl( $url ) {
 		// If url starts with "protocol://" then we assume it's not inline raw data
 		if ( 0 !== preg_match( '#^[a-z_+]+://#', $url ) ) {
 			return null;
@@ -22,11 +25,18 @@ class InlineResourceResolver implements ResourceResolverInterface {
 		return InlineResource::class;
 	}
 
-	public function supports( ResourceDefinitionInterface $resource ): bool {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface $resource
+  */
+ public function supports( $resource ): bool {
 		return $resource instanceof InlineResource;
 	}
 
-	public function stream( ResourceDefinitionInterface $resource, Tracker $progress_tracker ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface $resource
+  * @param \WordPress\Blueprints\Progress\Tracker $progress_tracker
+  */
+ public function stream( $resource, $progress_tracker ) {
 		if ( ! $this->supports( $resource ) ) {
 			throw new \InvalidArgumentException( 'Resource ' . get_class( $resource ) . ' unsupported' );
 		}

--- a/src/WordPress/Blueprints/Resources/Resolver/ResourceResolverCollection.php
+++ b/src/WordPress/Blueprints/Resources/Resolver/ResourceResolverCollection.php
@@ -10,7 +10,7 @@ use WordPress\Blueprints\Progress\Tracker;
 class ResourceResolverCollection implements ResourceResolverInterface {
 
 	/** @var ResourceResolverInterface[] */
-	protected array $resource_resolvers;
+	protected $resource_resolvers;
 
 	public function __construct(
 		array $resource_resolvers
@@ -22,7 +22,10 @@ class ResourceResolverCollection implements ResourceResolverInterface {
 		throw new RuntimeException( 'Not implemented' );
 	}
 
-	public function parseUrl( string $url ): ?ResourceDefinitionInterface {
+	/**
+  * @param string $url
+  */
+ public function parseUrl( $url ) {
 		foreach ( $this->resource_resolvers as $resolver ) {
 			/** @var ResourceResolverInterface $resolver */
 			$resource = $resolver->parseUrl( $url );
@@ -34,7 +37,10 @@ class ResourceResolverCollection implements ResourceResolverInterface {
 		return null;
 	}
 
-	public function supports( ResourceDefinitionInterface $resource ): bool {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface $resource
+  */
+ public function supports( $resource ): bool {
 		foreach ( $this->resource_resolvers as $resolver ) {
 			/** @var ResourceResolverInterface $resolver */
 			if ( $resolver->supports( $resource ) ) {
@@ -45,7 +51,11 @@ class ResourceResolverCollection implements ResourceResolverInterface {
 		return false;
 	}
 
-	public function stream( ResourceDefinitionInterface $resource, Tracker $progressTracker ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface $resource
+  * @param \WordPress\Blueprints\Progress\Tracker $progressTracker
+  */
+ public function stream( $resource, $progressTracker ) {
 		foreach ( $this->resource_resolvers as $resolver ) {
 			/** @var ResourceResolverInterface $resolver */
 			if ( $resolver->supports( $resource ) ) {

--- a/src/WordPress/Blueprints/Resources/Resolver/ResourceResolverInterface.php
+++ b/src/WordPress/Blueprints/Resources/Resolver/ResourceResolverInterface.php
@@ -6,11 +6,21 @@ use WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface;
 use WordPress\Blueprints\Progress\Tracker;
 
 interface ResourceResolverInterface {
-	public function parseUrl( string $url ): ?ResourceDefinitionInterface;
+	/**
+  * @param string $url
+  */
+ public function parseUrl( $url );
 
-	public function supports( ResourceDefinitionInterface $resource ): bool;
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface $resource
+  */
+ public function supports( $resource ): bool;
 
 	static public function getResourceClass(): string;
 
-	public function stream( ResourceDefinitionInterface $resource, Tracker $progress_tracker );
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface $resource
+  * @param \WordPress\Blueprints\Progress\Tracker $progress_tracker
+  */
+ public function stream( $resource, $progress_tracker );
 }

--- a/src/WordPress/Blueprints/Resources/Resolver/UrlResourceResolver.php
+++ b/src/WordPress/Blueprints/Resources/Resolver/UrlResourceResolver.php
@@ -11,14 +11,17 @@ use WordPress\DataSource\DataSourceProgressEvent;
 
 class UrlResourceResolver implements ResourceResolverInterface {
 
-	protected DataSourceInterface $data_source;
+	protected $data_source;
 
 	public function __construct( DataSourceInterface $data_source ) {
 		$this->data_source = $data_source;
 	}
 
-	public function parseUrl( string $url ): ?ResourceDefinitionInterface {
-		if ( ! str_starts_with( $url, 'http://' ) && ! str_starts_with( $url, 'https://' ) ) {
+	/**
+  * @param string $url
+  */
+ public function parseUrl( $url ) {
+		if ( strncmp($url, 'http://', strlen('http://')) !== 0 && strncmp($url, 'https://', strlen('https://')) !== 0 ) {
 			return null;
 		}
 
@@ -30,11 +33,18 @@ class UrlResourceResolver implements ResourceResolverInterface {
 		return UrlResource::class;
 	}
 
-	public function supports( ResourceDefinitionInterface $resource ): bool {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface $resource
+  */
+ public function supports( $resource ): bool {
 		return $resource instanceof UrlResource;
 	}
 
-	public function stream( ResourceDefinitionInterface $resource, Tracker $progress_tracker ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ResourceDefinitionInterface $resource
+  * @param \WordPress\Blueprints\Progress\Tracker $progress_tracker
+  */
+ public function stream( $resource, $progress_tracker ) {
 		if ( ! $this->supports( $resource ) ) {
 			throw new InvalidArgumentException( 'Resource ' . get_class( $resource ) . ' unsupported' );
 		}

--- a/src/WordPress/Blueprints/Resources/ResourceManager.php
+++ b/src/WordPress/Blueprints/Resources/ResourceManager.php
@@ -9,9 +9,9 @@ use WordPress\Util\Map;
 
 class ResourceManager {
 
-	protected Filesystem $fs;
-	protected Map $map;
-	protected ResourceResolverCollection $resource_resolvers;
+	protected $fs;
+	protected $map;
+	protected $resource_resolvers;
 
 	public function __construct(
 		ResourceResolverCollection $resource_resolvers
@@ -21,7 +21,10 @@ class ResourceManager {
 		$this->map = new Map();
 	}
 
-	public function enqueue( array $compiledResources ) {
+	/**
+  * @param mixed[] $compiledResources
+  */
+ public function enqueue( $compiledResources ) {
 		foreach ( $compiledResources as $compiled ) {
 			/** @var CompiledResource $compiled */
 

--- a/src/WordPress/Blueprints/Runner/Blueprint/BlueprintRunner.php
+++ b/src/WordPress/Blueprints/Runner/Blueprint/BlueprintRunner.php
@@ -11,8 +11,8 @@ use WordPress\Blueprints\Runtime\RuntimeInterface;
 
 class BlueprintRunner {
 
-	public EventDispatcher $events;
-	protected RuntimeInterface $runtime;
+	public $events;
+	protected $runtime;
 	protected $resourceManagerFactory;
 
 	public function __construct(
@@ -24,7 +24,10 @@ class BlueprintRunner {
 		$this->events = new EventDispatcher();
 	}
 
-	public function run( CompiledBlueprint $blueprint ) {
+	/**
+  * @param \WordPress\Blueprints\Compile\CompiledBlueprint $blueprint
+  */
+ public function run( $blueprint ) {
 		$resourceManagerFactory = $this->resourceManagerFactory;
 		$resourceManager = $resourceManagerFactory();
 		$resourceManager->enqueue(

--- a/src/WordPress/Blueprints/Runner/Step/ActivatePluginStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/ActivatePluginStepRunner.php
@@ -8,8 +8,12 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class ActivatePluginStepRunner extends BaseStepRunner {
 
-	function run( ActivatePluginStep $input, Tracker $tracker ) {
-		$tracker?->setCaption( $input->progress->caption ?? "Activating plugin " . $input->slug );
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ActivatePluginStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker $tracker
+  */
+ function run( $input, $tracker ) {
+		($nullsafeVariable1 = $tracker) ? $nullsafeVariable1->setCaption($input->progress->caption ?? "Activating plugin " . $input->slug) : null;
 
 		// @TODO: Compare performance to the wp_activate_plugin.php script.
 		//        On the first sight it seems to be significantly faster.
@@ -31,7 +35,7 @@ class ActivatePluginStepRunner extends BaseStepRunner {
 //		);
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Activating plugin";
 	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/ActivateThemeStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/ActivateThemeStepRunner.php
@@ -16,13 +16,18 @@ class ActivateThemeStepRunner extends BaseStepRunner {
 	}
 
 	/**
-	 * @param ActivateThemeStep $input
-	 */
-	public function getDefaultCaption( $input ): string|null {
+  * @param ActivateThemeStep $input
+  * @return string|null
+  */
+ public function getDefaultCaption( $input ) {
 		return "Activating theme " . $input->slug;
 	}
 
-	public function run( ActivateThemeStep $input, Tracker $tracker ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ActivateThemeStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker $tracker
+  */
+ public function run( $input, $tracker ) {
 		// @TODO: Compare performance to the wp_activate_theme.php script.
 		//        On the first sight it seems to be significantly faster.
 		return $this->getRuntime()->runShellCommand(

--- a/src/WordPress/Blueprints/Runner/Step/BaseStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/BaseStepRunner.php
@@ -5,34 +5,34 @@ namespace WordPress\Blueprints\Runner\Step;
 use WordPress\Blueprints\Resources\ResourceManager;
 use WordPress\Blueprints\Runtime\RuntimeInterface;
 
-abstract class BaseStepRunner implements StepRunnerInterface
-{
-    protected ResourceManager $resourceManager;
+abstract class BaseStepRunner implements StepRunnerInterface {
+	protected $resourceManager;
 
-    protected RuntimeInterface $runtime;
+	protected $runtime;
 
-    public function setResourceManager(ResourceManager $map)
-    {
-        $this->resourceManager = $map;
-    }
+	/**
+  * @param \WordPress\Blueprints\Resources\ResourceManager $map
+  */
+ public function setResourceManager( $map ) {
+		$this->resourceManager = $map;
+	}
 
-    protected function getResource($declaration)
-    {
-        return $this->resourceManager->getStream($declaration);
-    }
+	protected function getResource( $declaration ) {
+		return $this->resourceManager->getStream( $declaration );
+	}
 
-    public function setRuntime(RuntimeInterface $runtime): void
-    {
-        $this->runtime = $runtime;
-    }
+	/**
+  * @param \WordPress\Blueprints\Runtime\RuntimeInterface $runtime
+  */
+ public function setRuntime( $runtime ) {
+		$this->runtime = $runtime;
+	}
 
-    protected function getRuntime(): RuntimeInterface
-    {
-        return $this->runtime;
-    }
+	protected function getRuntime(): RuntimeInterface {
+		return $this->runtime;
+	}
 
-	public function getDefaultCaption($input): ?string
-    {
-        return null;
-    }
+	public function getDefaultCaption( $input ) {
+		return null;
+	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/CpStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/CpStepRunner.php
@@ -9,7 +9,7 @@ class CpStepRunner extends BaseStepRunner {
 	/**
 	 * @param CpStep $input
 	 */
-	function run( CpStep $input ) {
+	function run( $input ) {
 		// @TODO: Treat the input paths as relative path to the document root (unless it's absolute)
 		$success = copy( $input->fromPath, $input->toPath );
 		if ( ! $success ) {

--- a/src/WordPress/Blueprints/Runner/Step/DefineSiteUrlStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/DefineSiteUrlStepRunner.php
@@ -7,7 +7,10 @@ use WordPress\Blueprints\Model\DataClass\DefineWpConfigConstsStep;
 
 class DefineSiteUrlStepRunner extends BaseStepRunner {
 
-	function run( DefineSiteUrlStep $input ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\DefineSiteUrlStep $input
+  */
+ function run( $input ) {
 		// @TODO: Don't manually construct the step object like this.
 		//        There may be more required fields in the future.
 		//        Instead, either remove this step, move the const-setting
@@ -21,7 +24,7 @@ class DefineSiteUrlStepRunner extends BaseStepRunner {
 		);
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Defining site URL";
 	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/DefineWpConfigConstsStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/DefineWpConfigConstsStepRunner.php
@@ -6,25 +6,28 @@ use WordPress\Blueprints\Model\DataClass\DefineWpConfigConstsStep;
 
 class DefineWpConfigConstsStepRunner extends BaseStepRunner {
 
-	function run( DefineWpConfigConstsStep $input ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\DefineWpConfigConstsStep $input
+  */
+ function run( $input ) {
 		$functions = file_get_contents( __DIR__ . '/DefineWpConfigConsts/functions.php' );
 
 		return $this->getRuntime()->evalPhpInSubProcess(
-			"$functions ?>" . <<<'PHP'
-<?php
+			"$functions ?>" . '<?php
     $wp_config_path = "./wp-config.php";
 	$consts = json_decode(getenv("CONSTS"), true);
 	$wp_config = file_get_contents($wp_config_path);
 	$new_wp_config = rewrite_wp_config_to_define_constants($wp_config, $consts);
 	file_put_contents($wp_config_path, $new_wp_config);
-PHP,
+',
 			[
 				'CONSTS' => json_encode( $input->consts ),
 			]
 		);
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Defining wp-config constants";
 	}
+
 }

--- a/src/WordPress/Blueprints/Runner/Step/DownloadWordPressStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/DownloadWordPressStepRunner.php
@@ -7,9 +7,13 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class DownloadWordPressStepRunner extends InstallAssetStepRunner {
 
-	public function run(
-		DownloadWordPressStep $input,
-		Tracker $progress
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\DownloadWordPressStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker $progress
+  */
+ public function run(
+		$input,
+		$progress
 	) {
 		$this->unzipAssetTo( $input->wordPressZip, $this->getRuntime()->getDocumentRoot() );
 
@@ -20,7 +24,7 @@ class DownloadWordPressStepRunner extends InstallAssetStepRunner {
 		}
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Extracting WordPress";
 	}
 

--- a/src/WordPress/Blueprints/Runner/Step/EnableMultisiteStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/EnableMultisiteStepRunner.php
@@ -8,7 +8,7 @@ class EnableMultisiteStepRunner extends BaseStepRunner {
 	/**
 	 * @param EnableMultisiteStep $input
 	 */
-	function run( EnableMultisiteStep $input ) {
+	function run( $input ) {
 		throw new \LogicException( 'Not implemented yet' );
 
 		// @TODO:

--- a/src/WordPress/Blueprints/Runner/Step/EvalPHPCallbackStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/EvalPHPCallbackStepRunner.php
@@ -10,7 +10,7 @@ class EvalPHPCallbackStepRunner extends BaseStepRunner {
 	 * @param EvalPHPCallbackStep $input
 	 * @param Tracker $tracker
 	 */
-	function run( EvalPHPCallbackStep $input, Tracker $tracker ) {
+	function run( $input, $tracker ) {
 		if ( ! is_callable( $input->callback ) ) {
 			throw new \InvalidArgumentException( "The 'callback' input property is not callable" );
 		}

--- a/src/WordPress/Blueprints/Runner/Step/ImportFileStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/ImportFileStepRunner.php
@@ -9,8 +9,12 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class ImportFileStepRunner extends BaseStepRunner {
 
-	function run( ImportFileStep $input, Tracker $tracker ) {
-		$tracker?->setCaption( $input->progress->caption ?? "Importing starter content" );
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\ImportFileStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker $tracker
+  */
+ function run( $input, $tracker ) {
+		($nullsafeVariable1 = $tracker) ? $nullsafeVariable1->setCaption($input->progress->caption ?? "Importing starter content") : null;
 
 		// @TODO: Install the wordpress-importer plugin if it's not already installed
 		//        wp plugin install wordpress-importer --activate

--- a/src/WordPress/Blueprints/Runner/Step/InstallPluginStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/InstallPluginStepRunner.php
@@ -8,7 +8,11 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class InstallPluginStepRunner extends InstallAssetStepRunner {
 
-	function run( InstallPluginStep $input, Tracker $tracker ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\InstallPluginStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker $tracker
+  */
+ function run( $input, $tracker ) {
 		// @TODO: inject this information into this step
 		$pluginDir = 'plugin' . rand( 0, 1000 );
 		$targetPath = $this->getRuntime()->resolvePath( 'wp-content/plugins/' . $pluginDir );
@@ -26,7 +30,7 @@ class InstallPluginStepRunner extends InstallAssetStepRunner {
 		}
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Installing plugin " . $input->pluginZipFile;
 	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/InstallSqliteIntegrationStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/InstallSqliteIntegrationStepRunner.php
@@ -11,7 +11,7 @@ class InstallSqliteIntegrationStepRunner extends InstallAssetStepRunner {
 	 * @param InstallSqliteIntegrationStep $input
 	 * @param Tracker $tracker
 	 */
-	function run( InstallSqliteIntegrationStep $input, Tracker $tracker ) {
+	function run( $input, $tracker ) {
 		$pluginDir = 'sqlite-database-integration';
 		$targetPath = $this->getRuntime()->resolvePath( 'wp-content/mu-plugins/' . $pluginDir );
 		$this->unzipAssetTo( $input->sqlitePluginZip, $targetPath );
@@ -33,7 +33,7 @@ class InstallSqliteIntegrationStepRunner extends InstallAssetStepRunner {
 			'<?php require_once __DIR__ . "/sqlite-database-integration/load.php"; ' );
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Installing SQLite integration plugin";
 	}
 

--- a/src/WordPress/Blueprints/Runner/Step/InstallThemeStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/InstallThemeStepRunner.php
@@ -11,9 +11,10 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class InstallThemeStepRunner extends InstallAssetStepRunner {
 	/**
-	 * @param InstallThemeStep $input
-	 */
-	function run( InstallThemeStep $input, Tracker $tracker ) {
+  * @param InstallThemeStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker $tracker
+  */
+ function run( $input, $tracker ) {
 		// @TODO: inject this information into this step
 		$themeDir = 'theme' . rand( 0, 1000 );
 		$targetPath = $this->getRuntime()->resolvePath( 'wp-content/themes/' . $themeDir );
@@ -31,7 +32,7 @@ class InstallThemeStepRunner extends InstallAssetStepRunner {
 		}
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Installing theme " . $input->themeZipFile;
 	}
 

--- a/src/WordPress/Blueprints/Runner/Step/MkdirStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/MkdirStepRunner.php
@@ -7,7 +7,10 @@ use WordPress\Blueprints\Model\DataClass\MkdirStep;
 
 class MkdirStepRunner extends BaseStepRunner {
 
-	function run( MkdirStep $input ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\MkdirStep $input
+  */
+ function run( $input ) {
 		// @TODO: Treat $input->path as relative path to the document root (unless it's absolute)
 		$success = mkdir( $input->path );
 		if ( ! $success ) {

--- a/src/WordPress/Blueprints/Runner/Step/MvStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/MvStepRunner.php
@@ -12,7 +12,7 @@ class MvStepRunner extends BaseStepRunner {
 	/**
 	 * @param MvStep $input
 	 */
-	function run( MvStep $input ) {
+	function run( $input ) {
 		// @TODO: Treat these paths as relative path to the document root (unless it's absolute)
 		$success = rename( $input->fromPath, $input->toPath );
 		if ( ! $success ) {

--- a/src/WordPress/Blueprints/Runner/Step/RmStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/RmStepRunner.php
@@ -12,7 +12,7 @@ class RmStepRunner extends BaseStepRunner
     /**
      * @param RmStep $input
      */
-    public function run(RmStep $input)
+    public function run($input)
     {
         $resolvedPath = $this->getRuntime()->resolvePath($input->path);
         $fileSystem = new Filesystem();

--- a/src/WordPress/Blueprints/Runner/Step/RunPHPStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/RunPHPStepRunner.php
@@ -6,8 +6,12 @@ use WordPress\Blueprints\Model\DataClass\RunPHPStep;
 use WordPress\Blueprints\Progress\Tracker;
 
 class RunPHPStepRunner extends BaseStepRunner {
-	function run( RunPHPStep $input, Tracker $tracker ) {
-		$tracker?->setCaption( "Running custom PHP code" );
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\RunPHPStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker $tracker
+  */
+ function run( $input, $tracker ) {
+		($nullsafeVariable1 = $tracker) ? $nullsafeVariable1->setCaption("Running custom PHP code") : null;
 
 		return $this->getRuntime()->evalPhpInSubProcess( $input->code );
 	}

--- a/src/WordPress/Blueprints/Runner/Step/RunSQLStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/RunSQLStepRunner.php
@@ -11,11 +11,12 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class RunSQLStepRunner extends BaseStepRunner {
 	/**
-	 * @param RunSQLStep $input
-	 */
-	function run(
-		RunSQLStep $input,
-		Tracker $progress = null
+  * @param RunSQLStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker|null $progress
+  */
+ function run(
+		$input,
+		$progress = null
 	) {
 		return $this->getRuntime()->evalPhpInSubProcess( <<<'CODE'
 <?php
@@ -36,13 +37,14 @@ class RunSQLStepRunner extends BaseStepRunner {
 			$buffer = '';
 		}
 		fclose($handle);
-CODE,
+CODE
+,
 			null,
 			$this->getResource( $input->sql )
 		);
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Running SQL queries";
 	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/RunWordPressInstallerStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/RunWordPressInstallerStepRunner.php
@@ -6,7 +6,11 @@ use WordPress\Blueprints\Model\DataClass\RunWordPressInstallerStep;
 use WordPress\Blueprints\Progress\Tracker;
 
 class RunWordPressInstallerStepRunner extends BaseStepRunner {
-	function run( RunWordPressInstallerStep $input, Tracker $tracker ) {
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\RunWordPressInstallerStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker $tracker
+  */
+ function run( $input, $tracker ) {
 		return $this->getRuntime()->runShellCommand(
 			[
 				'php',
@@ -23,8 +27,8 @@ class RunWordPressInstallerStepRunner extends BaseStepRunner {
 		);
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Installing WordPress";
 	}
-	
+
 }

--- a/src/WordPress/Blueprints/Runner/Step/SetSiteOptionsStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/SetSiteOptionsStepRunner.php
@@ -8,26 +8,27 @@ use WordPress\Blueprints\Progress\Tracker;
 
 class SetSiteOptionsStepRunner extends BaseStepRunner {
 	/**
-	 * @param SetSiteOptionsStep $input
-	 */
-	function run( SetSiteOptionsStep $input, Tracker $tracker ) {
+  * @param SetSiteOptionsStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker $tracker
+  */
+ function run( $input, $tracker ) {
 		// Running a custom PHP script is much faster than setting each option
 		// with a separate wp-cli command.
-		return $this->getRuntime()->evalPhpInSubProcess( <<<'CODE'
+		return $this->getRuntime()->evalPhpInSubProcess( '
 <?php
-		require getenv('DOCROOT'). '/wp-load.php';
+		require getenv(\'DOCROOT\'). \'/wp-load.php\';
 		$site_options = getenv("OPTIONS") ? json_decode(getenv("OPTIONS"), true) : [];
 		foreach($site_options as $name => $value) {
 			update_option($name, $value);
 		}
-CODE,
+',
 			[
 				'OPTIONS' => json_encode( $input->options ),
 			]
 		);
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Setting site options";
 	}
 

--- a/src/WordPress/Blueprints/Runner/Step/StepRunnerInterface.php
+++ b/src/WordPress/Blueprints/Runner/Step/StepRunnerInterface.php
@@ -5,12 +5,17 @@ namespace WordPress\Blueprints\Runner\Step;
 use WordPress\Blueprints\Resources\ResourceManager;
 use WordPress\Blueprints\Runtime\RuntimeInterface;
 
-interface StepRunnerInterface
-{
+interface StepRunnerInterface {
 
-    public function setResourceManager(ResourceManager $map);
+	/**
+  * @param \WordPress\Blueprints\Resources\ResourceManager $map
+  */
+ public function setResourceManager( $map );
 
-    public function setRuntime(RuntimeInterface $runtime): void;
+	/**
+  * @param \WordPress\Blueprints\Runtime\RuntimeInterface $runtime
+  */
+ public function setRuntime( $runtime );
 
 //  @TODO: Document how this method isn't defined because
 //         PHP doens't support covariant arguments

--- a/src/WordPress/Blueprints/Runner/Step/UnzipStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/UnzipStepRunner.php
@@ -16,8 +16,8 @@ class UnzipStepRunner extends BaseStepRunner {
 	 * @return void
 	 */
 	public function run(
-		UnzipStep $input,
-		Tracker $progress_tracker
+		$input,
+		$progress_tracker
 	) {
 		$progress_tracker->set( 10, 'Unzipping...' );
 

--- a/src/WordPress/Blueprints/Runner/Step/WPCLIStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/WPCLIStepRunner.php
@@ -8,7 +8,7 @@ class WPCLIStepRunner extends BaseStepRunner {
 	/**
 	 * @param WPCLIStep $input
 	 */
-	function run( WPCLIStep $input ) {
+	function run( $input ) {
 		$this->getRuntime()->runShellCommand( $input->command );
 	}
 }

--- a/src/WordPress/Blueprints/Runner/Step/WriteFileStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/WriteFileStepRunner.php
@@ -6,9 +6,13 @@ use WordPress\Blueprints\Model\DataClass\WriteFileStep;
 use WordPress\Blueprints\Progress\Tracker;
 
 class WriteFileStepRunner extends BaseStepRunner {
-	public function run(
-		WriteFileStep $input,
-		Tracker $progress = null
+	/**
+  * @param \WordPress\Blueprints\Model\DataClass\WriteFileStep $input
+  * @param \WordPress\Blueprints\Progress\Tracker|null $progress
+  */
+ public function run(
+		$input,
+		$progress = null
 	) {
 		$path = $this->getRuntime()->resolvePath( $input->path );
 		// @TODO: Treat $input->path as relative path to the document root (unless it's absolute)
@@ -25,7 +29,7 @@ class WriteFileStepRunner extends BaseStepRunner {
 		fclose( $fp2 );
 	}
 
-	public function getDefaultCaption( $input ): null|string {
+	public function getDefaultCaption( $input ) {
 		return "Writing file " . $input->path;
 	}
 

--- a/src/WordPress/Blueprints/Runtime/ProcessFailedException.php
+++ b/src/WordPress/Blueprints/Runtime/ProcessFailedException.php
@@ -8,9 +8,12 @@ use WordPress\Blueprints\BlueprintException;
 
 class ProcessFailedException extends BlueprintException {
 
-	protected Process $process;
+	/**
+	 * @var \Symfony\Component\Process\Process
+	 */
+	protected $process;
 
-	public function __construct( Process $process, ?Throwable $previous = null ) {
+	public function __construct( Process $process, Throwable $previous = null ) {
 		$this->process = $process;
 		parent::__construct(
 			"Process `" . $process->getCommandLine() . "` failed with exit code " . $process->getExitCode() . " and the following stderr output: \n" . $process->getErrorOutput() . "\n" . $process->getOutput(),

--- a/src/WordPress/Blueprints/Runtime/Runtime.php
+++ b/src/WordPress/Blueprints/Runtime/Runtime.php
@@ -9,14 +9,14 @@ use function WordPress\Blueprints\join_paths;
 
 class Runtime implements RuntimeInterface {
 
-	public Filesystem $fs;
-    protected string $documentRoot;
+	public $fs;
+	protected $documentRoot;
 
-    public function __construct(
+	public function __construct(
 		string $documentRoot
 	) {
-        $this->documentRoot = $documentRoot;
-        $this->fs = new Filesystem();
+		$this->documentRoot = $documentRoot;
+		$this->fs = new Filesystem();
 		if ( ! file_exists( $this->getDocumentRoot() ) ) {
 			$this->fs->mkdir( $this->getDocumentRoot() );
 		}
@@ -34,7 +34,10 @@ class Runtime implements RuntimeInterface {
 		return $this->documentRoot;
 	}
 
-	public function resolvePath( string $path ): string {
+	/**
+  * @param string $path
+  */
+ public function resolvePath( $path ): string {
 		return Path::makeAbsolute( $path, $this->getDocumentRoot() );
 	}
 
@@ -68,11 +71,15 @@ class Runtime implements RuntimeInterface {
 	}
 
 	// @TODO: Move this to a separate class
-	public function evalPhpInSubProcess(
+ /**
+  * @param mixed[]|null $env
+  * @param float $timeout
+  */
+ public function evalPhpInSubProcess(
 		$code,
-		?array $env = null,
+		$env = null,
 		$input = null,
-		?float $timeout = 60
+		$timeout = 60
 	) {
 		return $this->runShellCommand(
 			[
@@ -81,22 +88,30 @@ class Runtime implements RuntimeInterface {
 				'?>' . $code,
 			],
 			null,
-			[
-				'DOCROOT' => $this->getDocumentRoot(),
-				...( $env ?? [] ),
-			],
+			array_merge(
+				[
+					'DOCROOT' => $this->getDocumentRoot(),
+				],
+				$env ?? []
+			),
 			$input,
 			$timeout
 		);
 	}
 
 	// @TODO: Move this to a separate class
-	public function runShellCommand(
-		array $command,
-		?string $cwd = null,
-		?array $env = null,
+ /**
+  * @param mixed[] $command
+  * @param string|null $cwd
+  * @param mixed[]|null $env
+  * @param float $timeout
+  */
+ public function runShellCommand(
+		$command,
+		$cwd = null,
+		$env = null,
 		$input = null,
-		?float $timeout = 60
+		$timeout = 60
 	) {
 		$process = $this->startProcess(
 			$command,
@@ -114,14 +129,20 @@ class Runtime implements RuntimeInterface {
 		return $process->getOutput();
 	}
 
-	public function startProcess(
-		array $command,
-		?string $cwd = null,
-		?array $env = null,
+	/**
+  * @param mixed[] $command
+  * @param string|null $cwd
+  * @param mixed[]|null $env
+  * @param float $timeout
+  */
+ public function startProcess(
+		$command,
+		$cwd = null,
+		$env = null,
 		$input = null,
-		?float $timeout = 60
+		$timeout = 60
 	): Process {
-		$cwd ??= $this->getDocumentRoot();
+		$cwd = $cwd ?? $this->getDocumentRoot();
 
 		return new Process(
 			$command,

--- a/src/WordPress/Blueprints/Runtime/RuntimeInterface.php
+++ b/src/WordPress/Blueprints/Runtime/RuntimeInterface.php
@@ -6,12 +6,18 @@ use Symfony\Component\Process\Process;
 
 interface RuntimeInterface {
 
-	public function startProcess(
-		array $command,
-		?string $cwd = null,
-		?array $env = null,
-		mixed $input = null,
-		?float $timeout = 60
+	/**
+  * @param mixed[] $command
+  * @param string|null $cwd
+  * @param mixed[]|null $env
+  * @param float $timeout
+  */
+ public function startProcess(
+		$command,
+		$cwd = null,
+		$env = null,
+		$input = null,
+		$timeout = 60
 	): Process;
 
 }

--- a/src/WordPress/Blueprints/bin/autogenerate_models.php
+++ b/src/WordPress/Blueprints/bin/autogenerate_models.php
@@ -78,7 +78,9 @@ foreach ( $janeClasses as $ref => $class ) {
  */
 $modelInfoClass = ( new PhpNamespace( $targetNamespace ) )->addClass( 'ModelInfo' );
 foreach ( $interfaceImplementors as $interfaceName => $implementors ) {
-	$implementorsClassExpressions = array_map( fn( $implementor ) => $implementor . '::class', $implementors );
+	$implementorsClassExpressions = array_map( function ($implementor) {
+     return $implementor . '::class';
+ }, $implementors );
 	$modelInfoClass->addMethod( 'get' . $interfaceName . 'Implementations' )
 		->setStatic( true )
 		->setReturnType( 'array' )
@@ -109,7 +111,9 @@ $unionReplacements = [];
 foreach ( $interfaceImplementors as $interfaceName => $implementors ) {
 	$unionReplacements[ implode( '|', $implementors ) ] = $interfaceName;
 
-	$arrayUnion = array_map( fn( $implementor ) => $implementor . '[]', $implementors );
+	$arrayUnion = array_map( function ($implementor) {
+     return $implementor . '[]';
+ }, $implementors );
 	$unionReplacements[ implode( '|', $arrayUnion ) ] = $interfaceName . '[]';
 }
 
@@ -143,7 +147,7 @@ foreach ( $janeClasses as $ref => $janeClass ) {
 		$description = $janeProperty->getDescription();
 		$typeHint = $janeProperty->getType()->getTypeHint( '' );
 		$docTypeHint = $janeProperty->getType()->getDocTypeHint( '' );
-		if ( str_contains( $docTypeHint, $targetNamespace ) ) {
+		if ( strpos($docTypeHint, $targetNamespace) !== false ) {
 			// Jane prepends "\$namespace\Model\" to type hints, let's remove that.
 			$docTypeHint = str_replace( '\\' . $targetNamespace . '\\Model\\', '', $docTypeHint );
 			// Let's replace the lengthy union types with the interface types.
@@ -182,7 +186,7 @@ foreach ( $janeClasses as $ref => $janeClass ) {
 		$setterArg = $setter->addParameter( $janeProperty->getName() );
 		$argTypeHint = $janeProperty->getType()->getTypeHint( $targetNamespace ) . '';
 		if ( $argTypeHint ) {
-			if ( str_contains( $argTypeHint, '\\' ) ) {
+			if ( strpos($argTypeHint, '\\') !== false ) {
 				$argTypeHint = $targetNamespace . '\\' . str_replace( '\\' . $targetNamespace . '\\Model\\',
 						'',
 						$argTypeHint );

--- a/src/WordPress/Blueprints/functions.php
+++ b/src/WordPress/Blueprints/functions.php
@@ -8,6 +8,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use WordPress\Blueprints\Runtime\Runtime;
 
 function run_blueprint( $json, $options = [] ) {
+
 	$environment = $options['environment'] ?? ContainerBuilder::ENVIRONMENT_NATIVE;
 	$documentRoot = $options['documentRoot'] ?? '/wordpress';
 	$progressSubscriber = $options['progressSubscriber'] ?? null;

--- a/src/WordPress/DataSource/BaseDataSource.php
+++ b/src/WordPress/DataSource/BaseDataSource.php
@@ -6,7 +6,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 abstract class BaseDataSource implements DataSourceInterface {
 
-	public EventDispatcher $events;
+	public $events;
 
 	public function __construct() {
 		$this->events = new EventDispatcher();

--- a/src/WordPress/DataSource/DataSourceProgressEvent.php
+++ b/src/WordPress/DataSource/DataSourceProgressEvent.php
@@ -5,10 +5,25 @@ namespace WordPress\DataSource;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class DataSourceProgressEvent extends Event {
-	public function __construct(
-		public string $url,
-		public int $downloadedBytes,
-		public int|null $totalBytes
-	) {
-	}
+	/**
+  * @var string
+  */
+ public $url;
+ /**
+  * @var int
+  */
+ public $downloadedBytes;
+ /**
+  * @var int|null
+  */
+ public $totalBytes;
+ /**
+  * @param int|null $totalBytes
+  */
+ public function __construct(string $url, int $downloadedBytes, $totalBytes)
+ {
+     $this->url = $url;
+     $this->downloadedBytes = $downloadedBytes;
+     $this->totalBytes = $totalBytes;
+ }
 }

--- a/src/WordPress/DataSource/PlaygroundFetchSource.php
+++ b/src/WordPress/DataSource/PlaygroundFetchSource.php
@@ -12,7 +12,7 @@ class PlaygroundFetchSource extends BaseDataSource {
 	public function stream( $resourceIdentifier ) {
 		$url = $resourceIdentifier;
 		$proc_handle = proc_open(
-			[ 'fetch', $url, ],
+			is_array([ 'fetch', $url, ]) ? implode(' ', array_map('escapeshellarg', [ 'fetch', $url, ])) : [ 'fetch', $url, ],
 			[ 1 => [ 'pipe', 'w' ], 2 => [ 'pipe', 'w' ] ],
 			$pipes
 		);

--- a/src/WordPress/DataSource/UrlSource.php
+++ b/src/WordPress/DataSource/UrlSource.php
@@ -10,10 +10,16 @@ use WordPress\Streams\StreamPeekerWrapper;
 
 class UrlSource extends BaseDataSource {
 
+	protected $client;
+	protected $cache;
+
 	public function __construct(
-		protected Client $client,
-		protected CacheInterface $cache
+		Client $client,
+		CacheInterface $cache
 	) {
+		$this->client = $client;
+		$this->cache = $cache;
+
 		parent::__construct();
 		$client->set_progress_callback( function ( Request $request, $downloaded, $total ) {
 			$this->events->dispatch( new DataSourceProgressEvent(
@@ -62,7 +68,7 @@ class UrlSource extends BaseDataSource {
 		return StreamPeekerWrapper::create_resource(
 			new StreamPeekerData(
 				$stream,
-				$onChunk,
+				$onChunk
 			)
 		);
 	}

--- a/src/WordPress/JsonMapper/JsonMapper.php
+++ b/src/WordPress/JsonMapper/JsonMapper.php
@@ -45,7 +45,7 @@ class JsonMapper {
 	 * @throws JsonMapperException If mapping the value to an associated property type failed or if setting was
 	 *                             impossible.
 	 */
-	public function hydrate( stdClass $json, string $class_name ) {
+	public function hydrate( $json, $class_name ) {
 		return $this->has_factory( $class_name )
 			? $this->run_factory( $class_name, $json )
 			: $this->create_and_hydrate( $class_name, $json );

--- a/src/WordPress/JsonMapper/PropertyParser.php
+++ b/src/WordPress/JsonMapper/PropertyParser.php
@@ -40,7 +40,7 @@ class PropertyParser {
 	 *
 	 * @return array<string,Property> the property map, key: property name
 	 */
-	public static function compute_property_map( ReflectionClass $reflection_class ) {
+	public static function compute_property_map( $reflection_class ) {
 		$property_map = array();
 
 		foreach ( self::get_properties( $reflection_class ) as $reflection_property ) {

--- a/src/WordPress/JsonMapper/Utils.php
+++ b/src/WordPress/JsonMapper/Utils.php
@@ -6,7 +6,10 @@ class Utils {
 
 	static public $scalar_types = array( 'string', 'bool', 'boolean', 'int', 'integer', 'double', 'float' );
 
-	static public function is_type_scalar( string $type ) {
+	/**
+  * @param string $type
+  */
+ static public function is_type_scalar( $type ) {
 		return in_array( $type, self::$scalar_types, true );
 	}
 

--- a/src/WordPress/Streams/StreamPeekerData.php
+++ b/src/WordPress/Streams/StreamPeekerData.php
@@ -4,7 +4,13 @@ namespace WordPress\Streams;
 
 class StreamPeekerData extends VanillaStreamWrapperData {
 
-	public function __construct( public $fp, public $onChunk = null, public $onClose = null ) {
-		parent::__construct( $fp );
+	public $fp;
+ public $onChunk = null;
+ public $onClose = null;
+ public function __construct( $fp, $onChunk = null, $onClose = null ) {
+		$this->fp = $fp;
+  $this->onChunk = $onChunk;
+  $this->onClose = $onClose;
+  parent::__construct( $fp );
 	}
 }

--- a/src/WordPress/Streams/StreamWrapperInterface.php
+++ b/src/WordPress/Streams/StreamWrapperInterface.php
@@ -13,14 +13,17 @@ interface StreamWrapperInterface {
 	 *
 	 * @return bool
 	 */
-	public function stream_set_option( int $option, int $arg1, ?int $arg2 ): bool;
+	public function stream_set_option( $option, $arg1, $arg2 = null ): bool;
 
 	/**
 	 * Opens the stream
 	 */
 	public function stream_open( $path, $mode, $options, &$opened_path );
 
-	public function stream_cast( int $cast_as );
+	/**
+  * @param int $cast_as
+  */
+ public function stream_cast( $cast_as );
 
 	/**
 	 * Reads from the stream

--- a/src/WordPress/Streams/VanillaStreamWrapper.php
+++ b/src/WordPress/Streams/VanillaStreamWrapper.php
@@ -11,7 +11,10 @@ class VanillaStreamWrapper implements StreamWrapperInterface {
 
 	const SCHEME = 'vanilla';
 
-	static public function create_resource( VanillaStreamWrapperData $data ) {
+	/**
+  * @param \WordPress\Streams\VanillaStreamWrapperData $data
+  */
+ static public function create_resource( $data ) {
 		static::register();
 
 		$context = stream_context_create( [
@@ -38,7 +41,12 @@ class VanillaStreamWrapper implements StreamWrapperInterface {
 	}
 
 
-	public function stream_set_option( int $option, int $arg1, ?int $arg2 ): bool {
+	/**
+  * @param int $option
+  * @param int $arg1
+  * @param int|null $arg2
+  */
+ public function stream_set_option( $option, $arg1, $arg2 = null ): bool {
 		if ( \STREAM_OPTION_BLOCKING === $option ) {
 			return stream_set_blocking( $this->stream, (bool) $arg1 );
 		} elseif ( \STREAM_OPTION_READ_TIMEOUT === $option ) {
@@ -64,7 +72,10 @@ class VanillaStreamWrapper implements StreamWrapperInterface {
 		return true;
 	}
 
-	public function stream_cast( int $cast_as ) {
+	/**
+  * @param int $cast_as
+  */
+ public function stream_cast( $cast_as ) {
 		return $this->stream;
 	}
 

--- a/src/WordPress/Util/Map.php
+++ b/src/WordPress/Util/Map.php
@@ -7,7 +7,7 @@ use IteratorAggregate;
 use Traversable;
 
 class Map implements ArrayAccess, IteratorAggregate {
-	private array $pairs = [];
+	private $pairs = [];
 
 	public function __construct() {
 	}
@@ -22,7 +22,8 @@ class Map implements ArrayAccess, IteratorAggregate {
 		return false;
 	}
 
-	public function offsetGet( $offset ): mixed {
+	#[\ReturnTypeWillChange]
+	public function offsetGet( $offset ) {
 		foreach ( $this->pairs as $pair ) {
 			if ( $pair[0] === $offset ) {
 				return $pair[1];
@@ -33,7 +34,7 @@ class Map implements ArrayAccess, IteratorAggregate {
 		throw new \Exception( "Stream for resource " . json_encode( $offset ) . " not found" );
 	}
 
-	public function offsetSet( $offset, $value ): void {
+	public function offsetSet( $offset, $value ) {
 		foreach ( $this->pairs as $k => $pair ) {
 			if ( $pair[0] === $offset ) {
 				$this->pairs[ $k ] = [ $offset, $value ];
@@ -44,7 +45,7 @@ class Map implements ArrayAccess, IteratorAggregate {
 		$this->pairs[] = [ $offset, $value ];
 	}
 
-	public function offsetUnset( $offset ): void {
+	public function offsetUnset( $offset ) {
 		foreach ( $this->pairs as $i => $pair ) {
 			if ( $pair[0] === $offset ) {
 				unset( $this->pairs[ $i ] );

--- a/src/WordPress/Zip/ZipCentralDirectoryEntry.php
+++ b/src/WordPress/Zip/ZipCentralDirectoryEntry.php
@@ -4,24 +4,24 @@ namespace WordPress\Zip;
 
 class ZipCentralDirectoryEntry {
 
-	public bool $isDirectory;
-	public int $firstByteAt;
-	public int $versionCreated;
-	public int $versionNeeded;
-	public int $generalPurpose;
-	public int $compressionMethod;
-	public int $lastModifiedTime;
-	public int $lastModifiedDate;
-	public int $crc;
-	public int $compressedSize;
-	public int $uncompressedSize;
-	public int $diskNumber;
-	public int $internalAttributes;
-	public int $externalAttributes;
-	public int $lastByteAt;
-	public string $path;
-	public string $extra;
-	public string $fileComment;
+	public $isDirectory;
+	public $firstByteAt;
+	public $versionCreated;
+	public $versionNeeded;
+	public $generalPurpose;
+	public $compressionMethod;
+	public $lastModifiedTime;
+	public $lastModifiedDate;
+	public $crc;
+	public $compressedSize;
+	public $uncompressedSize;
+	public $diskNumber;
+	public $internalAttributes;
+	public $externalAttributes;
+	public $lastByteAt;
+	public $path;
+	public $extra;
+	public $fileComment;
 
 	public function __construct(
 		int $versionCreated,
@@ -42,24 +42,24 @@ class ZipCentralDirectoryEntry {
 		string $extra,
 		string $fileComment
 	) {
-		$this->fileComment        = $fileComment;
-		$this->extra              = $extra;
-		$this->path               = $path;
-		$this->lastByteAt         = $lastByteAt;
+		$this->fileComment = $fileComment;
+		$this->extra = $extra;
+		$this->path = $path;
+		$this->lastByteAt = $lastByteAt;
 		$this->externalAttributes = $externalAttributes;
 		$this->internalAttributes = $internalAttributes;
-		$this->diskNumber         = $diskNumber;
-		$this->uncompressedSize   = $uncompressedSize;
-		$this->compressedSize     = $compressedSize;
-		$this->crc                = $crc;
-		$this->lastModifiedDate   = $lastModifiedDate;
-		$this->lastModifiedTime   = $lastModifiedTime;
-		$this->compressionMethod  = $compressionMethod;
-		$this->generalPurpose     = $generalPurpose;
-		$this->versionNeeded      = $versionNeeded;
-		$this->versionCreated     = $versionCreated;
-		$this->firstByteAt        = $firstByteAt;
-		$this->isDirectory        = $this->path[- 1] === '/';
+		$this->diskNumber = $diskNumber;
+		$this->uncompressedSize = $uncompressedSize;
+		$this->compressedSize = $compressedSize;
+		$this->crc = $crc;
+		$this->lastModifiedDate = $lastModifiedDate;
+		$this->lastModifiedTime = $lastModifiedTime;
+		$this->compressionMethod = $compressionMethod;
+		$this->generalPurpose = $generalPurpose;
+		$this->versionNeeded = $versionNeeded;
+		$this->versionCreated = $versionCreated;
+		$this->firstByteAt = $firstByteAt;
+		$this->isDirectory = $this->path[ - 1 ] === '/';
 	}
 
 	public function isFileEntry() {

--- a/src/WordPress/Zip/ZipEndCentralDirectoryEntry.php
+++ b/src/WordPress/Zip/ZipEndCentralDirectoryEntry.php
@@ -4,13 +4,34 @@ namespace WordPress\Zip;
 
 class ZipEndCentralDirectoryEntry {
 
-	public int $diskNumber;
-	public int $centralDirectoryStartDisk;
-	public int $numberCentralDirectoryRecordsOnThisDisk;
-	public int $numberCentralDirectoryRecords;
-	public int $centralDirectorySize;
-	public int $centralDirectoryOffset;
-	public string $comment;
+	/**
+  * @var int
+  */
+ public $diskNumber;
+	/**
+  * @var int
+  */
+ public $centralDirectoryStartDisk;
+	/**
+  * @var int
+  */
+ public $numberCentralDirectoryRecordsOnThisDisk;
+	/**
+  * @var int
+  */
+ public $numberCentralDirectoryRecords;
+	/**
+  * @var int
+  */
+ public $centralDirectorySize;
+	/**
+  * @var int
+  */
+ public $centralDirectoryOffset;
+	/**
+  * @var string
+  */
+ public $comment;
 
 	public function __construct(
 		int $diskNumber,

--- a/src/WordPress/Zip/ZipFileEntry.php
+++ b/src/WordPress/Zip/ZipFileEntry.php
@@ -3,18 +3,54 @@
 namespace WordPress\Zip;
 
 class ZipFileEntry {
-	public bool $isDirectory;
-	public int $version;
-	public int $generalPurpose;
-	public int $compressionMethod;
-	public int $lastModifiedTime;
-	public int $lastModifiedDate;
-	public int $crc;
-	public int $compressedSize;
-	public int $uncompressedSize;
-	public string $path;
-	public string $extra;
-	public string $bytes;
+	/**
+  * @var bool
+  */
+ public $isDirectory;
+	/**
+  * @var int
+  */
+ public $version;
+	/**
+  * @var int
+  */
+ public $generalPurpose;
+	/**
+  * @var int
+  */
+ public $compressionMethod;
+	/**
+  * @var int
+  */
+ public $lastModifiedTime;
+	/**
+  * @var int
+  */
+ public $lastModifiedDate;
+	/**
+  * @var int
+  */
+ public $crc;
+	/**
+  * @var int
+  */
+ public $compressedSize;
+	/**
+  * @var int
+  */
+ public $uncompressedSize;
+	/**
+  * @var string
+  */
+ public $path;
+	/**
+  * @var string
+  */
+ public $extra;
+	/**
+  * @var string
+  */
+ public $bytes;
 
 	public function __construct(
 		int $version,

--- a/src/WordPress/Zip/ZipStreamReader.php
+++ b/src/WordPress/Zip/ZipStreamReader.php
@@ -143,7 +143,7 @@ class ZipStreamReader {
 			$data['firstByteAt'] + 30 + $data['pathLength'] + $data['fileCommentLength'] + $data['extraLength'] + $data['compressionMethod'] - 1,
 			$path,
 			$extra,
-			$fileComment,
+			$fileComment
 		);
 	}
 


### PR DESCRIPTION
## PHP 7.0 Compatibility

Makes the Blueprints library syntax–compatible with PHP >= 7.0 with automated transpilation and manual adjustments.

The automated transpilation is done with [rector](https://github.com/rectorphp/rector),
which downgrades features specific to PHP 7.2 and later features to PHP 7.1.

The manual part requires using regexps and editing the files by hand.

### Automated part

To transpile the code to PHP 7.1, run:

```bash
# Install rector:
composer require rector/rector --ignore-platform-req=php

# Transpile:
php vendor/bin/rector process src
```

Unfortunately, Rector does not support downgrading to PHP 7.0 yet, so we need to do the
last stretch manually.

### Manual part

Rector will downgrade PHP code to PHP 7.1 but not further. We need PHP 7.0 compat
so here's a few additional regexps to run. Regexps are not, of course, reliable in
the general case, but they seem to do the trick here.

List of manual replacements

* `: \?[a-zA-Z_0-9]+` -> (empty string) to remove the unsupported return type
  from `function(): ?SchemaResolver {}` -> `function() {}`.
* `: iterable` to fix `Fatal error: Generators may only declare a return type of Generator, Iterator or Traversable`.
* `\?[a-zA-Z_0-9]+ \$` -> `$` to remove the unsupported nullable type from function signatures,
  e.g. `function(?Schema $schema){}` -> `function($schema){}`.
* `(protected|public|private) const` -> `const` as const visibility is not supported in PHP 7.0.
* `: void` -> `` as `void` return type is unsupported in PHP 7.0.
* `[$ns, $name] = $this->parseName($name);` -> `list($ns, $name) = $this->parseName($name);`
* `foreach ($data as [$cp, $chars]) {` -> `foreach ($data as list($cp, $chars)) {`
* Find or write Rector rules for downgrading to PHP 7.0
