### PR TITLE
Fix zip compatibility issue

### DIFF
--- a/src/WordPress/Blueprints/Runner/Step/UnzipStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/UnzipStepRunner.php
@@ -12,12 +12,12 @@ class UnzipStepRunner extends BaseStepRunner {
 	 * Runs the Unzip Step
 	 *
 	 * @param UnzipStep $input Step.
-	 * @param Tracker   $progress_tracker Tracker.
+	 * @param Tracker $progress_tracker Tracker.
 	 * @return void
 	 */
 	public function run(
-		$input,
-		$progress_tracker
+		UnzipStep $input,
+		Tracker   $progress_tracker
 	) {
 		$progress_tracker->set( 10, 'Unzipping...' );
 

--- a/src/WordPress/Zip/ZipCentralDirectoryEntry.php
+++ b/src/WordPress/Zip/ZipCentralDirectoryEntry.php
@@ -59,7 +59,7 @@ class ZipCentralDirectoryEntry {
 		$this->versionNeeded      = $versionNeeded;
 		$this->versionCreated     = $versionCreated;
 		$this->firstByteAt        = $firstByteAt;
-		$this->isDirectory        = $this->path[- 1] === '/';
+		$this->isDirectory        = substr( $this->path, -1 ) === '/';
 	}
 
 	public function isFileEntry() {

--- a/src/WordPress/Zip/ZipFileEntry.php
+++ b/src/WordPress/Zip/ZipFileEntry.php
@@ -76,7 +76,7 @@ class ZipFileEntry {
 		$this->compressionMethod = $compressionMethod;
 		$this->generalPurpose    = $generalPurpose;
 		$this->version           = $version;
-		$this->isDirectory       = $this->path[- 1] === '/';
+		$this->isDirectory       = substr( $this->path, -1 ) === '/';
 	}
 
 	public function isFileEntry() {

--- a/tests/unit/steps/UnzipStepRunnerTest.php
+++ b/tests/unit/steps/UnzipStepRunnerTest.php
@@ -2,6 +2,7 @@
 
 namespace unit\steps;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnitTestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -25,17 +26,17 @@ class UnzipStepRunnerTest extends PHPUnitTestCase {
 	private $runtime;
 
 	/**
-	 * @var UnzipStepRunner $step
+	 * @var UnzipStepRunner $step_runner
 	 */
-	private $step;
+	private $step_runner;
 
 	/**
 	 * @var Filesystem
 	 */
-	private $file_system;
+	private $filesystem;
 
 	/**
-	 * @var Stub
+	 * @var ResourceManager&MockObject $resource_manager resource manager mock
 	 */
 	private $resource_manager;
 
@@ -48,51 +49,47 @@ class UnzipStepRunnerTest extends PHPUnitTestCase {
 
 		$this->resource_manager = $this->createMock( ResourceManager::class );
 
-		$this->step = new UnzipStepRunner();
-		$this->step->setRuntime( $this->runtime );
-		$this->step->setResourceManager( $this->resource_manager );
+		$this->step_runner = new UnzipStepRunner();
+		$this->step_runner->setRuntime( $this->runtime );
+		$this->step_runner->setResourceManager( $this->resource_manager );
 
-		$this->file_system = new Filesystem();
+		$this->filesystem = new Filesystem();
 	}
 
 	/**
 	 * @after
 	 */
 	public function after() {
-		$this->file_system->remove( $this->document_root );
+		$this->filesystem->remove( $this->document_root );
 	}
 
-	public function test(){
-		$this->assertTrue(true); // Placeholder until true test are fixed.
+	public function testUnzipFileWhenUsingAbsolutePath() {
+		$zip = __DIR__ . '/resources/test_zip.zip';
+		$this->resource_manager->method( 'getStream' )
+			->willReturn( fopen( $zip, 'rb' ) );
+
+		$step = new UnzipStep();
+		$step->setZipFile( $zip );
+		$extracted_file_path = $this->runtime->resolvePath( 'dir/test_zip.txt' );
+		$step->setExtractToPath( Path::getDirectory( $extracted_file_path ) );
+
+		$this->step_runner->run( $step, new Tracker() );
+
+		self::assertFileEquals( __DIR__ . '/resources/test_zip.txt', $extracted_file_path );
 	}
 
-//	public function testUnzipFileWhenUsingAbsolutePath() {
-//		$zip = __DIR__ . '/resources/test_zip.zip';
-//		$this->resource_manager->method( 'getStream' )
-//			->willReturn( fopen( $zip, 'rb' ) );
-//
-//		$input = new UnzipStep();
-//		$input->setZipFile( $zip );
-//		$extracted_file_path = $this->runtime->resolvePath( 'dir/test_zip.txt' );
-//		$input->setExtractToPath( Path::getDirectory( $extracted_file_path ) );
-//
-//		$this->step->run( $input, new Tracker() );
-//
-//		$this->assertFileEquals( __DIR__ . '/resources/test_zip.txt', $extracted_file_path );
-//	}
-//
-//	public function testUnzipFileWhenUsingRelativePath() {
-//		$zip = __DIR__ . '/resources/test_zip.zip';
-//		$this->resource_manager->method( 'getStream' )
-//			->willReturn( fopen( $zip, 'rb' ) );
-//
-//		$input = new UnzipStep();
-//		$input->setZipFile( $zip );
-//		$input->setExtractToPath( 'dir' );
-//
-//		$this->step->run( $input, new Tracker() );
-//
-//		$extracted_file_path = $this->runtime->resolvePath( 'dir/test_zip.txt' );
-//		$this->assertFileEquals( __DIR__ . '/resources/test_zip.txt', $extracted_file_path );
-//	}
+	public function testUnzipFileWhenUsingRelativePath() {
+		$zip = __DIR__ . '/resources/test_zip.zip';
+		$this->resource_manager->method( 'getStream' )
+			->willReturn( fopen( $zip, 'rb' ) );
+
+		$step = new UnzipStep();
+		$step->setZipFile( $zip );
+		$step->setExtractToPath( 'dir' );
+
+		$this->step_runner->run( $step, new Tracker() );
+
+		$extracted_file_path = $this->runtime->resolvePath( 'dir/test_zip.txt' );
+		self::assertFileEquals( __DIR__ . '/resources/test_zip.txt', $extracted_file_path );
+	}
 }


### PR DESCRIPTION
### What does this PR do?
- `UnzipStepRunner` tests will now pass for all supported PHP versions
- some variables in the test were renamed for better readability and to match linting standards 

### What problem does it fix?

- the `ZipCentralDirectoryEntry` and `ZipFileEntry` had some code that was PHP == 7.0 incompatible
- some tests for the `UnzipStepRunner` were commented out since it broke the pipeline for PHP == 7.0

### How to test if it works?
- this PR includes tests for `UnzipStepRunner`
- all tests should pass for all supported PHP versions