### PR TITLE
Clean up `RmStepRunner` and its tests

### DIFF
--- a/src/WordPress/Blueprints/Runner/Step/RmStepRunner.php
+++ b/src/WordPress/Blueprints/Runner/Step/RmStepRunner.php
@@ -12,16 +12,12 @@ class RmStepRunner extends BaseStepRunner {
 	/**
 	 * @param RmStep $input
 	 */
-	public function run( $input ) {
-		$resolvedPath = $this->getRuntime()->resolvePath( $input->path );
-		$fileSystem   = new Filesystem();
-		if ( false === $fileSystem->exists( $resolvedPath ) ) {
-			throw new BlueprintException( "Failed to remove \"$resolvedPath\": the directory or file does not exist." );
+	public function run( RmStep $input ) {
+		$resolved_path = $this->getRuntime()->resolvePath( $input->path );
+		$filesystem   = new Filesystem();
+		if ( false === $filesystem->exists( $resolved_path ) ) {
+			throw new BlueprintException( "Failed to remove \"$resolved_path\": the directory or file does not exist." );
 		}
-		try {
-			$fileSystem->remove( $resolvedPath );
-		} catch ( IOException $exception ) {
-			throw new BlueprintException( "Failed to remove the directory or file at \"$resolvedPath\"", 0, $exception );
-		}
+		$filesystem->remove( $resolved_path );
 	}
 }

--- a/tests/unit/steps/RmStepRunnerTest.php
+++ b/tests/unit/steps/RmStepRunnerTest.php
@@ -10,166 +10,154 @@ use WordPress\Blueprints\Model\DataClass\RmStep;
 use WordPress\Blueprints\Runner\Step\RmStepRunner;
 use WordPress\Blueprints\Runtime\Runtime;
 
-class RmStepRunnerTest extends PHPUnitTestCase
-{
-    /**
-     * @var string
-     */
-    private $documentRoot;
+class RmStepRunnerTest extends PHPUnitTestCase {
+	/**
+	 * @var string
+	 */
+	private $document_root;
 
-    /**
-     * @var Runtime
-     */
-    private $runtime;
+	/**
+	 * @var Runtime
+	 */
+	private $runtime;
 
-    /**
-     * @var RmStepRunner
-     */
-    private $step;
+	/**
+	 * @var RmStepRunner
+	 */
+	private $step_runner;
 
-    /**
-     * @var Filesystem
-     */
-    private $fileSystem;
+	/**
+	 * @var Filesystem
+	 */
+	private $filesystem;
 
-    /**
-     * @before
-     */
-    public function before()
-    {
-        $this->documentRoot = Path::makeAbsolute("test", sys_get_temp_dir());
-        $this->runtime = new Runtime($this->documentRoot);
+	/**
+	 * @before
+	 */
+	public function before() {
+		$this->document_root = Path::makeAbsolute( "test", sys_get_temp_dir() );
+		$this->runtime = new Runtime( $this->document_root );
 
-        $this->step = new RmStepRunner();
-        $this->step->setRuntime($this->runtime);
+		$this->step_runner = new RmStepRunner();
+		$this->step_runner->setRuntime( $this->runtime );
 
-        $this->fileSystem = new Filesystem();
-    }
+		$this->filesystem = new Filesystem();
+	}
 
-    /**
-     * @after
-     */
-    public function after()
-    {
-        $this->fileSystem->remove($this->documentRoot);
-    }
+	/**
+	 * @after
+	 */
+	public function after() {
+		$this->filesystem->remove( $this->document_root );
+	}
 
-    public function testRemoveDirectoryWhenUsingAbsolutePath()
-    {
-        $absolutePath = $this->runtime->resolvePath("dir");
-        $this->fileSystem->mkdir($absolutePath);
+	public function testRemoveDirectoryWhenUsingAbsolutePath() {
+		$absolute_path = $this->runtime->resolvePath( "dir" );
+		$this->filesystem->mkdir( $absolute_path );
 
-        $input = new RmStep();
-        $input->path = $absolutePath;
+		$step = new RmStep();
+		$step->path = $absolute_path;
 
-        $this->step->run($input);
+		$this->step_runner->run( $step );
 
-        $this->assertDirectoryDoesNotExist($absolutePath);
-    }
+		self::assertDirectoryDoesNotExist( $absolute_path );
+	}
 
-    public function testRemoveDirectoryWhenUsingRelativePath()
-    {
-        $relativePath = "dir";
-        $absolutePath = $this->runtime->resolvePath($relativePath);
-        $this->fileSystem->mkdir($absolutePath);
+	public function testRemoveDirectoryWhenUsingRelativePath() {
+		$relative_path = "dir";
+		$absolute_path = $this->runtime->resolvePath( $relative_path );
+		$this->filesystem->mkdir( $absolute_path );
 
-        $input = new RmStep();
-        $input->path = $relativePath;
+		$step = new RmStep();
+		$step->path = $relative_path;
 
-        $this->step->run($input);
+		$this->step_runner->run( $step );
 
-        $this->assertDirectoryDoesNotExist($absolutePath);
-    }
+		self::assertDirectoryDoesNotExist( $absolute_path );
+	}
 
-    public function testRemoveDirectoryWithSubdirectory()
-    {
-        $relativePath = "dir/subdir";
-        $absolutePath = $this->runtime->resolvePath($relativePath);
-        $this->fileSystem->mkdir($absolutePath);
+	public function testRemoveDirectoryWithSubdirectory() {
+		$relative_path = "dir/subdir";
+		$absolute_path = $this->runtime->resolvePath( $relative_path );
+		$this->filesystem->mkdir( $absolute_path );
 
-        $input = new RmStep();
-        $input->path = dirname($relativePath);
+		$step = new RmStep();
+		$step->path = dirname( $relative_path );
 
-        $this->step->run($input);
+		$this->step_runner->run( $step );
 
-        $this->assertDirectoryDoesNotExist($absolutePath);
-    }
+		self::assertDirectoryDoesNotExist( $absolute_path );
+	}
 
-    public function testRemoveDirectoryWithFile()
-    {
-        $relativePath = "dir/file.txt";
-        $absolutePath = $this->runtime->resolvePath($relativePath);
-        $this->fileSystem->dumpFile($absolutePath, "test");
+	public function testRemoveDirectoryWithFile() {
+		$relative_path = "dir/file.txt";
+		$absolute_pPath = $this->runtime->resolvePath( $relative_path );
+		$this->filesystem->dumpFile( $absolute_pPath, "test" );
 
-        $input = new RmStep();
-        $input->path = dirname($relativePath);
+		$step = new RmStep();
+		$step->path = dirname( $relative_path );
 
-        $this->step->run($input);
+		$this->step_runner->run( $step );
 
-        $this->assertDirectoryDoesNotExist(dirname($absolutePath));
-    }
+		self::assertDirectoryDoesNotExist( dirname( $absolute_pPath ) );
+	}
 
-    public function testRemoveFile()
-    {
-        $relativePath = "file.txt";
-        $absolutePath = $this->runtime->resolvePath($relativePath);
-        $this->fileSystem->dumpFile($absolutePath, "test");
+	public function testRemoveFile() {
+		$relative_path = "file.txt";
+		$absolute_path = $this->runtime->resolvePath( $relative_path );
+		$this->filesystem->dumpFile( $absolute_path, "test" );
 
-        $input = new RmStep();
-        $input->path = $relativePath;
+		$step = new RmStep();
+		$step->path = $relative_path;
 
-        $this->step->run($input);
+		$this->step_runner->run( $step );
 
-        $this->assertDirectoryDoesNotExist($absolutePath);
-    }
+		self::assertDirectoryDoesNotExist( $absolute_path );
+	}
 
-    public function testThrowExceptionWhenRemovingNonexistentDirectoryAndUsingRelativePath()
-    {
-        $relativePath = "dir";
-        $absolutePath = $this->runtime->resolvePath($relativePath);
+	public function testThrowExceptionWhenRemovingNonexistentDirectoryAndUsingRelativePath() {
+		$relative_path = "dir";
+		$absolute_path = $this->runtime->resolvePath( $relative_path );
 
-        $input = new RmStep();
-        $input->path = $relativePath;
+		$step = new RmStep();
+		$step->path = $relative_path;
 
-        $this->expectException(BlueprintException::class);
-        $this->expectExceptionMessage("Failed to remove \"$absolutePath\": the directory or file does not exist.");
-        $this->step->run($input);
-    }
+		self::expectException( BlueprintException::class );
+		self::expectExceptionMessage( "Failed to remove \"$absolute_path\": the directory or file does not exist." );
+		$this->step_runner->run( $step );
+	}
 
-    public function testThrowExceptionWhenRemovingNonexistentDirectoryAndUsingAbsolutePath()
-    {
-        $absolutePath = "/dir";
+	public function testThrowExceptionWhenRemovingNonexistentDirectoryAndUsingAbsolutePath() {
+		$absolute_path = "/dir";
 
-        $input = new RmStep();
-        $input->path = $absolutePath;
+		$step = new RmStep();
+		$step->path = $absolute_path;
 
-        $this->expectException(BlueprintException::class);
-        $this->expectExceptionMessage("Failed to remove \"$absolutePath\": the directory or file does not exist.");
-        $this->step->run($input);
-    }
+		self::expectException( BlueprintException::class );
+		self::expectExceptionMessage( "Failed to remove \"$absolute_path\": the directory or file does not exist." );
+		$this->step_runner->run( $step );
+	}
 
-    public function testThrowExceptionWhenRemovingNonexistentFileAndUsingAbsolutePath()
-    {
-        $relativePath = "/file.txt";
+	public function testThrowExceptionWhenRemovingNonexistentFileAndUsingAbsolutePath() {
+		$relative_path = "/file.txt";
 
-        $input = new RmStep();
-        $input->path = $relativePath;
+		$step = new RmStep();
+		$step->path = $relative_path;
 
-        $this->expectException(BlueprintException::class);
-        $this->expectExceptionMessage("Failed to remove \"$relativePath\": the directory or file does not exist.");
-        $this->step->run($input);
-    }
+		self::expectException( BlueprintException::class );
+		self::expectExceptionMessage( "Failed to remove \"$relative_path\": the directory or file does not exist." );
+		$this->step_runner->run( $step );
+	}
 
-    public function testThrowExceptionWhenRemovingNonexistentFileAndUsingRelativePath()
-    {
-        $relativePath = "file.txt";
-        $absolutePath = $this->runtime->resolvePath($relativePath);
+	public function testThrowExceptionWhenRemovingNonexistentFileAndUsingRelativePath() {
+		$relativePath = "file.txt";
+		$absolutePath = $this->runtime->resolvePath($relativePath);
 
-        $input = new RmStep();
-        $input->path = $relativePath;
+		$step = new RmStep();
+		$step->path = $relativePath;
 
-        $this->expectException(BlueprintException::class);
-        $this->expectExceptionMessage("Failed to remove \"$absolutePath\": the directory or file does not exist.");
-        $this->step->run($input);
-    }
+		self::expectException( BlueprintException::class );
+		self::expectExceptionMessage( "Failed to remove \"$absolutePath\": the directory or file does not exist." );
+		$this->step_runner->run( $step );
+	}
 }


### PR DESCRIPTION
### What does this PR do?
- removes the try / catch block from the `RmStepRunner`
- renames some variables in the test class for better readability and to match linting standards

### What problem does it fix?
- the runner was catching IOExceptions, but we agreed it shouldn't #65
- some variables could've been named better

### How to test if it works?
- this PR includes tests for `RmStepRunner`
- all tests should pass for all supported PHP versions