### PR TITLE
Support composer test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ composer install
 ### Run tests with
 
 ```shell
-vendor/bin/phpunit --testdox
+composer test
 ```
 
 ### Run Blueprints in a variety of ways
@@ -82,7 +82,7 @@ vendor/bin/phpunit --testdox
  php examples/blueprint_compiling.php
 ```
 
-#### using a string containg a Blueprint (in JSON):
+#### using a string containing a Blueprint (in JSON):
 
 ```shell
  php examples/json_string_compiling.php

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,8 @@
     "classmap": [
       "tests/"
     ]
+  },
+  "scripts": {
+    "test": "phpunit --testdox"
   }
 }


### PR DESCRIPTION
This is a simple PR that allows tests to be run with `composer test`, as one might guess they could be run.

This also fixes an unrelated typo.