### PR TITLE
Remove BlueprintBuilder as a possible runner input type

### DIFF
--- a/src/WordPress/Blueprints/BlueprintParser.php
+++ b/src/WordPress/Blueprints/BlueprintParser.php
@@ -4,6 +4,7 @@ namespace WordPress\Blueprints;
 
 use InvalidArgumentException;
 use Opis\JsonSchema\Errors\ErrorFormatter;
+use stdClass;
 use WordPress\Blueprints\Model\BlueprintBuilder;
 use WordPress\Blueprints\Model\DataClass\Blueprint;
 
@@ -27,8 +28,13 @@ class BlueprintParser {
 		$this->mapper    = $mapper;
 	}
 
+	/**
+	 * @param Blueprint|string|stdClass $raw_blueprint
+	 * @return Blueprint
+	 * @throws InvalidArgumentException if unsupported input type or json string can not be decoded
+	 */
 	public function parse( $raw_blueprint ) {
-		if ( $raw_blueprint instanceof \stdClass ) {
+		if ( $raw_blueprint instanceof stdClass ) {
 			return $this->fromObject( $raw_blueprint );
 		}
 
@@ -46,17 +52,13 @@ class BlueprintParser {
 			return $this->fromBlueprint( $raw_blueprint );
 		}
 
-		if ( $raw_blueprint instanceof BlueprintBuilder ) {
-			return $this->fromBlueprint( $raw_blueprint->toBlueprint() );
-		}
-
 		throw new InvalidArgumentException(
-			'Unsupported $rawBlueprint type. Use a JSON string, a parsed JSON object, or a BlueprintBuilder instance.'
+			'Unsupported $rawBlueprint type. Use a JSON string, a parsed JSON object, or a Blueprint instance.'
 		);
 	}
 
 	/**
-	 * @param \stdClass $data
+	 * @param stdClass $data
 	 */
 	public function fromObject( $data ) {
 		$result = $this->validator->validate( $data );


### PR DESCRIPTION
### What does this PR do?
- removes the possibility of parsing a Blueprint from a BlueprintBuilder 
### What problem does it fix?
- the BlueprintParser's method parse could accept a BlueprintBuilder object as a potential input which could lead to errors

As context: 
- the only difference between passing a Blueprint and a BlueprintBuilder was that the method `toBlueprint()` was called for the builder, which has little utility
- calling the method `toBlueprint()` on a specific instance of the BlueprintBuilder always returns the same instance of a `Blueprint`
- this leads to an issue where someone:
     - creates a builder,
     - sets some of the variables,
     - runs the code with success, 
     - sets some more variables,
     - runs it expecting another blueprint being generated and receives an error.
- running the same Blueprint twice greatly confuses the program.   
  
In conclusion:
- the user expected the builder to generate another instance of a Blueprint, but it just set some values to the first instance. The runner extracted the first instance instead of creating a new one.
    
The explicit source of this particular error will be fixed in another PR, but as an example of what could go wrong:
`InvalidArgumentException: Progress cannot go backwards (tried updating to 3.0105460023897 when it already was 3.0157410774586)`
   
### How to test if it works?
- this PR only removes an execution path from the parser