### PR TITLE
Refactor MkdirStepRunner and test it

### DIFF
--- a/src/WordPress/Blueprints/Runner/Step/MkdirStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/MkdirStepRunner.php
@@ -2,19 +2,22 @@
 
 namespace WordPress\Blueprints\Runner\Step;
 
+use Symfony\Component\Filesystem\Filesystem;
+use WordPress\Blueprints\BlueprintException;
 use WordPress\Blueprints\Model\DataClass\MkdirStep;
 
 
 class MkdirStepRunner extends BaseStepRunner {
 
 	/**
-	 * @param \WordPress\Blueprints\Model\DataClass\MkdirStep $input
+	 * @param MkdirStep $input
 	 */
-	function run( $input ) {
-		// @TODO: Treat $input->path as relative path to the document root (unless it's absolute)
-		$success = mkdir( $input->path );
-		if ( ! $success ) {
-			throw new \Exception( "Failed to create directory at {$input->path}" );
+	function run( MkdirStep $input ) {
+		$resolved_path = $this->getRuntime()->resolvePath( $input->path );
+		$filesystem   = new Filesystem();
+		if ( $filesystem->exists( $resolved_path ) ) {
+			throw new BlueprintException( "Failed to create \"$resolved_path\": the directory exists." );
 		}
+		$filesystem->mkdir( $resolved_path );
 	}
 }

--- a/tests/unit/steps/MkdirStepRunnerTest.php
+++ b/tests/unit/steps/MkdirStepRunnerTest.php
@@ -101,11 +101,10 @@ class MkdirStepRunnerTest extends PHPUnitTestCase {
     public function testThrowExceptionWhenCreatingDirectoryWhenDirectoryAlreadyExists() {
         $path = 'dir';
         $resolved_path = $this->runtime->resolvePath( $path );
+		$this->filesystem->mkdir( $resolved_path );
 
-        $step = new MkdirStep();
-        $step->setPath( $path );
-
-		$this->step_runner->run( $step );
+		$step = new MkdirStep();
+		$step->setPath( $path );
 
 		self::expectException( BlueprintException::class );
 		self::expectExceptionMessage( "Failed to create \"$resolved_path\": the directory exists." );

--- a/tests/unit/steps/MkdirStepRunnerTest.php
+++ b/tests/unit/steps/MkdirStepRunnerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace unit\steps;
+
+use PHPUnitTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+use WordPress\Blueprints\Model\DataClass\MkdirStep;
+use WordPress\Blueprints\Runner\Step\MkdirStepRunner;
+use WordPress\Blueprints\Runtime\Runtime;
+use WordPress\Blueprints\BlueprintException;
+
+class MkdirStepRunnerTest extends PHPUnitTestCase {
+	/**
+	 * @var string
+	 */
+	private $document_root;
+
+	/**
+	 * @var Runtime
+	 */
+	private $runtime;
+
+	/**
+	 * @var MkdirStepRunner
+	 */
+	private $step;
+
+	/**
+	 * @var Filesystem
+	 */
+	private $filesystem;
+
+	/**
+	 * @before
+	 */
+	public function before() {
+		$this->document_root = Path::makeAbsolute( "test", sys_get_temp_dir() );
+		$this->runtime = new Runtime( $this->document_root );
+
+		$this->step = new MkdirStepRunner();
+		$this->step->setRuntime( $this->runtime );
+
+		$this->filesystem = new Filesystem();
+	}
+
+	/**
+	 * @after
+	 */
+	public function after() {
+		$this->filesystem->remove( $this->document_root );
+	}
+
+    public function testCreateDirectoryWhenUsingRelativePath() {
+        $path = 'dir';
+        $input = new MkdirStep();
+		$input->setPath( $path );
+
+        $this->step->run( $input );
+		$resolved_path = $this->runtime->resolvePath( $path );
+
+		self::assertDirectoryExists( $resolved_path );
+    }
+
+    public function testCreateDirectoryWhenUsingAbsoluteAbsolutePath() {
+        $relative_path = 'dir';
+        $resolved_path = $this->runtime->resolvePath( $relative_path );
+
+        $input = new MkdirStep();
+        $input->setPath( $resolved_path );
+
+        $this->step->run( $input );
+        
+        self::assertDirectoryExists( $resolved_path );
+    }
+
+    public function testCreateDirectoryRecursively() {
+        $path = 'dir/subdir';
+        $input = new MkdirStep();
+        $input->setPath( $path );
+
+        $this->step->run( $input );
+
+        $resolved_path = $this->runtime->resolvePath( $path );
+        self::assertDirectoryExists( $resolved_path );
+    }
+
+	public function testCreateDirectoryWithProperMode() {
+		$path = 'dir';
+		$input = new MkdirStep();
+		$input->setPath( $path );
+
+		$this->step->run( $input );
+
+		$resolved_path = $this->runtime->resolvePath( $path );
+		self::assertDirectoryExists( $resolved_path );
+		self::assertDirectoryIsWritable( $resolved_path );
+		self::assertDirectoryIsReadable( $resolved_path );
+	}
+    
+    public function testThrowExceptionWhenCreatingDirectoryWhenDirectoryAlreadyExists() {
+        $path = 'dir';
+        $resolved_path = $this->runtime->resolvePath( $path );
+
+        $input = new MkdirStep();
+        $input->setPath( $path );
+
+		$this->step->run( $input );
+
+		self::expectException( BlueprintException::class );
+		self::expectExceptionMessage( "Failed to create \"$resolved_path\": the directory exists." );
+        $this->step->run( $input );
+    }
+}

--- a/tests/unit/steps/MkdirStepRunnerTest.php
+++ b/tests/unit/steps/MkdirStepRunnerTest.php
@@ -24,7 +24,7 @@ class MkdirStepRunnerTest extends PHPUnitTestCase {
 	/**
 	 * @var MkdirStepRunner
 	 */
-	private $step;
+	private $step_runner;
 
 	/**
 	 * @var Filesystem
@@ -38,8 +38,8 @@ class MkdirStepRunnerTest extends PHPUnitTestCase {
 		$this->document_root = Path::makeAbsolute( "test", sys_get_temp_dir() );
 		$this->runtime = new Runtime( $this->document_root );
 
-		$this->step = new MkdirStepRunner();
-		$this->step->setRuntime( $this->runtime );
+		$this->step_runner = new MkdirStepRunner();
+		$this->step_runner->setRuntime( $this->runtime );
 
 		$this->filesystem = new Filesystem();
 	}
@@ -53,10 +53,10 @@ class MkdirStepRunnerTest extends PHPUnitTestCase {
 
     public function testCreateDirectoryWhenUsingRelativePath() {
         $path = 'dir';
-        $input = new MkdirStep();
-		$input->setPath( $path );
+        $step = new MkdirStep();
+		$step->setPath( $path );
 
-        $this->step->run( $input );
+        $this->step_runner->run( $step );
 		$resolved_path = $this->runtime->resolvePath( $path );
 
 		self::assertDirectoryExists( $resolved_path );
@@ -66,20 +66,20 @@ class MkdirStepRunnerTest extends PHPUnitTestCase {
         $relative_path = 'dir';
         $resolved_path = $this->runtime->resolvePath( $relative_path );
 
-        $input = new MkdirStep();
-        $input->setPath( $resolved_path );
+        $step = new MkdirStep();
+        $step->setPath( $resolved_path );
 
-        $this->step->run( $input );
+        $this->step_runner->run( $step );
         
         self::assertDirectoryExists( $resolved_path );
     }
 
     public function testCreateDirectoryRecursively() {
         $path = 'dir/subdir';
-        $input = new MkdirStep();
-        $input->setPath( $path );
+        $step = new MkdirStep();
+        $step->setPath( $path );
 
-        $this->step->run( $input );
+        $this->step_runner->run( $step );
 
         $resolved_path = $this->runtime->resolvePath( $path );
         self::assertDirectoryExists( $resolved_path );
@@ -87,10 +87,10 @@ class MkdirStepRunnerTest extends PHPUnitTestCase {
 
 	public function testCreateDirectoryWithProperMode() {
 		$path = 'dir';
-		$input = new MkdirStep();
-		$input->setPath( $path );
+		$step = new MkdirStep();
+		$step->setPath( $path );
 
-		$this->step->run( $input );
+		$this->step_runner->run( $step );
 
 		$resolved_path = $this->runtime->resolvePath( $path );
 		self::assertDirectoryExists( $resolved_path );
@@ -102,13 +102,13 @@ class MkdirStepRunnerTest extends PHPUnitTestCase {
         $path = 'dir';
         $resolved_path = $this->runtime->resolvePath( $path );
 
-        $input = new MkdirStep();
-        $input->setPath( $path );
+        $step = new MkdirStep();
+        $step->setPath( $path );
 
-		$this->step->run( $input );
+		$this->step_runner->run( $step );
 
 		self::expectException( BlueprintException::class );
 		self::expectExceptionMessage( "Failed to create \"$resolved_path\": the directory exists." );
-        $this->step->run( $input );
+        $this->step_runner->run( $step );
     }
 }

--- a/tests/unit/steps/MkdirStepRunnerTest.php
+++ b/tests/unit/steps/MkdirStepRunnerTest.php
@@ -51,41 +51,41 @@ class MkdirStepRunnerTest extends PHPUnitTestCase {
 		$this->filesystem->remove( $this->document_root );
 	}
 
-    public function testCreateDirectoryWhenUsingRelativePath() {
-        $path = 'dir';
-        $step = new MkdirStep();
+	public function testCreateDirectoryWhenUsingRelativePath() {
+		$path = 'dir';
+		$step = new MkdirStep();
 		$step->setPath( $path );
 
-        $this->step_runner->run( $step );
+		$this->step_runner->run( $step );
+
 		$resolved_path = $this->runtime->resolvePath( $path );
-
 		self::assertDirectoryExists( $resolved_path );
-    }
+	}
 
-    public function testCreateDirectoryWhenUsingAbsoluteAbsolutePath() {
-        $relative_path = 'dir';
-        $resolved_path = $this->runtime->resolvePath( $relative_path );
+	public function testCreateDirectoryWhenUsingAbsolutePath() {
+		$relative_path = 'dir';
+		$absolute_path = $this->runtime->resolvePath( $relative_path );
 
-        $step = new MkdirStep();
-        $step->setPath( $resolved_path );
+		$step = new MkdirStep();
+		$step->setPath( $absolute_path );
 
-        $this->step_runner->run( $step );
-        
-        self::assertDirectoryExists( $resolved_path );
-    }
+		$this->step_runner->run( $step );
 
-    public function testCreateDirectoryRecursively() {
-        $path = 'dir/subdir';
-        $step = new MkdirStep();
-        $step->setPath( $path );
+		self::assertDirectoryExists( $absolute_path );
+	}
 
-        $this->step_runner->run( $step );
+	public function testCreateDirectoryRecursively() {
+		$path = 'dir/subdir';
+		$step = new MkdirStep();
+		$step->setPath( $path );
 
-        $resolved_path = $this->runtime->resolvePath( $path );
-        self::assertDirectoryExists( $resolved_path );
-    }
+		$this->step_runner->run( $step );
 
-	public function testCreateDirectoryWithProperMode() {
+		$resolved_path = $this->runtime->resolvePath( $path );
+		self::assertDirectoryExists( $resolved_path );
+	}
+
+	public function testCreateReadableAndWritableDirectory() {
 		$path = 'dir';
 		$step = new MkdirStep();
 		$step->setPath( $path );
@@ -97,10 +97,10 @@ class MkdirStepRunnerTest extends PHPUnitTestCase {
 		self::assertDirectoryIsWritable( $resolved_path );
 		self::assertDirectoryIsReadable( $resolved_path );
 	}
-    
-    public function testThrowExceptionWhenCreatingDirectoryWhenDirectoryAlreadyExists() {
-        $path = 'dir';
-        $resolved_path = $this->runtime->resolvePath( $path );
+
+	public function testThrowExceptionWhenCreatingDirectoryAndItAlreadyExists() {
+		$path = 'dir';
+		$resolved_path = $this->runtime->resolvePath( $path );
 		$this->filesystem->mkdir( $resolved_path );
 
 		$step = new MkdirStep();
@@ -108,6 +108,6 @@ class MkdirStepRunnerTest extends PHPUnitTestCase {
 
 		self::expectException( BlueprintException::class );
 		self::expectExceptionMessage( "Failed to create \"$resolved_path\": the directory exists." );
-        $this->step_runner->run( $step );
-    }
+		$this->step_runner->run( $step );
+	}
 }


### PR DESCRIPTION
### What does this PR do?

`MkdirStepRunner` will now:
- handle both relative and absolute paths
- throw an exception if the directory it wants to create already exists
- throw an original Symfony Filesystem `IOException` not rewrapping it into a `BlueprintException`, as agreed in #65

### What problem does it fix?
- until now the runner would only handle absolute paths
- has thrown an exception in a bad way
- we use this step in the `examples` directory, and since it only accepted absolute paths and we have provided it a relative path the example was flawed

### How to test if it works?
- this PR includes a full suite of tests for this runner