### PR TITLE
Throw an exception on error, introduce error domains to handle them safely

### DIFF
--- a/src/WordPress/ByteReader/WP_Byte_Reader.php
+++ b/src/WordPress/ByteReader/WP_Byte_Reader.php
@@ -12,15 +12,11 @@ abstract class WP_Byte_Reader {
 	abstract public function is_finished(): bool;
 	abstract public function next_bytes(): bool;
 	abstract public function get_bytes(): ?string;
-	abstract public function get_last_error(): ?string;
 	abstract public function close(): bool;
 	public function read_all(): string {
 		$buffer = '';
 		while( $this->next_bytes() ) {
 			$buffer .= $this->get_bytes();
-		}
-		if( $this->get_last_error() ) {
-			return false;
 		}
 		return $buffer;
 	}

--- a/src/WordPress/ByteReader/WP_File_Reader.php
+++ b/src/WordPress/ByteReader/WP_File_Reader.php
@@ -2,6 +2,8 @@
 
 namespace WordPress\ByteReader;
 
+use WordPress\Error\WordPressException;
+
 class WP_File_Reader extends WP_Byte_Reader {
 
 	const STATE_STREAMING = '#streaming';
@@ -13,19 +15,14 @@ class WP_File_Reader extends WP_Byte_Reader {
 	protected $offset_in_file;
 	protected $output_bytes	= '';
 	protected $last_chunk_size = 0;
-	protected $last_error;
 	protected $state = self::STATE_STREAMING;
 
 	static public function create( $file_path, $chunk_size = 8096 ) {
 		if(!file_exists($file_path)) {
-            throw new \Exception(sprintf( 'File %s does not exist', $file_path ));
-			_doing_it_wrong( __METHOD__, sprintf( 'File %s does not exist', $file_path ), '1.0.0' );
-			return false;
+            throw new WordPressException(sprintf( 'File %s does not exist', $file_path ));
 		}
 		if(!is_file($file_path)) {
-            throw new \Exception(sprintf( '%s is not a file', $file_path ));
-			_doing_it_wrong( __METHOD__, sprintf( '%s is not a file', $file_path ), '1.0.0' );
-			return false;
+            throw new WordPressException(sprintf( '%s is not a file', $file_path ));
 		}
 		return new self( $file_path, $chunk_size );
 	}
@@ -48,8 +45,7 @@ class WP_File_Reader extends WP_Byte_Reader {
 
 	public function seek( $offset_in_file ): bool {
 		if ( ! is_int( $offset_in_file ) ) {
-			_doing_it_wrong( __METHOD__, 'Cannot set a file reader cursor to a non-integer offset.', '1.0.0' );
-			return false;
+			throw new WordPressException('Cannot set a file reader cursor to a non-integer offset.');
 		}
 		$this->offset_in_file  = $offset_in_file;
 		$this->last_chunk_size = 0;
@@ -64,11 +60,10 @@ class WP_File_Reader extends WP_Byte_Reader {
 
 	public function close(): bool {
 		if(!$this->file_pointer) {
-			return false;
+			throw new WordPressException('File pointer is not open');
 		}
 		if(!fclose($this->file_pointer)) {
-			$this->last_error = 'Failed to close file pointer';
-			return false;
+			throw new WordPressException('Failed to close file pointer');
 		}
 		$this->file_pointer = null;
 		$this->state = static::STATE_FINISHED;
@@ -83,18 +78,17 @@ class WP_File_Reader extends WP_Byte_Reader {
 		return $this->output_bytes;
 	}
 
-	public function get_last_error(): ?string {
-		return $this->last_error;
-	}
-
 	public function next_bytes(): bool {
 		$this->output_bytes	= '';
 		$this->last_chunk_size = 0;
-		if ( $this->last_error || $this->is_finished() ) {
+		if ( $this->is_finished() ) {
 			return false;
 		}
 		if ( ! $this->file_pointer ) {
 			$this->file_pointer = fopen( $this->file_path, 'r' );
+            if(false === $this->file_pointer) {
+                throw new WordPressException(sprintf('Failed to open the file: %s', $this->file_path));
+            }
 			if ( $this->offset_in_file ) {
 				fseek( $this->file_pointer, $this->offset_in_file );
 			}

--- a/src/WordPress/ByteReader/WP_GZ_File_Reader.php
+++ b/src/WordPress/ByteReader/WP_GZ_File_Reader.php
@@ -6,7 +6,7 @@ class WP_GZ_File_Reader extends WP_File_Reader {
 
 	public function next_bytes(): bool {
 		$this->output_bytes = '';
-		if ( $this->last_error || $this->is_finished() ) {
+		if ( $this->is_finished() ) {
 			return false;
 		}
 		if ( ! $this->file_pointer ) {

--- a/src/WordPress/ByteReader/WP_Remote_File_Ranged_Reader.php
+++ b/src/WordPress/ByteReader/WP_Remote_File_Ranged_Reader.php
@@ -94,10 +94,6 @@ class WP_Remote_File_Ranged_Reader extends WP_Byte_Reader {
 			fwrite($file, $reader->get_bytes());
 		}
 		fclose($file);
-		if($reader->get_last_error()) {
-			// How should we log this error?
-			return false;
-		}
 		return WP_File_Reader::create( $file_path );
 	}
 
@@ -183,12 +179,6 @@ class WP_Remote_File_Ranged_Reader extends WP_Byte_Reader {
 
 	public function get_bytes(): ?string {
 		return $this->current_reader->get_bytes();
-	}
-
-	public function get_last_error(): ?string {
-		// @TODO: Preserve the error information when the current reader
-		//        is reset.
-		return $this->current_reader->get_last_error();
 	}
 
 	private function ensure_content_length() {

--- a/src/WordPress/ByteReader/WP_Remote_File_Reader.php
+++ b/src/WordPress/ByteReader/WP_Remote_File_Reader.php
@@ -2,6 +2,8 @@
 
 namespace WordPress\ByteReader;
 
+use WordPress\Error\WordPressException;
+
 /**
  * Streams bytes from a remote file.
  */
@@ -33,13 +35,10 @@ class WP_Remote_File_Reader extends WP_Byte_Reader {
 
 	public function seek( $offset_in_file ): bool {
 		if ( $this->request ) {
-			_doing_it_wrong( 
-				__METHOD__,
+			throw new WordPressException(
 				'Cannot seek() a WP_Remote_File_Reader instance once the request was initialized. ' .
-				'Use WP_Remote_File_Ranged_Reader to seek() using range requests instead.',
-				'1.0.0'
+				'Use WP_Remote_File_Ranged_Reader to seek() using range requests instead.'
 			);
-			return false;
 		}
 		$this->skip_bytes = $offset_in_file;
 		return true;
@@ -52,8 +51,7 @@ class WP_Remote_File_Reader extends WP_Byte_Reader {
 				array( 'headers' => $this->headers )
 			);
 			if ( false === $this->client->enqueue( $this->request ) ) {
-				// TODO: Think through error handling
-				return false;
+				throw new WordPressException(sprintf('Failed to enqueue the request to %s', $this->url));
 			}
 		}
 
@@ -85,8 +83,7 @@ class WP_Remote_File_Reader extends WP_Byte_Reader {
 				case \WordPress\AsyncHttp\Client::EVENT_BODY_CHUNK_AVAILABLE:
 					$chunk = $this->client->get_response_body_chunk();
 					if ( ! is_string( $chunk ) ) {
-						// TODO: Think through error handling
-						return false;
+						throw new WordPressException(sprintf('Failed to get the response body chunk from %s', $this->url));
 					}
 					$this->current_chunk = $chunk;
 
@@ -108,11 +105,7 @@ class WP_Remote_File_Reader extends WP_Byte_Reader {
 					}
 					return true;
 				case \WordPress\AsyncHttp\Client::EVENT_FAILED:
-					// TODO: Think through error handling. Errors are expected when working with
-					//       the network. Should we auto retry? Make it easy for the caller to retry?
-					//       Something else?
-					$this->last_error = $this->client->get_request()->error;
-					return false;
+					throw new WordPressException(sprintf('Failed to fetch data from %s', $this->url));
 				case \WordPress\AsyncHttp\Client::EVENT_FINISHED:
 					$this->is_finished = true;
 					return false;
@@ -130,23 +123,16 @@ class WP_Remote_File_Reader extends WP_Byte_Reader {
 			array( 'method' => 'HEAD' )
 		);
 		if ( false === $this->client->enqueue( $request ) ) {
-			// TODO: Think through error handling
-			return false;
+			throw new WordPressException(sprintf('Failed to enqueue the request to %s', $this->url));
 		}
 		while ( $this->client->await_next_event() ) {
 			switch ( $this->client->get_event() ) {
 				case \WordPress\AsyncHttp\Client::EVENT_GOT_HEADERS:
 					$request = $this->client->get_request();
-					if ( ! $request ) {
-						return false;
-					}
 					if($request->redirected_to) {
 						continue 2;
 					}
 					$response = $request->response;
-					if ( false === $response ) {
-						return false;
-					}
 					$content_length = $response->get_header( 'Content-Length' );
 					if ( false === $content_length ) {
 						return false;
@@ -181,11 +167,6 @@ class WP_Remote_File_Reader extends WP_Byte_Reader {
 	}
 
 	public function close(): bool {
-		_doing_it_wrong(
-			__METHOD__,
-			'Not implemented yet',
-			'1.0.0'
-		);
-		return false;
+		throw new WordPressException('Not implemented yet');
 	}
 }

--- a/src/WordPress/ByteReader/WP_String_Reader.php
+++ b/src/WordPress/ByteReader/WP_String_Reader.php
@@ -2,6 +2,8 @@
 
 namespace WordPress\ByteReader;
 
+use WordPress\Error\WordPressException;
+
 class WP_String_Reader extends WP_Byte_Reader {
 
 	const STATE_STREAMING = '#streaming';
@@ -12,13 +14,11 @@ class WP_String_Reader extends WP_Byte_Reader {
 	protected $offset = 0;
 	protected $output_bytes = '';
 	protected $last_chunk_size = 0;
-	protected $last_error;
 	protected $state = self::STATE_STREAMING;
 
 	static public function create($string, $chunk_size = 8096) {
 		if (!is_string($string)) {
-			_doing_it_wrong(__METHOD__, 'Input must be a string', '1.0.0');
-			return false;
+			throw new WordPressException('Input must be a string');
 		}
 		return new self($string, $chunk_size);
 	}
@@ -38,11 +38,10 @@ class WP_String_Reader extends WP_Byte_Reader {
 
 	public function seek($offset): bool {
 		if (!is_int($offset)) {
-			_doing_it_wrong(__METHOD__, 'Cannot set cursor to a non-integer offset.', '1.0.0');
-			return false;
+			throw new WordPressException('Cannot set cursor to a non-integer offset.');
 		}
 		if ($offset < 0 || $offset > strlen($this->string)) {
-			return false;
+			throw new WordPressException('Cannot set cursor to an offset outside the string bounds.');
 		}
 		$this->offset = $offset;
 		$this->last_chunk_size = 0;
@@ -63,15 +62,11 @@ class WP_String_Reader extends WP_Byte_Reader {
 		return $this->output_bytes;
 	}
 
-	public function get_last_error(): ?string {
-		return $this->last_error;
-	}
-
 	public function next_bytes(): bool {
 		$this->output_bytes = '';
 		$this->last_chunk_size = 0;
 
-		if ($this->last_error || $this->is_finished()) {
+		if ($this->is_finished()) {
 			return false;
 		}
 

--- a/src/WordPress/Error/ErrorDomain.php
+++ b/src/WordPress/Error/ErrorDomain.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace WordPress\Error;
+
+use \WP_Error;
+
+/**
+ * A Domain groups error handling into a container, similar to Node.js domains.
+ * It allows grouping multiple different operations into one error handling context.
+ */
+class ErrorDomain {
+
+    /**
+     * @var callable|null The error handler registered for this domain
+     */
+    private $error_handler = null;
+
+    /**
+     * @var string|null A label for the domain, useful for debugging
+     */
+    private $label = null;
+
+    /**
+     * @var callable|null A fallback fallback error handler
+     */
+    private static $fallback_error_handler = null;
+
+    private $last_return_value = null;
+
+    /**
+     * Creates a new domain instance with an optional label.
+     *
+     * @param string|null $label A label for the domain
+     * @return self
+     */
+    public static function create($label = null) {
+        $instance = new self();
+        $instance->label = $label;
+        return $instance;
+    }
+
+    /**
+     * Sets a fallback fallback error handler.
+     *
+     * @param callable $handler The fallback error handler function
+     * @return void
+     */
+    public static function set_fallback_error_handler($handler) {
+        self::$fallback_error_handler = $handler;
+    }
+
+    public static function bail($exception) {
+        throw $exception;
+    }
+
+    /**
+     * Adds an error handler to this domain.
+     *
+     * @param callable $handler The error handler function
+     * @return void
+     */
+    public function set_error_handler($handler) {
+        $this->error_handler = $handler;
+    }
+
+    /**
+     * Executes a callback within this domain's error handling context.
+     *
+     * @param callable $callback The code to execute
+     * @return bool True if the callback executed successfully, false otherwise
+     */
+    public function safe_run(callable $callback) {
+        try {
+            $this->last_return_value = $callback($this);
+            return true;
+        } catch (\Throwable $exception) {
+            if ($this->error_handler) {
+                call_user_func($this->error_handler, $exception, $this);
+            } else {
+                call_user_func(self::$fallback_error_handler, $exception);
+            }
+            return false;
+        }
+    }
+
+    public function get_last_return_value() {
+        return $this->last_return_value;
+    }
+
+    /**
+     * Gets the label of the domain.
+     *
+     * @return string|null The label of the domain
+     */
+    public function get_label() {
+        return $this->label;
+    }
+
+}
+
+// Set the default fallback error handler
+ErrorDomain::set_fallback_error_handler(function($exception) {
+    error_log('fallback handler: ' . $exception->getMessage() . "\n" . $exception->getTraceAsString());
+});

--- a/src/WordPress/Error/WordPressException.php
+++ b/src/WordPress/Error/WordPressException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace WordPress\Error;
+
+class WordPressException extends \Exception {
+
+}

--- a/src/WordPress/Filesystem/WP_Abstract_Filesystem.php
+++ b/src/WordPress/Filesystem/WP_Abstract_Filesystem.php
@@ -3,6 +3,7 @@
 namespace WordPress\Filesystem;
 
 use WordPress\ByteReader\WP_Byte_Reader;
+use WordPress\Error\WordPressException;
 
 /**
  * Abstract class for filesystem implementations.
@@ -87,44 +88,35 @@ abstract class WP_Abstract_Filesystem {
 	abstract public function close_read_stream();
 
 	// @TODO: Support for write methods, perhaps in a separate interface?
-	// abstract public function open_write_stream($path);
-    // abstract public function append_bytes($data);
-    // abstract public function close_write_stream();
-	// abstract public function rename($old_path, $new_path);
-	// abstract public function mkdir($path);
-	// abstract public function rm($path);
-	// abstract public function rmdir($path, $options = []);
+	abstract public function open_write_stream($path);
+    abstract public function append_bytes($data);
+    abstract public function close_write_stream();
+	abstract public function rename($old_path, $new_path);
+	abstract public function mkdir($path);
+	abstract public function rm($path);
+	abstract public function rmdir($path, $options = []);
 
     public function put_contents($path, $data, $options = []) {
-        if(!$this->open_write_stream($path)) {
-            return false;
-        }
+        $this->open_write_stream($path);
+
         if(is_string($data)) {
-            if(!$this->append_bytes($data)) {
-                return false;
-            }
+            $this->append_bytes($data);
         } else if(is_object($data) && $data instanceof WP_Byte_Reader) {
-            while($data->next_chunk()) {
-                if(!$this->append_bytes($data->get_chunk())) {
-                    return false;
-                }
+            while($data->next_bytes()) {
+                $this->append_bytes($data->get_bytes());
             }
         } else {
-            _doing_it_wrong(__METHOD__, 'Invalid $data argument provided. Expected a string or a WP_Byte_Reader instance. Received: ' . gettype($data), '1.0.0');
-            return false;
+            throw new WordPressException('Invalid $data argument provided. Expected a string or a WP_Byte_Reader instance. Received: ' . gettype($data));
         }
-        if(!$this->close_write_stream($options)) {
-            return false;
-        }
-        return true;
+
+        $this->close_write_stream($options);
     }
 
     public function copy($from_path, $to_path, $options = []) {
         $to_fs = $options['to_fs'] ?? $this;
         $recursive = $options['recursive'] ?? false;
         if($this->is_dir($from_path) && !$recursive) {
-            _doing_it_wrong( __METHOD__, 'Cannot copy a directory without recursive => true option', '1.0.0' );
-            return false;
+            throw new WordPressException('Cannot copy a directory without recursive => true option');
         }
         
         $stack = [[$from_path, $to_path]];
@@ -141,20 +133,11 @@ abstract class WP_Abstract_Filesystem {
                     ];
                 }
             } else {
-                if(false === $this->open_read_stream($from_path)) {
-                    throw new \Exception('Failed to open read stream for ' . $from_path);
-                    return false;
-                }
-                if(false === $to_fs->open_write_stream($to_path)) {
-                    throw new \Exception('Failed to open write stream for ' . $to_path);
-                    return false;
-                }
+                $this->open_read_stream($from_path);
+                $to_fs->open_write_stream($to_path);
                 $chunks_written = 0;
                 while($this->next_file_chunk()) {
-                    if(false === $to_fs->append_bytes($this->get_file_chunk())) {
-                        throw new \Exception('Failed to append bytes to ' . $to_path);
-                        return false;
-                    }
+                    $to_fs->append_bytes($this->get_file_chunk());
                     $chunks_written++;
                 }
                 if($chunks_written === 0) {
@@ -163,14 +146,8 @@ abstract class WP_Abstract_Filesystem {
                     // destination filesystem is lazy.
                     $to_fs->append_bytes('');
                 }
-                if(false === $this->close_read_stream()) {
-                    throw new \Exception('Failed to close read stream for ' . $from_path);
-                    return false;
-                }
-                if(false === $to_fs->close_write_stream()) {
-                    throw new \Exception('Failed to close write stream for ' . $to_path);
-                    return false;
-                }
+                $this->close_read_stream();
+                $to_fs->close_write_stream();
             }
         }
         return true;

--- a/src/WordPress/Filesystem/WP_Google_Drive_Filesystem.php
+++ b/src/WordPress/Filesystem/WP_Google_Drive_Filesystem.php
@@ -5,6 +5,7 @@ namespace WordPress\Filesystem;
 use WordPress\AsyncHttp\Client;
 use WordPress\AsyncHttp\Request;
 use WordPress\ByteReader\WP_String_Reader;
+use WordPress\Error\WordPressException;
 
 /**
  * Represents a Google Drive filesystem implementation.
@@ -15,7 +16,6 @@ class WP_Google_Drive_Filesystem extends WP_Abstract_Filesystem {
     private $write_stream = null;
     private $last_file_reader = null;
     private $access_token;
-    private $last_error = null;
     private $path_id_cache = [];
     private $http_client;
 
@@ -76,8 +76,7 @@ class WP_Google_Drive_Filesystem extends WP_Abstract_Filesystem {
         }
         $response_json = json_decode($buffered_response, true);
         if(isset($response_json['error'])) {
-            $this->last_error = $response_json['error']['message'];
-            return false;
+            throw new WordPressException( $response_json['error']['message']);
         }
         return $response_json;
     }
@@ -290,8 +289,7 @@ BODY;
 
     public function open_write_stream($path) {
         if ($this->write_stream) {
-            _doing_it_wrong(__METHOD__, 'Cannot open a new write stream while another write stream is open.', '1.0.0');
-            return false;
+            throw new WordPressException( 'Cannot open a new write stream while another write stream is open.');
         }
         
         // Initialize upload session
@@ -301,16 +299,14 @@ BODY;
 
     public function append_bytes($data) {
         if (!$this->write_stream) {
-            _doing_it_wrong(__METHOD__, 'Cannot append bytes to a write stream that is not open.', '1.0.0');
-            return false;
+            throw new WordPressException( 'Cannot append bytes to a write stream that is not open.');
         }
         return fwrite($this->write_stream, $data);
     }
 
     public function close_write_stream() {
         if (!$this->write_stream) {
-            _doing_it_wrong(__METHOD__, 'Cannot close a write stream that is not open.', '1.0.0');
-            return false;
+            throw new WordPressException( 'Cannot close a write stream that is not open.');
         }
 
         fclose($this->write_stream);

--- a/src/WordPress/Filesystem/WP_In_Memory_Filesystem.php
+++ b/src/WordPress/Filesystem/WP_In_Memory_Filesystem.php
@@ -2,6 +2,8 @@
 
 namespace WordPress\Filesystem;
 
+use WordPress\Error\WordPressException;
+
 /**
  * Represents an in-memory filesystem.
  */
@@ -64,35 +66,35 @@ class WP_In_Memory_Filesystem extends WP_Abstract_Filesystem {
 
 	public function next_file_chunk() {
 		if(!$this->last_file_reader) {
-			return false;
+			throw new WordPressException('No file reader is open.');
 		}
 		return $this->last_file_reader->next_bytes();
 	}
 
 	public function get_file_chunk() {
 		if(!$this->last_file_reader) {
-			return false;
+			throw new WordPressException('No file reader is open.');
 		}
 		return $this->last_file_reader->get_bytes();
 	}
 
 	public function get_streamed_file_length() {
 		if(!$this->last_file_reader) {
-			return false;
+			throw new WordPressException('No file reader is open.');
 		}
 		return $this->last_file_reader->length();
 	}
 
 	public function get_last_error() {
 		if(!$this->last_file_reader) {
-			return false;
+			throw new WordPressException('No file reader is open.');
 		}
 		return $this->last_file_reader->get_last_error();
 	}
 
 	public function close_read_stream() {
 		if(!$this->last_file_reader) {
-			return false;
+			throw new WordPressException('No file reader is open.');
 		}
 		$this->last_file_reader->close();
 		$this->last_file_reader = null;
@@ -103,12 +105,12 @@ class WP_In_Memory_Filesystem extends WP_Abstract_Filesystem {
 		$old_path = wp_canonicalize_path($old_path);
 		$new_path = wp_canonicalize_path($new_path);
 		if (!$this->exists($old_path)) {
-			return false;
+			throw new WordPressException('The old path does not exist.');
 		}
 
 		$parent = $this->get_parent_dir($new_path);
 		if (!$this->is_dir($parent)) {
-			return false;
+			throw new WordPressException('The parent directory does not exist.');
 		}
 
 		$this->files[$new_path] = $this->files[$old_path];
@@ -119,7 +121,11 @@ class WP_In_Memory_Filesystem extends WP_Abstract_Filesystem {
 	public function mkdir($path) {
 		$path = wp_canonicalize_path($path);
 		if ($this->exists($path)) {
-			return false;
+            if($this->is_dir($path)) {
+                return false;
+            } else {
+                throw new WordPressException('The path already exists but is not a directory.');
+            }
 		}
 
 		$parent = $this->get_parent_dir($path);
@@ -138,7 +144,7 @@ class WP_In_Memory_Filesystem extends WP_Abstract_Filesystem {
 	public function rm($path) {
 		$path = wp_canonicalize_path($path);
 		if (!$this->is_file($path)) {
-			return false;
+			throw new WordPressException('The path is not a file and cannot be removed.');
 		}
 
 		$parent = $this->get_parent_dir($path);
@@ -151,7 +157,7 @@ class WP_In_Memory_Filesystem extends WP_Abstract_Filesystem {
 		$path = wp_canonicalize_path($path);
 		$recursive = $options['recursive'] ?? false;
 		if (!$this->is_dir($path)) {
-			return false;
+			throw new WordPressException('The path is not a directory and cannot be removed.');
 		}
 
 		if ($recursive) {
@@ -175,7 +181,7 @@ class WP_In_Memory_Filesystem extends WP_Abstract_Filesystem {
 		$path = wp_canonicalize_path($path);
 		$parent = $this->get_parent_dir($path);
 		if (!$this->is_dir($parent)) {
-			return false;
+			throw new WordPressException('The parent directory does not exist.');
 		}
 
 		$this->files[$path] = [
@@ -188,8 +194,7 @@ class WP_In_Memory_Filesystem extends WP_Abstract_Filesystem {
 
     public function open_write_stream($path) {
         if($this->write_stream) {
-            _doing_it_wrong(__METHOD__, 'Cannot open a new write stream while another write stream is open.', '1.0.0');
-            return false;
+            throw new WordPressException('Cannot open a new write stream while another write stream is open.');
         }
         $this->write_stream = [
             'path' => $path,
@@ -200,8 +205,7 @@ class WP_In_Memory_Filesystem extends WP_Abstract_Filesystem {
 
     public function append_bytes($data) {
         if(!$this->write_stream) {
-            _doing_it_wrong(__METHOD__, 'Cannot append bytes to a write stream that is not open.', '1.0.0');
-            return false;
+            throw new WordPressException('Cannot append bytes to a write stream that is not open.');
         }
         $path = $this->write_stream['path'];
         if(!isset($this->files[$path])) {
@@ -213,8 +217,7 @@ class WP_In_Memory_Filesystem extends WP_Abstract_Filesystem {
 
     public function close_write_stream() {
         if(!$this->write_stream) {
-            _doing_it_wrong(__METHOD__, 'Cannot close a write stream that is not open.', '1.0.0');
-            return false;
+            throw new WordPressException('Cannot close a write stream that is not open.');
         }
         $this->write_stream = null;
         return true;

--- a/src/WordPress/Filesystem/WP_Local_Filesystem.php
+++ b/src/WordPress/Filesystem/WP_Local_Filesystem.php
@@ -2,6 +2,8 @@
 
 namespace WordPress\Filesystem;
 
+use WordPress\Error\WordPressException;
+
 /**
  * Represents the currently available filesystem.
  */
@@ -22,7 +24,7 @@ class WP_Local_Filesystem extends WP_Abstract_Filesystem {
 		$fullPath = $this->get_full_path($parent);
 		$dh = opendir( $fullPath );
 		if ( $dh === false ) {
-			return false;
+            throw new WordPressException('Failed to open directory: ' . $parent);
 		}
 
 		$children = array();
@@ -63,9 +65,6 @@ class WP_Local_Filesystem extends WP_Abstract_Filesystem {
 		}
 		$fullPath = $this->get_full_path($path);
 		$this->last_file_reader = \WordPress\ByteReader\WP_File_Reader::create($fullPath);
-        if(false === $this->last_file_reader) {
-            return false;
-        }
 		return true;
 	}
 
@@ -128,35 +127,38 @@ class WP_Local_Filesystem extends WP_Abstract_Filesystem {
 	}
 
 	public function put_contents($path, $data, $options = []) {
-		return false !== file_put_contents(
+		if(false === file_put_contents(
 			$this->get_full_path($path),
 			$data
-		);
+		)) {
+			throw new WordPressException('Failed to write to the file: ' . $path);
+		}
 	}
 
     public function open_write_stream($path) {
         if($this->write_stream) {
-            _doing_it_wrong(__METHOD__, 'Cannot open a new write stream while another write stream is open.', '1.0.0');
-            return false;
+            throw new WordPressException('Cannot open a new write stream while another write stream is open.');
         }
         $this->write_stream = fopen($this->get_full_path($path), 'wb');
-        return true;
+        if(false === $this->write_stream) {
+            throw new WordPressException('Failed to open the file: ' . $path);
+        }
     }
 
     public function append_bytes($data) {
         if(!$this->write_stream) {
-            _doing_it_wrong(__METHOD__, 'Cannot append bytes to a write stream that is not open.', '1.0.0');
-            return false;
+            throw new WordPressException('Cannot append bytes to a write stream that is not open.');
         }
         return fwrite($this->write_stream, $data);
     }
 
     public function close_write_stream() {
         if(!$this->write_stream) {
-            _doing_it_wrong(__METHOD__, 'Cannot close a write stream that is not open.', '1.0.0');
-            return false;
+            throw new WordPressException('Cannot close a write stream that is not open.');
         }
-        fclose($this->write_stream);
+        if(false === fclose($this->write_stream)) {
+            throw new WordPressException('Failed to close the write stream.');
+        }
         $this->write_stream = null;
         return true;
     }

--- a/src/WordPress/Filesystem/WP_SQLite_Filesystem.php
+++ b/src/WordPress/Filesystem/WP_SQLite_Filesystem.php
@@ -2,6 +2,8 @@
 
 namespace WordPress\Filesystem;
 
+use WordPress\Error\WordPressException;
+
 /**
  * Stores files in SQLite database.
  */
@@ -100,63 +102,61 @@ class WP_SQLite_Filesystem extends WP_Abstract_Filesystem {
 			$this->last_file_reader->close();
 		}
 		if (!$this->is_file($path)) {
-			return false;
+			throw new WordPressException('File not found ' . $path);
 		}
 		$stmt = $this->db->prepare('SELECT contents FROM files WHERE path = ?');
 		$stmt->bindValue(1, $path, SQLITE3_TEXT);
 		$result = $stmt->execute();
 		$row = $result->fetchArray(SQLITE3_ASSOC);
 		$this->last_file_reader = \WordPress\ByteReader\WP_String_Reader::create($row['contents']);
-		return true;
 	}
 
 	public function next_file_chunk() {
 		if(!$this->last_file_reader) {
-			return false;
+			throw new WordPressException('No file reader open');
 		}
 		return $this->last_file_reader->next_bytes();
 	}
 
 	public function get_file_chunk() {
 		if(!$this->last_file_reader) {
-			return false;
+			throw new WordPressException('No file reader open');
 		}
 		return $this->last_file_reader->get_bytes();
 	}
 
 	public function get_streamed_file_length() {
 		if(!$this->last_file_reader) {
-			return false;
+			throw new WordPressException('No file reader open');
 		}
 		return $this->last_file_reader->length();
 	}
 
 	public function get_last_error() {
 		if(!$this->last_file_reader) {
-			return false;
+			throw new WordPressException('No file reader open');
 		}
 		return $this->last_file_reader->get_last_error();
 	}
 
 	public function close_read_stream() {
 		if(!$this->last_file_reader) {
-			return false;
+			throw new WordPressException('No file reader open');
 		}
 		$this->last_file_reader->close();
 		$this->last_file_reader = null;
-		return true;
 	}
 
 	public function rename($old_path, $new_path) {
 		$old_path = wp_canonicalize_path($old_path);
 		$new_path = wp_canonicalize_path($new_path);
 		if (!$this->exists($old_path)) {
-			return false;
+			throw new WordPressException('File not found ' . $old_path);
 		}
 
 		$parent = $this->get_parent_dir($new_path);
 		if (!$this->is_dir($parent)) {
-			return false;
+			throw new WordPressException('Parent directory not found ' . $parent);
 		}
 
 		$this->db->exec('BEGIN TRANSACTION');
@@ -186,22 +186,21 @@ class WP_SQLite_Filesystem extends WP_Abstract_Filesystem {
 			$stmt->execute();
 
 			$this->db->exec('COMMIT');
-			return true;
 		} catch (\Exception $e) {
 			$this->db->exec('ROLLBACK');
-			return false;
+			throw new WordPressException('Failed to rename ' . $old_path . ' to ' . $new_path, $e);
 		}
 	}
 
 	public function mkdir($path) {
 		$path = wp_canonicalize_path($path);
 		if ($this->exists($path)) {
-			return false;
+			throw new WordPressException('Directory already exists ' . $path);
 		}
 
 		$parent = $this->get_parent_dir($path);
 		if (!$this->is_dir($parent)) {
-			return false;
+			throw new WordPressException('Parent directory not found ' . $parent);
 		}
 
 		$this->db->exec('BEGIN TRANSACTION');
@@ -223,17 +222,16 @@ class WP_SQLite_Filesystem extends WP_Abstract_Filesystem {
 			$stmt->execute();
 
 			$this->db->exec('COMMIT');
-			return true;
 		} catch (\Exception $e) {
 			$this->db->exec('ROLLBACK');
-			return false;
+			throw new WordPressException('Failed to create directory ' . $path, $e);
 		}
 	}
 
 	public function rm($path) {
 		$path = wp_canonicalize_path($path);
 		if (!$this->is_file($path)) {
-			return false;
+			throw new WordPressException('File not found ' . $path);
 		}
 
 		$this->db->exec('BEGIN TRANSACTION');
@@ -253,10 +251,9 @@ class WP_SQLite_Filesystem extends WP_Abstract_Filesystem {
 			$stmt->execute();
 
 			$this->db->exec('COMMIT');
-			return true;
 		} catch (\Exception $e) {
 			$this->db->exec('ROLLBACK');
-			return false;
+			throw new WordPressException('Failed to remove file ' . $path, $e);
 		}
 	}
 
@@ -264,7 +261,7 @@ class WP_SQLite_Filesystem extends WP_Abstract_Filesystem {
 		$path = wp_canonicalize_path($path);
 		$recursive = $options['recursive'] ?? false;
 		if (!$this->is_dir($path)) {
-			return false;
+			throw new WordPressException('Directory not found ' . $path);
 		}
 
 		$this->db->exec('BEGIN TRANSACTION');
@@ -295,10 +292,9 @@ class WP_SQLite_Filesystem extends WP_Abstract_Filesystem {
 			$stmt->execute();
 
 			$this->db->exec('COMMIT');
-			return true;
 		} catch (\Exception $e) {
 			$this->db->exec('ROLLBACK');
-			return false;
+			throw new WordPressException('Failed to remove directory ' . $path, $e);
 		}
 	}
 
@@ -329,10 +325,9 @@ class WP_SQLite_Filesystem extends WP_Abstract_Filesystem {
 			$stmt->execute();
 
 			$this->db->exec('COMMIT');
-			return true;
 		} catch (\Exception $e) {
 			$this->db->exec('ROLLBACK');
-			return false;
+			throw new WordPressException('Failed to put contents into ' . $path, $e);
 		}
 	}
 


### PR DESCRIPTION
Managing errors via a cascade of `return false` and `get_error_info()` is cumbersome and error-prone. This PR proposes migrating that to Exceptions. To avoid crashing applications with uncaught exceptions, it also drafts an error domain clas that could wrap all the registered hooks and filters.

WIP.

cc @dmsnell 