### PR TITLE
Rework ci and add e2e tests scaffolding

### DIFF
--- a/.github/workflows/automatic-dispatch.yml
+++ b/.github/workflows/automatic-dispatch.yml
@@ -1,10 +1,6 @@
-name: PHPUnit Tests
+name: Automatic Tests Dispatch
 
-on:
-  push:
-    branches:
-      - trunk
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   test:
@@ -20,6 +16,7 @@ jobs:
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
 
     with:
-      os: ${{ matrix.os }}
-      php: ${{ matrix.php }}
-      phpunit-config: ${{ 'phpunit.xml.dist' }}
+      OS: ${{ matrix.os }}
+      PHP: ${{ matrix.php }}
+      TEST_SUITE: all
+      FAIL_FAST: true

--- a/.github/workflows/manual-dispatch.yml
+++ b/.github/workflows/manual-dispatch.yml
@@ -1,0 +1,60 @@
+name: Manual Tests Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      PHP:
+        description: 'pick which PHP version to use'
+        type: choice
+        options:
+          - all
+          - '7.2'
+          - '7.3'
+          - '7.4'
+          - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
+        required: false
+        default: all
+      OS:
+        description: 'pick which OS to run on'
+        type: choice
+        options:
+          - all
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        required: false
+        default: all
+      TEST_SUITE:
+        description: 'pick which PHPUnit test suite to run'
+        type: choice
+        options:
+          - all
+          - unit
+          - e2e
+        required: false
+        default: all
+
+run-name: >-
+  PHP: ${{ github.event.inputs.PHP }} OS: ${{ github.event.inputs.OS }} TEST SUITE: ${{ github.event.inputs.TEST_SUITE }}
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }}
+    uses: ./.github/workflows/phpunit-tests-run.yml
+    permissions:
+      contents: read
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ ( github.event.inputs.OS == 'all' && fromJSON( '["ubuntu-latest", "macos-latest", "windows-latest"]' ) ) || fromJSON( format( '["{0}"]', github.event.inputs.OS ) ) }}
+        php: ${{ ( github.event.inputs.PHP == 'all' && fromJSON( '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]' ) ) || fromJSON( format( '["{0}"]', github.event.inputs.PHP ) ) }}
+
+    with:
+      OS: ${{ matrix.os }}
+      PHP: ${{ matrix.php }}
+      TEST_SUITE: ${{ github.event.inputs.TEST_SUITE }}
+      FAIL_FAST: false

--- a/.github/workflows/phpunit-tests-run.yml
+++ b/.github/workflows/phpunit-tests-run.yml
@@ -3,29 +3,37 @@ name: Run PHPUnit tests
 on:
   workflow_call:
     inputs:
-      os:
-        description: 'Operating system to run tests on'
+      OS:
+        description: 'The operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
-      php:
+        default: ubuntu-latest
+      PHP:
         description: 'The version of PHP to use, in the format of X.Y'
-        required: true
-        type: 'string'
-      phpunit-config:
-        description: 'The PHPUnit configuration file to use'
         required: false
         type: 'string'
-        default: 'phpunit.xml.dist'
+        default: '7.2'
+      TEST_SUITE:
+        description: 'The PHPUnit test suite to use'
+        required: false
+        type: 'string'
+        default: unit
+      FAIL_FAST:
+        description: 'If test job should fail at first defect'
+        required: false
+        type: boolean
+        default: true
+
 env:
-  LOCAL_PHP: ${{ inputs.php }}-fpm
-  PHPUNIT_CONFIG: ${{ inputs.phpunit-config }}
+  LOCAL_PHP: ${{ inputs.PHP }}-fpm
+  PHPUNIT_CONFIG: phpunit.xml.dist
+  STRICT_FLAGS: ${{ ( inputs.FAIL_FAST && '--stop-on-defect --fail-on-warning --fail-on-risky' ) || '' }}
 
 jobs:
   phpunit-tests:
-    name: ${{ inputs.os }}
-    runs-on: ${{ inputs.os }}
-    timeout-minutes: 20
+    name: ${{ inputs.OS }} ${{ inputs.TEST_SUITE }} tests
+    runs-on: ${{ inputs.OS }}
+    timeout-minutes: 5
 
     steps:
       - name: Checkout repository
@@ -34,9 +42,9 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '${{ inputs.php }}'
+          php-version: '${{ inputs.PHP }}'
           tools: phpunit-polyfills
-          extensions: zip
+          extensions: zip, pdo_sqlite, sqlite3
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v3
@@ -44,5 +52,11 @@ jobs:
           ignore-cache: "yes"
           composer-options: "--optimize-autoloader"
 
-      - name: Run PHPUnit tests
-        run: phpunit tests --testdox
+      - name: Run PHPUnit unit tests
+        id: unit
+        if: contains( fromJSON( '["unit", "all"]' ), inputs.TEST_SUITE )
+        run: phpunit --testsuite unit ${{ env.STRICT_FLAGS }}
+
+      - name: Run PHPUnit e2e tests
+        if: inputs.TEST_SUITE == 'e2e' || ( inputs.TEST_SUITE == 'all' && ( ! inputs.FAIL_FAST || steps.unit.outcome == 'success' ) )
+        run: phpunit --testsuite e2e ${{ env.STRICT_FLAGS }}

--- a/README.md
+++ b/README.md
@@ -68,10 +68,21 @@ Install [composer](https://getcomposer.org/). Once you have it, install the requ
 composer install
 ```
 
-### Run tests with
+## Tests
+### Run all tests with
+```shell
+vendor/bin/phpunit
+```
+
+### Run unit tests with
 
 ```shell
-vendor/bin/phpunit --testdox
+vendor/bin/phpunit --testsuite unit
+```
+
+### Run e2e tests with
+```shell
+vendor/bin/phpunit --testsuite e2e
 ```
 
 ### Run Blueprints in a variety of ways
@@ -82,7 +93,7 @@ vendor/bin/phpunit --testdox
  php examples/blueprint_compiling.php
 ```
 
-#### using a string containg a Blueprint (in JSON):
+#### using a string containing a Blueprint (in JSON):
 
 ```shell
  php examples/json_string_compiling.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,10 +4,18 @@
         bootstrap="vendor/autoload.php"
         colors="true"
         beStrictAboutOutputDuringTests="true"
+        defaultTestSuite="all"
+        testdox="true"
 >
     <testsuites>
-        <testsuite name="default">
+        <testsuite name="all">
             <directory>tests</directory>
+        </testsuite>
+        <testsuite name="unit">
+            <directory>tests/unit</directory>
+        </testsuite>
+        <testsuite name="e2e">
+            <directory>tests/e2e</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/e2e/configuration/E2ETestCase.php
+++ b/tests/e2e/configuration/E2ETestCase.php
@@ -1,0 +1,5 @@
+<?php
+
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase as TestCase;
+
+abstract class E2ETestCase extends TestCase {}


### PR DESCRIPTION
### Summary 
Rework CI with 2 dispatch workflows: automatic as a quick and thick quality gate for all pushes and pull requests and manual for a nice and easy way of geeting details on failing tests.

The first step toward achieving robust end-to-end (#108) coverage.

### Major Changes
- add a fast-failing broad automatic-dispatch run for pushes and merge requests
- add a modular manual-dispatch run
- add unit and e2e test suites to phpunit.xml.dist
- add the defaultTestSuite ("all") attribute to phpunit.xml.dist
- move the testdox flag from scripts to phpunit.xml.dist
- add the E2ETestCase config for all e2e tests
- add shell scripts to the README

The manual-dispatch allows for control over the branch it will run on, php version, os and test suite. Every default is set to `all` and the parameter `FAIL_FAST` is always set to `false`. This dispatches the run with a configuration that is broad and offers maximum info on the condition of the tested branch.

The automatic-disptach is more rigid and always tests all php versions, os and with all test suites. It also has the `FAIL_FAST` parameter set to `true`. This also introduces `--stop-on-defect ` `--fail-on-warning` `--fail-on-risky` PHPUnit flags for enchanced quality control. Yet, this is a job-level feature. This means that the whole test matrix will always run (3 os * 7 php versions => 21 jobs). The benefit of the `FAIL_FAST` parameter is to run as few tests as possible to ascertain if a os-php version combination is stable.

I'd hope this will enable a workflow going more or less like that:
1. You work on a feature on your local fork. 
2. After work is done you run tests locally with `vendor/bin/phpunit`, but unless you are really into PHP versions this will run on the single version you have configured as your default project interpreter `C:\php\php-8.3.exe`. Obviously, the local test run also only tests the code performance on your OS. For examples sake, let's say you are developting on a Mac and that all tests have passed.
3. You push your code and the automatic-disptach kicks in. GitHub quickly informs you that some of the jobs failed. Since all 21 jobs have run you have an instant and quite broad idea of what is going on. Let's assume your Mac-coding skills are flawless and all but the Windows jobs have passed.
4. You go the the manual-dispatch and pick your branch, `windows-latest` as the os to run on and decide to check `all` php versions. With an initial idea on the scope of your changes and data from the automatic runs you might have also conclued that only e2e tests actually failed. To save a few precious seconds you decide to only run the `e2e` suite.
5. You enjoy precise infos and helpfull stacktraces for failing Windows tests.

### Example Usage

1. In the `Actions` tab, pick `Manual Tests Dispatch`.
![image](https://github.com/WordPress/blueprints-library/assets/30837295/ddcbe594-8c76-4b8d-978d-1c34be9b4b23)
2. Click the `Run workflow` button:
![image](https://github.com/WordPress/blueprints-library/assets/30837295/cf35649e-4f60-4d0e-a1a9-e410d5818ecf)
3. Customize your dispatch run with `inputs`:
![image](https://github.com/WordPress/blueprints-library/assets/30837295/a2e32398-9cb8-4457-9309-4dad4f66700c)
- pick which branch to test:
![image](https://github.com/WordPress/blueprints-library/assets/30837295/5b6b5ab2-fac2-46c6-9669-50565907dd4a)
![image](https://github.com/WordPress/blueprints-library/assets/30837295/04881d77-f8f9-45f2-9894-084011f16792)
- pick which PHP version to use (`all` is default and will use all versions)
![image](https://github.com/WordPress/blueprints-library/assets/30837295/4bfc2710-320c-46b6-8b7e-36f2b61cc9a7)
![image](https://github.com/WordPress/blueprints-library/assets/30837295/3e183f49-253a-4021-9410-d2f2dc1fffa8)
- pick which OS to run on (`all` is default and will run on all os)
![image](https://github.com/WordPress/blueprints-library/assets/30837295/508a73d3-7842-4195-ae1f-5e6f8495464e)
![image](https://github.com/WordPress/blueprints-library/assets/30837295/a7d5d148-c44d-44f4-803c-88e41f16ce27)
- pick which PHPUnit test suite to run (`all` is default and will run both unit and e2e tests)
![image](https://github.com/WordPress/blueprints-library/assets/30837295/781b92f3-0827-459b-8058-24858c5dfce4)
![image](https://github.com/WordPress/blueprints-library/assets/30837295/2bfb61df-fd25-4c06-af25-f23b19f5730b)
4. Inspect final dispatch configuration:
![image](https://github.com/WordPress/blueprints-library/assets/30837295/d63726c5-8466-43f5-a43b-e56f75adfff5)
5. Disptach tests.
![image](https://github.com/WordPress/blueprints-library/assets/30837295/b35933eb-ebcc-45dc-a0a3-9951b9395f0b)
![image](https://github.com/WordPress/blueprints-library/assets/30837295/c73995d0-28b4-4822-a1b5-b6fe96e18b6c)
6. Enjoy the autogenerated run name on GitHub:
![image](https://github.com/WordPress/blueprints-library/assets/30837295/60010cac-8263-474d-8b75-456ebf1532c5)
7. Inspect results:
![image](https://github.com/WordPress/blueprints-library/assets/30837295/44252a12-30fd-4bbd-821b-c5892ae36fae)
(in the example only unit tests were selected, so e2e tests were skipped)