### PR TITLE
Fix issues in HTTP client

### DIFF
--- a/src/WordPress/AsyncHttp/Client.php
+++ b/src/WordPress/AsyncHttp/Client.php
@@ -192,7 +192,7 @@ class Client {
 
 		foreach ( $streams as $k => $stream ) {
 			$request                            = $enqueued[ $k ];
-			$total                              = $response_headers[ $k ]['headers']['content-length'];
+			$total                              = $response_headers[ $k ]['headers']['content-length'] ?? null;
 			$this->requests[ $request ]->state  = RequestInfo::STATE_STREAMING;
 			$this->requests[ $request ]->stream = stream_monitor_progress(
 				$stream,

--- a/src/WordPress/AsyncHttp/async_http_streams.php
+++ b/src/WordPress/AsyncHttp/async_http_streams.php
@@ -219,18 +219,17 @@ function stream_http_prepare_request_bytes( $url ) {
 	$parts   = parse_url( $url );
 	$host    = $parts['host'];
 	$path    = $parts['path'] . ( isset( $parts['query'] ) ? '?' . $parts['query'] : '' );
-	$request = <<<REQUEST
-GET $path HTTP/1.0
-Host: $host
-User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36
-Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
-Accept-Language: en-US,en;q=0.9
-Connection: close
-REQUEST;
+	$request_parts = array(
+		"GET $path HTTP/1.0",
+		"Host: $host",
+		"User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36",
+		"Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+		"Accept-Language: en-US,en;q=0.9",
+		"Connection: close"
+	);
 
 	// @TODO: Add support for Accept-Encoding: gzip
-
-	return $request . "\r\n\r\n";
+	return implode( "\r\n", $request_parts ) . "\r\n\r\n";
 }
 
 /**

--- a/src/WordPress/AsyncHttp/async_http_streams.php
+++ b/src/WordPress/AsyncHttp/async_http_streams.php
@@ -220,7 +220,7 @@ function stream_http_prepare_request_bytes( $url ) {
 	$host    = $parts['host'];
 	$path    = $parts['path'] . ( isset( $parts['query'] ) ? '?' . $parts['query'] : '' );
 	$request = <<<REQUEST
-GET $path HTTP/1.1
+GET $path HTTP/1.0
 Host: $host
 User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
@@ -230,7 +230,7 @@ REQUEST;
 
 	// @TODO: Add support for Accept-Encoding: gzip
 
-	return str_replace( "\n", "\r\n", $request ) . "\r\n\r\n";
+	return $request . "\r\n\r\n";
 }
 
 /**


### PR DESCRIPTION
### Summary
This pull request introduces fixes to the HTTP client as described in #104.

### Major Changes:
- temporary change of protocol HTTP/1.1 -> HTTP/1.0 - HTTP/1.0 doesn't support Transfer-Encoding: chunked and thus temporarily solves the dechunking problem, until some more robust solution is implemented,
- additional null-check for Content-Length header, when assigning total bytes size in HTTP client, which otherwise resulted in an `PHP Notice:  Undefined index: content-length`
- removal of excessive line-ending replacement - the explicit replacement from "\n" to "\r\n" broke sending requests on Windows.

### How to Test
After checking out to the feature branch, run `blueprint_compiling_simple_progress.php` script. The script passes all steps connected with downloading and installing WordPress (but still does not complete). 

### Notes
- the `blueprint_compiling_simple_progress.php` script fails on my machine at step DefineWpConfigConsts, at the moment I'm not sure why, but I'll create a separate issue describing the problem
- the change of protocol is only temporary and will allow further work on #82 @reimic 
