### PR TITLE
Async HTTP Client PHP 7.0 fixes: Non-blocking mode after SSL handshake, recomputing the stream key

### DIFF
--- a/src/WordPress/AsyncHttp/async_http_streams.php
+++ b/src/WordPress/AsyncHttp/async_http_streams.php
@@ -76,7 +76,13 @@ function stream_http_open_nonblocking( $url ) {
 		throw new Exception( 'stream_socket_client() was unable to open a stream to ' . $url );
 	}
 
-	stream_set_blocking( $stream, 0 );
+	if ( PHP_VERSION_ID >= 72000 ) {
+		// In PHP <= 7.1 and later, making the socket non-blocking before the
+		// SSL handshake makes the stream_socket_enable_crypto() call always return
+		// false. Therefore, we only make the socket non-blocking after the
+		// SSL handshake.
+		stream_set_blocking( $stream, 0 );
+	}
 
 	return $stream;
 }
@@ -105,6 +111,10 @@ function streams_http_requests_send( $streams ) {
 		}
 
 		foreach ( $write as $k => $stream ) {
+			if ( PHP_VERSION_ID <= 71999 ) {
+				// In PHP <= 7.1, stream_select doesn't preserve the keys of the array
+				$k = array_search( $stream, $streams, true );
+			}
 			$enabled_crypto = stream_socket_enable_crypto( $stream, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT );
 			if ( false === $enabled_crypto ) {
 				throw new Exception( 'Failed to enable crypto: ' . error_get_last()['message'] );
@@ -114,6 +124,14 @@ function streams_http_requests_send( $streams ) {
 				// SSL handshake complete, send the request headers
 				$context = stream_context_get_options( $stream );
 				$request = stream_http_prepare_request_bytes( $context['socket']['originalUrl'] );
+
+				if ( PHP_VERSION_ID <= 72000 ) {
+					// In PHP <= 7.1 and later, making the socket non-blocking before the
+					// SSL handshake makes the stream_socket_enable_crypto() call always return
+					// false. Therefore, we only make the socket non-blocking after the
+					// SSL handshake.
+					stream_set_blocking( $stream, 0 );
+				}
 				fwrite( $stream, $request );
 				unset( $remaining_streams[ $k ] );
 			}
@@ -126,8 +144,8 @@ function streams_http_requests_send( $streams ) {
  * Waits for response bytes to be available in the given streams.
  *
  * @param array $streams The array of streams to wait for.
- * @param int   $length The number of bytes to read from each stream.
- * @param int   $timeout_microseconds The timeout in microseconds for the stream_select function.
+ * @param int $length The number of bytes to read from each stream.
+ * @param int $timeout_microseconds The timeout in microseconds for the stream_select function.
  *
  * @return array|false An array of chunks read from the streams, or false if no streams are available.
  * @throws Exception If an error occurs during the stream_select operation or if the operation times out.
@@ -149,6 +167,10 @@ function streams_http_response_await_bytes( $streams, $length, $timeout_microsec
 
 	$chunks = array();
 	foreach ( $read as $k => $stream ) {
+		if ( PHP_VERSION_ID <= 71999 ) {
+			// In PHP <= 7.1, stream_select doesn't preserve the keys of the array
+			$k = array_search( $stream, $streams, true );
+		}
 		$chunks[ $k ] = fread( $stream, $length );
 	}
 
@@ -224,16 +246,29 @@ function streams_http_response_await_headers( $streams ) {
 		$headers[ $k ] = '';
 	}
 	$remaining_streams = $streams;
+	$i                 = 0;
 	while ( true ) {
+		$keys  = implode( ",", array_keys( $remaining_streams ) );
 		$bytes = streams_http_response_await_bytes( $remaining_streams, 1 );
 		if ( false === $bytes ) {
 			break;
+		}
+		$keys2 = implode( ",", array_keys( $bytes ) );
+		if ( false === strpos( $keys, $keys2 ) ) {
+			var_dump( $keys, $keys2 );
+			throw new Exception( 'The keys of the remaining streams changed' );
 		}
 		foreach ( $bytes as $k => $byte ) {
 			$headers[ $k ] .= $byte;
 			if ( substr_compare( $headers[ $k ], "\r\n\r\n", - strlen( "\r\n\r\n" ) ) === 0 ) {
 				unset( $remaining_streams[ $k ] );
 			}
+		}
+		if ( ++ $i > 1000 ) {
+			print_r( $headers );
+			print_r( $remaining_streams );
+
+			throw new Exception( 'Too many iterations' );
 		}
 	}
 
@@ -259,7 +294,7 @@ function stream_monitor_progress( $stream, $onProgress ) {
 			$stream,
 			function ( $data ) use ( $onProgress ) {
 				static $streamedBytes = 0;
-				$streamedBytes       += strlen( $data );
+				$streamedBytes += strlen( $data );
 				$onProgress( $streamedBytes );
 			}
 		)

--- a/src/WordPress/AsyncHttp/async_http_streams.php
+++ b/src/WordPress/AsyncHttp/async_http_streams.php
@@ -126,10 +126,10 @@ function streams_http_requests_send( $streams ) {
 				$request = stream_http_prepare_request_bytes( $context['socket']['originalUrl'] );
 
 				if ( PHP_VERSION_ID <= 72000 ) {
-					// In PHP <= 7.1 and later, making the socket non-blocking before the
-					// SSL handshake makes the stream_socket_enable_crypto() call always return
-					// false. Therefore, we only make the socket non-blocking after the
-					// SSL handshake.
+// In PHP <= 7.1 and later, making the socket non-blocking before the
+// SSL handshake makes the stream_socket_enable_crypto() call always return
+// false. Therefore, we only make the socket non-blocking after the
+// SSL handshake.
 					stream_set_blocking( $stream, 0 );
 				}
 				fwrite( $stream, $request );
@@ -246,29 +246,16 @@ function streams_http_response_await_headers( $streams ) {
 		$headers[ $k ] = '';
 	}
 	$remaining_streams = $streams;
-	$i                 = 0;
 	while ( true ) {
-		$keys  = implode( ",", array_keys( $remaining_streams ) );
 		$bytes = streams_http_response_await_bytes( $remaining_streams, 1 );
 		if ( false === $bytes ) {
 			break;
-		}
-		$keys2 = implode( ",", array_keys( $bytes ) );
-		if ( false === strpos( $keys, $keys2 ) ) {
-			var_dump( $keys, $keys2 );
-			throw new Exception( 'The keys of the remaining streams changed' );
 		}
 		foreach ( $bytes as $k => $byte ) {
 			$headers[ $k ] .= $byte;
 			if ( substr_compare( $headers[ $k ], "\r\n\r\n", - strlen( "\r\n\r\n" ) ) === 0 ) {
 				unset( $remaining_streams[ $k ] );
 			}
-		}
-		if ( ++ $i > 1000 ) {
-			print_r( $headers );
-			print_r( $remaining_streams );
-
-			throw new Exception( 'Too many iterations' );
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/WordPress/blueprints-library/issues/79

Makes the AsyncHTTPClient usable in PHP 7.0 with two changes:

In PHP <= 7.1 and later, making the socket non-blocking before the SSL handshake makes the stream_socket_enable_crypto() call always return false. Therefore, we only make the socket non-blocking after the SSL handshake.

In PHP <= 7.1, stream_select doesn't preserve the keys of the array:

```php
stream_select( $read, $write, $except, 0, $timeout_microseconds );
// If $read is array( 1=> $fp ) before the stream_select() call,
// it will be array( 0 => $fp ) after.
foreach ( $read as $k => $stream ) {
	$chunks[ $k ] = fread( $stream, $length );
}
```

Therefore, we recompute the key using array_search() on these older PHP versions.