### PR TITLE
[Blueprints v2] Playground CLI compatibility

### DIFF
--- a/components/Blueprints/DataReference/DataReferenceResolver.php
+++ b/components/Blueprints/DataReference/DataReferenceResolver.php
@@ -52,7 +52,7 @@ class DataReferenceResolver {
 		$this->tmpRoot = $tmpRoot ?: wp_unix_sys_get_temp_dir();
 	}
 
-	public function setExecutionContext( Filesystem $executionContext ) {
+	public function setExecutionContext( ?Filesystem $executionContext ) {
 		$this->executionContext = $executionContext;
 	}
 

--- a/components/Blueprints/Runner.php
+++ b/components/Blueprints/Runner.php
@@ -640,9 +640,9 @@ class Runner {
 			// @TODO: Make sure this doesn't get included twice in the execution plan,
 			//        e.g. if the Blueprint specified this step manually.
 			if ( $step instanceof ImportContentStep ) {
-				if($this->configuration->isRunningAsPhar()) {
-					throw new InvalidArgumentException( '@TODO: Importing content is not supported when running as phar.' );
-				} else {
+				// if($this->configuration->isRunningAsPhar()) {
+				// 	throw new InvalidArgumentException( '@TODO: Importing content is not supported when running as phar.' );
+				// } else {
 					$libraries_phar_path = __DIR__ . '/../../dist/php-toolkit.phar';
 					if(!file_exists($libraries_phar_path)) {
 						throw new InvalidArgumentException(
@@ -655,7 +655,7 @@ class Runner {
 						'filename' => 'php-toolkit.phar',
 						'content' => file_get_contents( $libraries_phar_path )
 					] ) );
-				}
+				// }
 				array_unshift( $plan, $this->createStepObject( 'writeFiles', [
 					'files' => [
 						'php-toolkit.phar' => $source,

--- a/components/Blueprints/Runner.php
+++ b/components/Blueprints/Runner.php
@@ -114,7 +114,7 @@ class Runner {
 		$this->configuration = $configuration;
 		$this->validateConfiguration( $configuration );
 
-		$this->client      = new Client();
+		$this->client      = apply_filters('blueprint.http_client', new Client());
 		$this->mainTracker = new Tracker();
 
 		// Set up progress logging

--- a/components/Blueprints/Runner.php
+++ b/components/Blueprints/Runner.php
@@ -476,6 +476,8 @@ class Runner {
 					$this->recommendedWpVersion = $wp_version['max'];
 					$max = WordPressVersion::fromString( $wp_version['max'] );
 					if ( ! $max ) {
+						// @TODO: Reuse this error message
+						// 'Unrecognized WordPress version. Please use "latest", a URL, or a numeric version such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
 						throw new BlueprintExecutionException( 'Invalid WordPress version string in wordpressVersion.max: ' . $wp_version['max'] );
 					}
 				}

--- a/components/Blueprints/Runner.php
+++ b/components/Blueprints/Runner.php
@@ -52,6 +52,7 @@ use WordPress\Filesystem\InMemoryFilesystem;
 use WordPress\Filesystem\LocalFilesystem;
 use WordPress\HttpClient\ByteStream\RequestReadStream;
 use WordPress\HttpClient\Client;
+use WordPress\HttpClient\Request;
 use WordPress\Zip\ZipFilesystem;
 
 use function WordPress\Encoding\utf8_is_valid_byte_stream;
@@ -243,7 +244,7 @@ class Runner {
 				$this->blueprintArray,
 				$tempRoot,
 				$wpCliReference,
-				$execution_context['root']
+				isset($execution_context['root']) ? $execution_context['root'] : null
 			);
 			$this->progressObserver->setRuntime( $this->runtime );
 			$progress['wpCli']->setCaption( 'Downloading WP-CLI' );

--- a/components/Blueprints/Runner.php
+++ b/components/Blueprints/Runner.php
@@ -300,7 +300,14 @@ class Runner {
 			$blueprintString                 = $resolved->getStream()->consume_all();
 			$this->blueprintExecutionContext = LocalFilesystem::create( dirname( $reference->get_path() ) );
 		} else {
+			// For the purposes of Blueprint resolution, the execution context is the
+			// current working directory. This way, a path such as ./blueprint.json
+			// will mean "a blueprint.json file in the current working directory" and not
+			// "a ./blueprint.json path without a point of reference".
+			$this->assets->setExecutionContext( LocalFilesystem::create( getcwd() ) );
 			$resolved = $this->assets->resolve( $reference );
+			$this->assets->setExecutionContext( null );
+
 			if ( $resolved instanceof File ) {
 				$stream = $resolved->getStream();
 
@@ -388,6 +395,8 @@ class Runner {
 
 		$this->configuration->getLogger()->debug( 'Final resolved Blueprint: ' . json_encode( $this->blueprintArray, JSON_PRETTY_PRINT ) );
 
+		$this->blueprintArray = apply_filters( 'blueprint.resolved', $this->blueprintArray );
+
 		// Assert the Blueprint conforms to the latest JSON schema.
 		$v     = new HumanFriendlySchemaValidator(
 			json_decode( file_get_contents( __DIR__ . '/Versions/Version2/json-schema/schema-v2.json' ), true )
@@ -450,7 +459,7 @@ class Runner {
 		// WordPress Version Constraint
 		if ( isset( $this->blueprintArray['wordpressVersion'] ) ) {
 			$wp_version = $this->blueprintArray['wordpressVersion'];
-			$recommended = null;
+			$min = $max = $recommended = null;
 			if ( is_string( $wp_version ) ) {
 				$this->recommendedWpVersion = $wp_version;
 				$recommended = WordPressVersion::fromString( $wp_version );
@@ -499,6 +508,14 @@ class Runner {
 			// Note: In here's we're only checking if the version constraint is defined
 			// correctly. The actual version check for WordPress is done in
 			// NewSiteResolver and ExistingSiteResolver.
+		}
+
+		// Validate the override constraint if it was set
+		if ( $this->wpVersionConstraint ) {
+			$wpConstraintErrors = $this->wpVersionConstraint->validate();
+			if ( ! empty( $wpConstraintErrors ) ) {
+				throw new BlueprintExecutionException( 'Invalid WordPress version constraint from CLI override: ' . implode( '; ', $wpConstraintErrors ) );
+			}
 		}
 	}
 
@@ -934,14 +951,6 @@ PHP
 
 				return new WriteFilesStep( $files );
 
-			case 'runPHP':
-				return new RunPHPStep(
-					$this->createDataReference( [
-						'filename' => 'run-php.php',
-						'content'  => $data['code'],
-					] ),
-					$data['env'] ?? []
-				);
 			case 'unzip':
 				$zipFile = $this->createDataReference( $data['zipFile'], [ ExecutionContextPath::class ] );
 

--- a/components/Blueprints/Runner.php
+++ b/components/Blueprints/Runner.php
@@ -52,7 +52,6 @@ use WordPress\Filesystem\InMemoryFilesystem;
 use WordPress\Filesystem\LocalFilesystem;
 use WordPress\HttpClient\ByteStream\RequestReadStream;
 use WordPress\HttpClient\Client;
-use WordPress\HttpClient\Request;
 use WordPress\Zip\ZipFilesystem;
 
 use function WordPress\Encoding\utf8_is_valid_byte_stream;
@@ -60,6 +59,13 @@ use function WordPress\Filesystem\wp_unix_sys_get_temp_dir;
 use function WordPress\Zip\is_zip_file_stream;
 
 class Runner {
+	const EXECUTION_MODE_CREATE_NEW_SITE = 'create-new-site';
+	const EXECUTION_MODE_APPLY_TO_EXISTING_SITE = 'apply-to-existing-site';
+	const EXECUTION_MODES = [
+		self::EXECUTION_MODE_CREATE_NEW_SITE,
+		self::EXECUTION_MODE_APPLY_TO_EXISTING_SITE,
+	];
+	
 	/**
 	 * @var RunnerConfiguration
 	 */
@@ -135,17 +141,17 @@ class Runner {
 
 		// Validate execution mode
 		$mode = $config->getExecutionMode();
-		if ( ! in_array( $mode, [ 'create-new-site', 'apply-to-existing-site' ], true ) ) {
-			throw new BlueprintExecutionException( "Execution mode must be either 'create-new-site' or 'apply-to-existing-site'." );
+		if ( ! in_array( $mode, self::EXECUTION_MODES, true ) ) {
+			throw new BlueprintExecutionException( "Execution mode must be one of: " . implode( ', ', self::EXECUTION_MODES ) );
 		}
 
 		// Validate site URL
 		// Note: $options is not defined in this context, so we skip this block.
 		// If you want to validate the site URL, you should use $config->getTargetSiteUrl().
 		$siteUrl = $config->getTargetSiteUrl();
-		if ( $mode === 'create-new-site' ) {
+		if ( $mode === self::EXECUTION_MODE_CREATE_NEW_SITE ) {
 			if ( empty( $siteUrl ) ) {
-				throw new BlueprintExecutionException( "Site URL is required when the execution mode is 'create-new-site'." );
+				throw new BlueprintExecutionException( sprintf( "Site URL is required when the execution mode is '%s'.", self::EXECUTION_MODE_CREATE_NEW_SITE ) );
 			}
 		}
 		if ( ! empty( $siteUrl ) && ! filter_var( $siteUrl, FILTER_VALIDATE_URL ) ) {
@@ -253,7 +259,7 @@ class Runner {
 			], $progress['wpCli'] );
 
 			$progress['targetResolution']->setCaption( 'Resolving target site' );
-			if ( $this->configuration->getExecutionMode() === 'apply-to-existing-site' ) {
+			if ( $this->configuration->getExecutionMode() === self::EXECUTION_MODE_APPLY_TO_EXISTING_SITE ) {
 				ExistingSiteResolver::resolve( $this->runtime, $progress['targetResolution'], $this->wpVersionConstraint );
 			} else {
 				NewSiteResolver::resolve( $this->runtime, $progress['targetResolution'], $this->wpVersionConstraint, $this->recommendedWpVersion );

--- a/components/Blueprints/Runner.php
+++ b/components/Blueprints/Runner.php
@@ -227,8 +227,13 @@ class Runner {
 			$targetSiteFs   = LocalFilesystem::create( $this->configuration->getTargetSiteRoot() );
 			$wpCliReference = DataReference::create( 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar' );
 
-			$execution_context_root = $this->blueprintExecutionContext->get_meta()['root'];
-			assert(is_string($execution_context_root) && strlen($execution_context_root) > 0, 'Assertion failed: Execution context root was empty.');
+			$execution_context = $this->blueprintExecutionContext->get_meta();
+			if(
+				isset($execution_context['root']) &&
+				( !is_string($execution_context['root']) || strlen($execution_context['root']) === 0)
+			) {
+				throw new BlueprintExecutionException('Execution context was a local directory, but the Runner could not determine the root directory. This should never happen. Please report this as a bug.');
+			}
 
 			$this->runtime  = new Runtime(
 				$targetSiteFs,
@@ -238,7 +243,7 @@ class Runner {
 				$this->blueprintArray,
 				$tempRoot,
 				$wpCliReference,
-				$execution_context_root
+				$execution_context['root']
 			);
 			$this->progressObserver->setRuntime( $this->runtime );
 			$progress['wpCli']->setCaption( 'Downloading WP-CLI' );

--- a/components/Blueprints/RunnerConfiguration.php
+++ b/components/Blueprints/RunnerConfiguration.php
@@ -23,7 +23,7 @@ class RunnerConfiguration {
 	/**
 	 * @var string
 	 */
-	private $mode = 'create-new-site';    // or apply-to-existing-site
+	private $mode = Runner::EXECUTION_MODE_CREATE_NEW_SITE;
 	/**
 	 * @var string
 	 */

--- a/components/Blueprints/Runtime.php
+++ b/components/Blueprints/Runtime.php
@@ -75,7 +75,7 @@ class Runtime {
 		array $blueprint,
 		string $tempRoot,
 		DataReference $wpCliReference,
-		string $executionContextRoot
+		?string $executionContextRoot=null
 	) {
 		$this->targetFs       = $targetFs;
 		$this->configuration  = $configuration;
@@ -87,7 +87,7 @@ class Runtime {
 		$this->executionContextRoot = $executionContextRoot;
 	}
 
-	public function getExecutionContextRoot(): string {
+	public function getExecutionContextRoot(): ?string {
 		return $this->executionContextRoot;
 	}
 

--- a/components/Blueprints/Runtime.php
+++ b/components/Blueprints/Runtime.php
@@ -263,7 +263,7 @@ class Runtime {
 			$phpBinary = null;
 			if ( getenv('PHP_BINARY') ) {
 				$phpBinary = getenv('PHP_BINARY');
-			} elseif ( PHP_SAPI === 'cli' && isset($_SERVER['argv'][0]) ) {
+			} elseif ( PHP_BINARY ) {
 				$phpBinary = PHP_BINARY;
 			} else {
 				$phpBinary = 'php';

--- a/components/Blueprints/Runtime.php
+++ b/components/Blueprints/Runtime.php
@@ -231,8 +231,9 @@ class Runtime {
 		$process = $this->createPhpSubProcess( $code, $env, $input, $timeout );
 		$process->mustRun();
 
+		$output = $process->getOutputStream(Process::OUTPUT_FILE)->consume_all();
 		return new EvalResult(
-			$process->getOutputStream(Process::OUTPUT_FILE)->consume_all(),
+			$output,
 			$process
 		);
 	}

--- a/components/Blueprints/SiteResolver/NewSiteResolver.php
+++ b/components/Blueprints/SiteResolver/NewSiteResolver.php
@@ -67,6 +67,10 @@ class NewSiteResolver {
 
 		// If SQLite integration zip provided, unzip into appropriate folder
 		if ( $runtime->getConfiguration()->getDatabaseEngine() === 'sqlite' ) {
+			/*
+			 * @TODO: Ensure DB_NAME gets defined in wp-config.php before installing the SQLite plugin.
+			 */
+
 			$progress['resolve_assets']->setCaption( 'Downloading SQLite integration plugin' );
 			$resolved = $runtime->resolve( $assets['sqlite-integration'] );
 			if ( ! $resolved instanceof File ) {
@@ -115,7 +119,7 @@ class NewSiteResolver {
 				$wp_cli_path,
 				'core',
 				'install',
-				'--path=' . getenv('DOCROOT'),
+				'--path=' . $runtime->getConfiguration()->getTargetSiteRoot(),
 
 				// For Docker compatibility. If we got this far, Blueprint runner was already
 				// allowed to run as root.
@@ -149,7 +153,8 @@ class NewSiteResolver {
 			require $wp_load;
 
 			append_output( function_exists('is_blog_installed') && is_blog_installed() ? '1' : '0' );
-PHP,
+PHP
+			,
 			[
 				'DOCROOT' => getenv('DOCROOT'),
 			],

--- a/components/Blueprints/SiteResolver/NewSiteResolver.php
+++ b/components/Blueprints/SiteResolver/NewSiteResolver.php
@@ -115,8 +115,8 @@ class NewSiteResolver {
 				$wp_cli_path,
 				'core',
 				'install',
-				// @TODO: DOCROOT is empty in Playground CLI
-				// '--path=' . getenv('DOCROOT'),
+				'--path=' . getenv('DOCROOT'),
+
 				// For Docker compatibility. If we got this far, Blueprint runner was already
 				// allowed to run as root.
 				'--allow-root',

--- a/components/Blueprints/SiteResolver/NewSiteResolver.php
+++ b/components/Blueprints/SiteResolver/NewSiteResolver.php
@@ -156,7 +156,7 @@ class NewSiteResolver {
 PHP
 			,
 			[
-				'DOCROOT' => getenv('DOCROOT'),
+				'DOCROOT' => $runtime->getConfiguration()->getTargetSiteRoot(),
 			],
 			null,
 			5

--- a/components/Blueprints/SiteResolver/NewSiteResolver.php
+++ b/components/Blueprints/SiteResolver/NewSiteResolver.php
@@ -9,6 +9,7 @@ use WordPress\Blueprints\Progress\Tracker;
 use WordPress\Blueprints\Runtime;
 use WordPress\Blueprints\VersionStrings\VersionConstraint;
 use WordPress\HttpClient\Client;
+use WordPress\HttpClient\Request;
 use WordPress\Zip\ZipFilesystem;
 
 use function WordPress\Filesystem\copy_between_filesystems;
@@ -96,22 +97,7 @@ class NewSiteResolver {
 		//    Technically, this is a "new site" resolver, but it's entirely possible
 		//    the developer-provided WordPress zip already has a sqlite database with the
 		//    a WordPress site installed..
-		$installCheck = $runtime->evalPhpCodeInSubProcess(
-			<<<'PHP'
-<?php
-$wp_load = getenv('DOCROOT') . '/wp-load.php';
-if (!file_exists($wp_load)) {
-append_output('0');
-exit;
-}
-require $wp_load;
-
-append_output( function_exists('is_blog_installed') && is_blog_installed() ? '1' : '0' );
-PHP
-
-		)->outputFileContent;
-
-		if ( trim( $installCheck ) !== '1' ) {
+		if ( ! self::isWordPressInstalled( $runtime, $progress ) ) {
 			if ( ! $targetFs->exists( '/wp-config.php' ) ) {
 				if ( $targetFs->exists( 'wp-config-sample.php' ) ) {
 					$targetFs->copy( 'wp-config-sample.php', 'wp-config.php' );
@@ -129,6 +115,8 @@ PHP
 				$wp_cli_path,
 				'core',
 				'install',
+				// @TODO: DOCROOT is empty in Playground CLI
+				// '--path=' . getenv('DOCROOT'),
 				// For Docker compatibility. If we got this far, Blueprint runner was already
 				// allowed to run as root.
 				'--allow-root',
@@ -140,8 +128,36 @@ PHP
 				'--skip-email',
 			] );
 			$process->mustRun();
+
+			if ( ! self::isWordPressInstalled( $runtime, $progress ) ) {
+				// @TODO: This breaks in Playground CLI
+				throw new BlueprintExecutionException( 'WordPress installation failed' );
+			}
 		}
 		$progress->finish();
+	}
+
+	static private function isWordPressInstalled( Runtime $runtime, Tracker $progress ) {
+		$installCheck = $runtime->evalPhpCodeInSubProcess(
+			<<<'PHP'
+			<?php
+			$wp_load = getenv('DOCROOT') . '/wp-load.php';
+			if (!file_exists($wp_load)) {
+				append_output('0');
+				exit;
+			}
+			require $wp_load;
+
+			append_output( function_exists('is_blog_installed') && is_blog_installed() ? '1' : '0' );
+PHP,
+			[
+				'DOCROOT' => getenv('DOCROOT'),
+			],
+			null,
+			5
+		)->outputFileContent;
+
+		return trim( $installCheck ) === '1';
 	}
 
 	static private function resolveWordPressZipUrl( Client $client, string $version_string ): string {
@@ -160,13 +176,19 @@ PHP
 			return 'https://wordpress.org/nightly-builds/wordpress-latest.zip';
 		}
 
-		$latestVersions = $client->fetch( 'https://api.wordpress.org/core/version-check/1.7/?channel=beta' )->json();
+		$latestVersions = $client->fetch( new Request( 'https://api.wordpress.org/core/version-check/1.7/?channel=beta' ) )->json();
 
 		$latestVersions = array_filter( $latestVersions['offers'], function ( $v ) {
 			return $v['response'] === 'autoupdate';
 		} );
-
+		$latestNonBeta = null;
+		
 		foreach ( $latestVersions as $apiVersion ) {
+			// Keep track of the first non-beta version (which is the latest)
+			if ( $latestNonBeta === null && strpos( $apiVersion['version'], 'beta' ) === false ) {
+				$latestNonBeta = $apiVersion;
+			}
+			
 			if ( $version_string === 'beta' && strpos( $apiVersion['version'], 'beta' ) !== false ) {
 				return $apiVersion['download'];
 			} elseif (
@@ -188,6 +210,11 @@ PHP
 				// version, e.g. "6.6"
 				return $apiVersion['download'];
 			}
+		}
+		
+		// If we're looking for beta but no beta was found, return latest
+		if ( $version_string === 'beta' && $latestNonBeta !== null ) {
+			return $latestNonBeta['download'];
 		}
 
 		/**

--- a/components/Blueprints/Steps/ImportContentStep.php
+++ b/components/Blueprints/Steps/ImportContentStep.php
@@ -68,7 +68,7 @@ class ImportContentStep implements StepInterface {
 <?php
 run_content_import([
 	'mode' => 'wxr',
-	'execution_context_root' => getenv('EXECUTION_CONTEXT'),
+	'execution_context_root' => getenv('EXECUTION_CONTEXT') ? getenv('EXECUTION_CONTEXT') : null,
 	'source' => json_decode(getenv('DATA_SOURCE_DEFINITION'), true),
 	// @TODO: Support arbitrary media URLs to enable fetching assets during import.
 	// 'media_url' => 'https://pd.w.org/'
@@ -99,8 +99,11 @@ PHP
 					break;
 				case 'error':
 					throw new BlueprintExecutionException( $data['message'] );
+				case 'completion':
+					$progress->finish();
+					break;
 				default:
-					throw new BlueprintExecutionException( 'Unknown messagetype: ' . $data['type'] );
+					throw new BlueprintExecutionException( 'Unknown message type: ' . $data['type'] );
 			}
 		}
 

--- a/components/Blueprints/Steps/InstallPluginStep.php
+++ b/components/Blueprints/Steps/InstallPluginStep.php
@@ -154,7 +154,7 @@ if ( ! class_exists( '\WP_Upgrader_Skin', false ) ) {
 
 		public function feedback( $string, ...$args ) {
 			// For debugging
-			error_log( sprintf( $string, ...$args ) );
+			fwrite( STDERR, sprintf( $string, ...$args ) . "\n" );
 		}
 
 		public function header() {
@@ -191,41 +191,34 @@ $admins = get_users( array( 'role' => 'Administrator' ) );
 if ( ! empty( $admins ) ) {
 	wp_set_current_user( $admins[0]->ID );
 } else {
-	error_log( "No admin user found to perform plugin installation." );
+	fwrite( STDERR, "No admin user found to perform plugin installation." . "\n" );
 	exit( 1 );
 }
 
 $plugin_zip_path = getenv( 'PLUGIN_ZIP_PATH' );
 if ( ! $plugin_zip_path ) {
-	error_log( "PLUGIN_ZIP_PATH environment variable not set." );
+	fwrite( STDERR, "PLUGIN_ZIP_PATH environment variable not set." . "\n" );
 	exit( 1 );
 }
 
 if ( ! file_exists( $plugin_zip_path ) ) {
-	error_log( "Plugin zip file not found at " . $plugin_zip_path );
+	fwrite( STDERR, "Plugin zip file not found at " . $plugin_zip_path . "\n" );
 	exit( 1 );
 }
 
 // List files from the plugin zip
 $zip = new ZipArchive();
 if ( $zip->open( $plugin_zip_path ) !== true ) {
-	error_log( "Failed to open plugin zip file: " . $plugin_zip_path );
+	fwrite( STDERR, "Failed to open plugin zip file: " . $plugin_zip_path . "\n" );
 	exit( 1 );
 }
 
-error_log( "Plugin zip contents:" );
+fwrite( STDERR, "Plugin zip contents:" . "\n" );
 for ( $i = 0; $i < $zip->numFiles; $i ++ ) {
 	$filename = $zip->getNameIndex( $i );
 	$stats    = $zip->statIndex( $i );
 	$size     = $stats['size'];
 	$is_dir   = substr( $filename, - 1 ) === '/';
-
-	error_log( sprintf(
-		"%s%s (%s bytes)",
-		$filename,
-		$is_dir ? " [directory]" : "",
-		$size
-	) );
 }
 
 // Extract plugin slug from the zip file
@@ -244,7 +237,7 @@ $zip->close();
 // Make sure the destination directory is writable
 $wp_plugin_dir = WP_PLUGIN_DIR;
 if ( ! is_writable( $wp_plugin_dir ) ) {
-	error_log( "Plugin directory is not writable: " . $wp_plugin_dir );
+	fwrite( STDERR, "Plugin directory is not writable: " . $wp_plugin_dir . "\n" );
 	// Try to fix permissions
 	@chmod( $wp_plugin_dir, 0755 );
 	if ( ! is_writable( $wp_plugin_dir ) ) {
@@ -269,7 +262,7 @@ if ( ! empty( $plugin_slug ) ) {
 	// Create the directory
 	$GLOBALS['wp_filesystem']->mkdir( $target_directory );
 
-	error_log( "Created target directory: " . $target_directory );
+	fwrite( STDERR, "Created target directory: " . $target_directory . "\n" );
 }
 
 // Install the plugin
@@ -281,22 +274,22 @@ $result = $upgrader->install( $plugin_zip_path, array(
 // Check for filesystem errors
 if ( $GLOBALS['wp_filesystem']->errors->has_errors() ) {
 	foreach ( $GLOBALS['wp_filesystem']->errors->get_error_messages() as $message ) {
-		error_log( "Filesystem error: " . $message );
+		fwrite( STDERR, "Filesystem error: " . $message . "\n" );
 	}
 	exit( 1 );
 }
 
 if ( is_wp_error( $result ) ) {
-	error_log( "Failed to install plugin (1): " . $result->get_error_message() );
+	fwrite( STDERR, "Failed to install plugin (1): " . $result->get_error_message() . "\n" );
 	exit( 1 );
 }
 
 if ( $result === false || $result === null ) {
 	// Check skin for errors if $result is not specific.
 	if ( isset( $skin->result ) && is_wp_error( $skin->result ) ) {
-		error_log( "Failed to install plugin (2): " . $skin->result->get_error_message() );
+		fwrite( STDERR, "Failed to install plugin (2): " . $skin->result->get_error_message() . "\n" );
 	} else {
-		error_log( "Failed to install plugin for an unknown reason." );
+		fwrite( STDERR, "Failed to install plugin for an unknown reason." . "\n" );
 	}
 	exit( 1 );
 }
@@ -304,14 +297,14 @@ if ( $result === false || $result === null ) {
 // Installation successful, find the main plugin file.
 $plugin_folder_name = ! empty( $plugin_slug ) ? $plugin_slug : ( $upgrader->result['destination_name'] ?? null );
 if ( ! $plugin_folder_name ) {
-	error_log( "Could not determine plugin folder name after installation." );
+	fwrite( STDERR, "Could not determine plugin folder name after installation." . "\n" );
 	exit( 1 );
 }
 
 // Get all plugins within the newly installed folder.
 $plugins_in_folder = get_plugins( '/' . $plugin_folder_name );
 if ( empty( $plugins_in_folder ) ) {
-	error_log( "Could not find any plugin files in the installed folder: " . $plugin_folder_name );
+	fwrite( STDERR, "Could not find any plugin files in the installed folder: " . $plugin_folder_name . "\n" );
 	exit( 1 );
 }
 // The key of the first plugin entry is the relative path needed for activation.

--- a/components/Blueprints/Steps/WPCLIStep.php
+++ b/components/Blueprints/Steps/WPCLIStep.php
@@ -43,7 +43,7 @@ class WPCLIStep implements StepInterface {
 			// For Docker compatibility. If we got this far, the Blueprint runner was already
 			// allowed to run as root.
 			'--allow-root',
-			'--path=/wordpress', // . (getenv('DOCROOT') ?? '/wordpress'),
+			'--path=' . $runtime->getConfiguration()->getTargetSiteRoot(),
 			substr($command, 3),
 		]);
 		$process = $runtime->startShellCommand( $command );

--- a/components/Blueprints/Steps/WPCLIStep.php
+++ b/components/Blueprints/Steps/WPCLIStep.php
@@ -43,6 +43,7 @@ class WPCLIStep implements StepInterface {
 			// For Docker compatibility. If we got this far, the Blueprint runner was already
 			// allowed to run as root.
 			'--allow-root',
+			'--path=/wordpress', // . (getenv('DOCROOT') ?? '/wordpress'),
 			substr($command, 3),
 		]);
 		$process = $runtime->startShellCommand( $command );

--- a/components/Blueprints/Steps/scripts/import-content.php
+++ b/components/Blueprints/Steps/scripts/import-content.php
@@ -10,6 +10,7 @@ use WordPress\HttpClient\Client;
 use WordPress\DataLiberation\EntityReader\EPubEntityReader;
 use WordPress\DataLiberation\EntityReader\FilesystemEntityReader;
 use WordPress\DataLiberation\EntityReader\WXREntityReader;
+use WordPress\DataLiberation\Importer\EntityImporter;
 use WordPress\DataLiberation\Importer\ImportSession;
 use WordPress\DataLiberation\Importer\ImportUtils;
 use WordPress\DataLiberation\Importer\RetryFrontloadingIterator;
@@ -569,6 +570,7 @@ function run_content_import( $options ) {
 		$importer = StreamImporter::create(
 			$entity_reader_factory,
 			array(
+				'entity_sink' => new EntityImporter(),
 				'source_site_url' => $source_site_url,
 				'new_site_content_root_url' => NEW_SITE_CONTENT_ROOT,
 				'source_media_root_urls' => $options['media_url'] ?? array( $source_site_url ),

--- a/components/Blueprints/Steps/scripts/import-content.php
+++ b/components/Blueprints/Steps/scripts/import-content.php
@@ -244,10 +244,6 @@ function run_content_import( $options ) {
 			bail_out( 'The "source" option is required.' );
 		}
 
-		if(!isset($options['execution_context_root'])) {
-			bail_out( 'The "execution_context_root" option is required.' );
-		}
-
 		// Set up progress stages
 		$mainTracker->split([
 			'setup' => ['ratio' => 10, 'caption' => 'Setting up import'],
@@ -263,9 +259,12 @@ function run_content_import( $options ) {
 		$content_source = DataReference::create($options['source'], [
 			ExecutionContextPath::class,
 		]);
-		$execution_context = LocalFilesystem::create($options['execution_context_root']);
 		$resolver = new DataReferenceResolver($httpClient);
-		$resolver->setExecutionContext($execution_context);
+		if(isset($options['execution_context_root']) && $options['execution_context_root'] !== '') {
+			$resolver->setExecutionContext(
+				LocalFilesystem::create($options['execution_context_root'])
+			);
+		}
 		$resolved_source = $resolver->resolve_uncached($content_source);
 
 		$setupTracker->set(30, 'Configuring import mode');

--- a/components/Blueprints/VersionStrings/WordPressVersion.php
+++ b/components/Blueprints/VersionStrings/WordPressVersion.php
@@ -46,7 +46,7 @@ class WordPressVersion implements Version {
 	 * @return $this|false|null
 	 */
 	static public function fromString( string $raw ) {
-		if(in_array($raw, ['beta','trunk'], true)) {
+		if(in_array($raw, ['beta','trunk','latest'], true)) {
 			return null;
 		}
 		if(substr($raw, 0, 8) === 'https://') {

--- a/components/Blueprints/Versions/Version1/V1ToV2Transpiler.php
+++ b/components/Blueprints/Versions/Version1/V1ToV2Transpiler.php
@@ -215,18 +215,7 @@ class V1ToV2Transpiler {
 						$this->logger->warning( 'The `enableMultisite` step is not supported by the Blueprint v2 schema and will be ignored.' );
 						break;
 					case 'importWordPressFiles':
-						if ( isset( $v1step['progress'] ) ) {
-							$this->logger->warning( 'The `progress` option is not supported on importWordPressFiles step and will be ignored: %s. Use the runtime configuration to set the progress bar instead.' );
-						}
-						if ( isset( $v1step['pathInZip'] ) ) {
-							$this->logger->warning( 'The `pathInZip` option is not supported on importWordPressFiles step. The entire step will be ignored.' );
-						} else {
-							/**
-							 * wordPressFilesZip refers to a zip file with a full WordPress installation.
-							 * It's relevant for the target site resolution stage, not as a step.
-							 */
-							$v2['wordpressVersion'] = self::convertV1ResourceToV2Reference( $v1step['wordPressFilesZip'] );
-						}
+						$this->logger->warning( 'The `importWordPressFiles` step is not supported by the Blueprint v2 schema. The entire step will be ignored.' );
 						break;
 					case 'runWpInstallationWizard':
 						$this->logger->warning( 'The `runWpInstallationWizard` step is not supported by the Blueprint v2 schema. Provide your WordPress export URL in the top-level "wordpressVersion" key and the runner will handle the installation automatically.' );

--- a/components/Blueprints/Versions/Version1/schema-v1.json
+++ b/components/Blueprints/Versions/Version1/schema-v1.json
@@ -144,6 +144,10 @@
 					"description": "User to log in as. If true, logs the user in as admin/password."
 				},
 				"phpExtensionBundles": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
 					"deprecated": "No longer used. Feel free to remove it from your Blueprint."
 				},
 				"steps": {

--- a/components/Blueprints/bin/blueprint.php
+++ b/components/Blueprints/bin/blueprint.php
@@ -352,7 +352,7 @@ function handleExecCommand( array $positionalArgs, array $options, array $comman
 		$permission = $ex->getPermission();
 		$flag       = RunnerConfiguration::getPermissionCliFlag( $permission );
 
-		$progressReporter->reportError(sprintf("Permission Error: %s", $ex->getMessage()));
+		$progressReporter->reportError(sprintf("Permission Error: %s", $ex->getMessage()), $ex);
 		$progressReporter->reportError(sprintf("Tip: Run with --allow=%s to grant this permission.", $flag));
 		exit( 1 );
 	}
@@ -609,7 +609,7 @@ try {
 		exit( 1 );
 	}
 
-	$progressReporter->reportError($ex->getMessage() . " See the validation errors below:");
+	$progressReporter->reportError($ex->getMessage() . ' See the validation errors below:');
 	$lastPrettyPath = '';
 	$currentError   = $ex->schemaError;
 	while ( $currentError ) {
@@ -623,7 +623,6 @@ try {
 	}
 	exit( 1 );
 } catch ( Exception $ex ) {
-	$progressReporter->reportError($ex->getMessage());
-	$progressReporter->reportError("Try 'help' for usage.");
+	$progressReporter->reportError($ex->getMessage(), $ex);
 	exit( 1 );
 }

--- a/components/Blueprints/bin/blueprint.php
+++ b/components/Blueprints/bin/blueprint.php
@@ -256,7 +256,7 @@ $commandConfigurations = [
 			'site-url'                    => [ 'u', true, null, 'Public site URL (https://example.com)' ],
 			'site-path'                   => [ null, true, null, 'Target directory with WordPress install context)' ],
 			'execution-context'           => [ 'x', true, null, 'Source directory with Blueprint context files' ],
-			'mode'                        => [ 'm', true, 'create-new-site', 'Execution mode (create-new-site|apply-to-existing-site)' ],
+			'mode'                        => [ 'm', true, Runner::EXECUTION_MODE_CREATE_NEW_SITE, sprintf( 'Execution mode (%s|%s)', Runner::EXECUTION_MODE_CREATE_NEW_SITE, Runner::EXECUTION_MODE_APPLY_TO_EXISTING_SITE ) ],
 			'db-engine'                   => [ 'd', true, 'mysql', 'Database engine (mysql|sqlite)' ],
 			'db-host'                     => [ null, true, '127.0.0.1', 'MySQL host' ],
 			'db-user'                     => [ null, true, 'root', 'MySQL user' ],
@@ -280,7 +280,7 @@ $commandConfigurations = [
 		] ),
 		'examples'        => [
 			'php blueprint.php exec my-blueprint.json --site-url https://mysite.test --site-path /var/www/mysite.com',
-			'php blueprint.php exec my-blueprint.json --execution-context /var/www --site-url https://mysite.test --mode apply-to-existing-site --site-path ./site',
+			sprintf( 'php blueprint.php exec my-blueprint.json --execution-context /var/www --site-url https://mysite.test --mode %s --site-path ./site', Runner::EXECUTION_MODE_APPLY_TO_EXISTING_SITE ),
 			'php blueprint.php exec my-blueprint.json --site-url https://mysite.test --site-path ./mysite --truncate-new-site-directory',
 		],
 		'aliases'         => [ 'run' ],
@@ -350,7 +350,7 @@ function handleExecCommand( array $positionalArgs, array $options, array $comman
 		$runner = new Runner( $config );
 
 		// Execute the Blueprint
-		if ( $config->getExecutionMode() === 'create-new-site' ) {
+		if ( $config->getExecutionMode() === Runner::EXECUTION_MODE_CREATE_NEW_SITE ) {
 			$progressReporter->reportProgress(0, 'Creating a new site');
 		} else {
 			$progressReporter->reportProgress(0, 'Updating an existing site');
@@ -405,24 +405,23 @@ function cliArgsToRunnerConfiguration( array $positionalArgs, array $options ): 
 	}
 
 	if ( ! empty( $options['mode'] ) ) {
-		// Accept 'create-new-site' or 'apply-to-existing-site' as CLI values, map to internal values
 		$mode = $options['mode'];
-		if ( $mode === 'create-new-site' ) {
-			$config->setExecutionMode( 'create-new-site' );
-		} elseif ( $mode === 'apply-to-existing-site' ) {
-			$config->setExecutionMode( 'apply-to-existing-site' );
+		if ( $mode === Runner::EXECUTION_MODE_CREATE_NEW_SITE ) {
+			$config->setExecutionMode( Runner::EXECUTION_MODE_CREATE_NEW_SITE );
+		} elseif ( $mode === Runner::EXECUTION_MODE_APPLY_TO_EXISTING_SITE ) {
+			$config->setExecutionMode( Runner::EXECUTION_MODE_APPLY_TO_EXISTING_SITE );
 			if(!empty($options['wp'])) {
-				throw new InvalidArgumentException( "The --wp option cannot be used with --mode=apply-to-existing-site. The WordPress version is whatever the existing site has." );
+				throw new InvalidArgumentException( sprintf( "The --wp option cannot be used with --mode=%s. The WordPress version is whatever the existing site has.", Runner::EXECUTION_MODE_APPLY_TO_EXISTING_SITE ) );
 			}
 		} else {
-			throw new InvalidArgumentException( "Invalid execution mode: {$mode}. Supported modes are: create-new-site, apply-to-existing-site" );
+			throw new InvalidArgumentException( sprintf( "Invalid execution mode: '{$mode}'. Supported modes are: %s", implode( ', ', Runner::EXECUTION_MODES ) ) );
 		}
 	}
 
 	$targetSiteRoot         = $options['site-path'];
 	if ( $options['truncate-new-site-directory'] ) {
-		if ( $options['mode'] !== 'create-new-site' ) {
-			throw new InvalidArgumentException( "--truncate-new-site-directory can only be used with --mode=create-new-site" );
+		if ( $options['mode'] !== Runner::EXECUTION_MODE_CREATE_NEW_SITE ) {
+			throw new InvalidArgumentException( sprintf( "--truncate-new-site-directory can only be used with --mode=%s", Runner::EXECUTION_MODE_CREATE_NEW_SITE ) );
 		}
 		$absoluteTargetSiteRoot = realpath( $targetSiteRoot );
 		if ( false === $absoluteTargetSiteRoot) {

--- a/components/Blueprints/bin/blueprint.php
+++ b/components/Blueprints/bin/blueprint.php
@@ -428,8 +428,19 @@ function cliArgsToRunnerConfiguration( array $positionalArgs, array $options ): 
 			mkdir( $targetSiteRoot, 0755, true );
 		} else if( is_dir( $absoluteTargetSiteRoot ) ) {
 			$fs = LocalFilesystem::create( $absoluteTargetSiteRoot );
-			$fs->rmdir( '/', [ 'recursive' => true ] );
-			$fs->mkdir( '/', [ 'chmod' => 0755 ] );
+			// Delete all the files and directories in the target site root, but preserve the
+			// target directory itself. Why? In Playground CLI, `/wordpress` is likely to be a
+			// mount removing a mount root throws an Exception.
+			foreach ( $fs->ls('/') as $file ) {
+				if( $fs->is_dir( $file ) ) {
+					$fs->rmdir( $file, [ 'recursive' => true ] );
+				} else {
+					$fs->rm( $file );
+				}
+			}
+			if ( ! $fs->is_dir( '/' ) ) {
+				$fs->mkdir( '/', [ 'chmod' => 0755 ] );
+			}
 		} 
 	}
 

--- a/components/Blueprints/bin/blueprint.php
+++ b/components/Blueprints/bin/blueprint.php
@@ -230,6 +230,7 @@ function createProgressReporter(): ProgressReporter {
     return new TerminalProgressReporter();
 }
 
+
 $progressReporter = createProgressReporter();
 
 // -----------------------------------------------------------------------------

--- a/components/Blueprints/bin/blueprint.php
+++ b/components/Blueprints/bin/blueprint.php
@@ -36,6 +36,7 @@ require __DIR__ . '/../../../vendor/autoload.php';
 use WordPress\CLI\CLI;
 use WordPress\Blueprints\DataReference\AbsoluteLocalPath;
 use WordPress\Blueprints\DataReference\DataReference;
+use WordPress\Blueprints\DataReference\ExecutionContextPath;
 use WordPress\Blueprints\Exception\BlueprintExecutionException;
 use WordPress\Blueprints\Exception\PermissionsException;
 use WordPress\Blueprints\Logger\CLILogger;
@@ -255,7 +256,7 @@ $commandConfigurations = [
 			'site-url'                    => [ 'u', true, null, 'Public site URL (https://example.com)' ],
 			'site-path'                   => [ null, true, null, 'Target directory with WordPress install context)' ],
 			'execution-context'           => [ 'x', true, null, 'Source directory with Blueprint context files' ],
-			'mode'                        => [ 'm', true, 'create-new-site', 'Execution mode (create|apply)' ],
+			'mode'                        => [ 'm', true, 'create-new-site', 'Execution mode (create-new-site|apply-to-existing-site)' ],
 			'db-engine'                   => [ 'd', true, 'mysql', 'Database engine (mysql|sqlite)' ],
 			'db-host'                     => [ null, true, '127.0.0.1', 'MySQL host' ],
 			'db-user'                     => [ null, true, 'root', 'MySQL user' ],
@@ -279,7 +280,7 @@ $commandConfigurations = [
 		] ),
 		'examples'        => [
 			'php blueprint.php exec my-blueprint.json --site-url https://mysite.test --site-path /var/www/mysite.com',
-			'php blueprint.php exec my-blueprint.json --execution-context /var/www --site-url https://mysite.test --mode apply --site-path ./site',
+			'php blueprint.php exec my-blueprint.json --execution-context /var/www --site-url https://mysite.test --mode apply-to-existing-site --site-path ./site',
 			'php blueprint.php exec my-blueprint.json --site-url https://mysite.test --site-path ./mysite --truncate-new-site-directory',
 		],
 		'aliases'         => [ 'run' ],
@@ -397,9 +398,10 @@ function cliArgsToRunnerConfiguration( array $positionalArgs, array $options ): 
 		$blueprint_reference = $positionalArgs[0];
 		$config->setBlueprint( DataReference::create( $blueprint_reference, [
 			AbsoluteLocalPath::class,
+			ExecutionContextPath::class,
 		] ) );
 	} catch ( InvalidArgumentException $e ) {
-		throw new InvalidArgumentException( "Invalid Blueprint reference: " . $positionalArgs[0] );
+		throw new InvalidArgumentException( sprintf( "Invalid Blueprint reference: %s. Hint: paths must start with ./ or /. URLs must start with http:// or https://.", $positionalArgs[0] ) );
 	}
 
 	if ( ! empty( $options['mode'] ) ) {
@@ -409,6 +411,9 @@ function cliArgsToRunnerConfiguration( array $positionalArgs, array $options ): 
 			$config->setExecutionMode( 'create-new-site' );
 		} elseif ( $mode === 'apply-to-existing-site' ) {
 			$config->setExecutionMode( 'apply-to-existing-site' );
+			if(!empty($options['wp'])) {
+				throw new InvalidArgumentException( "The --wp option cannot be used with --mode=apply-to-existing-site. The WordPress version is whatever the existing site has." );
+			}
 		} else {
 			throw new InvalidArgumentException( "Invalid execution mode: {$mode}. Supported modes are: create-new-site, apply-to-existing-site" );
 		}

--- a/components/Blueprints/bin/blueprint.php
+++ b/components/Blueprints/bin/blueprint.php
@@ -262,6 +262,18 @@ $commandConfigurations = [
 			'db-name'                     => [ null, true, 'wordpress', 'MySQL database' ],
 			'db-path'                     => [ 'p', true, 'wp.db', 'SQLite file path' ],
 			'truncate-new-site-directory' => [ 't', false, false, 'Delete target directory if it exists before execution' ],
+			/**
+			 * @TODO: Reuse this error message removed from the Playground repo:
+			 * 
+			 *			if (!blueprintMayReadAdjacentFiles) {
+			 *				throw new ReportableError(
+			 *					`Error: Blueprint contained tried to read a local file at path "${path}" (via a resource of type "bundled"). ` +
+			 *						`Playground restricts access to local resources by default as a security measure. \n\n` +
+			 *						`You can allow this Blueprint to read files from the same parent directory by explicitly adding the ` +
+			 *						`--blueprint-may-read-adjacent-files option to your command.`
+			 *				);
+			 *			}
+			 */
 			'allow'                       => [ null, true, null, 'Allowed permissions. One of: ' . implode( ', ', $supportedPermissions ) ],
 		] ),
 		'examples'        => [

--- a/components/ByteStream/ReadStream/BaseByteReadStream.php
+++ b/components/ByteStream/ReadStream/BaseByteReadStream.php
@@ -7,7 +7,7 @@ use WordPress\ByteStream\NotEnoughDataException;
 
 abstract class BaseByteReadStream implements ByteReadStream {
 
-	const CHUNK_SIZE = 100;// 64 * 1024;
+	const CHUNK_SIZE = 64 * 1024;
 
 	protected $buffer_size = 2048;
 

--- a/components/DataLiberation/Importer/EntityImporter.php
+++ b/components/DataLiberation/Importer/EntityImporter.php
@@ -103,7 +103,7 @@ class EntityImporter {
 		$this->exists               = $empty_types;
 		$this->logger               = new Logger();
 
-		$this->options = wp_parse_args(
+		$this->options = array_merge(
 			$options,
 			array(
 				'prefill_existing_posts'    => true,
@@ -115,7 +115,9 @@ class EntityImporter {
 		);
 
 		// Load the function wp_read_audio_metadata
-		require_once ABSPATH . 'wp-admin/includes/media.php';
+		if(!function_exists('wp_read_audio_metadata')) {
+			require_once ABSPATH . 'wp-admin/includes/media.php';
+		}
 	}
 
 	public function import_entity( ImportEntity $entity ) {

--- a/components/DataLiberation/Importer/EntityImporter.php
+++ b/components/DataLiberation/Importer/EntityImporter.php
@@ -144,6 +144,20 @@ class EntityImporter {
 	}
 
 	public function import_site_option( $data ) {
+		/**
+		 * Ignore site URL options. There doesn't seem to be a compelling use-case for
+		 * overwriting the site URL during a content import. For example, WXR files may
+		 * specify a site URL (typically of the source site) and it is emitted as a
+		 * siteurl option. Is that a good reason to change the target site URL, trigger
+		 * a redirect, and very likely break the entire site? No.
+		 *
+		 * We may need to revisit this approach if this class is ever used to import
+		 * from data sources different than static content files, e.g. a database dump.
+		 */
+		if($data['option_name'] === 'siteurl' || $data['option_name'] === 'home') {
+			return;
+		}
+
 		$this->logger->info(
 			sprintf(
 			/* translators: %s: option name */
@@ -603,7 +617,7 @@ class EntityImporter {
 			 * @param  array  $comments  Raw comment data, already processed by {@see process_comments}.
 			 * @param  array  $terms  Raw term data, already processed.
 			 */
-			do_action( 'wxr_importer_process_failed_post', $post_id, $data, $meta, $comments, $terms );
+			do_action( 'wxr_importer_process_failed_post', $post_id, $data, $meta );
 
 			return false;
 		}
@@ -737,7 +751,7 @@ class EntityImporter {
 
 			default:
 				// associated object is missing or not imported yet, we'll retry later
-				$this->missing_menu_items[] = $item;
+				// $this->missing_menu_items[] = $item;
 				$this->logger->debug( 'Unknown menu item type' );
 				break;
 		}
@@ -1203,7 +1217,7 @@ class Logger {
 	 * @param  string  $message  Message to log
 	 */
 	public function debug( $message ) {
-		// echo( '[DEBUG] ' . $message );
+		echo( '[DEBUG] ' . $message . "\n" );
 	}
 
 	/**
@@ -1212,7 +1226,7 @@ class Logger {
 	 * @param  string  $message  Message to log
 	 */
 	public function info( $message ) {
-		// echo( '[INFO] ' . $message );
+		echo( '[INFO] ' . $message . "\n" );
 	}
 
 	/**
@@ -1221,7 +1235,7 @@ class Logger {
 	 * @param  string  $message  Message to log
 	 */
 	public function warning( $message ) {
-		echo( '[WARNING] ' . $message );
+		echo( '[WARNING] ' . $message . "\n" );
 	}
 
 	/**
@@ -1230,7 +1244,7 @@ class Logger {
 	 * @param  string  $message  Message to log
 	 */
 	public function error( $message ) {
-		echo( '[ERROR] ' . $message );
+		echo( '[ERROR] ' . $message . "\n" );
 	}
 
 	/**
@@ -1239,6 +1253,6 @@ class Logger {
 	 * @param  string  $message  Message to log
 	 */
 	public function notice( $message ) {
-		// echo( '[NOTICE] ' . $message );
+		echo( '[NOTICE] ' . $message . "\n" );
 	}
 }

--- a/components/DataLiberation/Importer/StreamImporter.php
+++ b/components/DataLiberation/Importer/StreamImporter.php
@@ -321,7 +321,9 @@ class StreamImporter {
 	) {
 		$this->entity_reader_factory = $entity_reader_factory;
 		$this->options               = $options;
-		$this->set_source_site_url( $options['source_site_url'] );
+		if ( ! empty( $options['source_site_url'] ) ) {
+			$this->set_source_site_url( $options['source_site_url'] );
+		}
 
 		if ( isset( $options['source_media_root_urls'] ) ) {
 			foreach ( $options['source_media_root_urls'] as $source_media_root_url ) {
@@ -714,7 +716,7 @@ class StreamImporter {
 		return true;
 	}
 
-	protected function get_current_entity() {
+	public function get_current_entity() {
 		$entity = $this->entity_iterator->current();
 		$entity = apply_filters(
 			'data_liberation.stream_importer.preprocess_entity',

--- a/components/DataLiberation/Tests/StreamImporterTest.php
+++ b/components/DataLiberation/Tests/StreamImporterTest.php
@@ -13,11 +13,24 @@ use WordPress\HttpClient\Request;
  */
 class StreamImporterTest extends TestCase {
 
+	private $tmp_dir;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		if ( ! isset( $_SERVER['SERVER_SOFTWARE'] ) || $_SERVER['SERVER_SOFTWARE'] !== 'PHP.wasm' ) {
 			// $this->markTestSkipped( 'Test only runs in Playground' );
+		}
+
+		$this->tmp_dir = sys_get_temp_dir() . '/uploads-' . uniqid();
+		@mkdir( $this->tmp_dir, 0777, true );
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+		if ( is_dir( $this->tmp_dir ) ) {
+			array_map( 'unlink', glob( "$this->tmp_dir/*.*" ) );
+			rmdir( $this->tmp_dir );
 		}
 	}
 
@@ -39,19 +52,10 @@ class StreamImporterTest extends TestCase {
 		}
 	}
 
-	public function test_import_simple_wxr() {
-		$import = data_liberation_import( __DIR__ . '/wxr/small-export.xml' );
-
-		$this->assertTrue( $import );
-	}
-
 	/**
 	 *
 	 */
 	public function test_stylish_press_local_file() {
-		$uploads_path = sys_get_temp_dir() . '/uploads';
-		@mkdir( $uploads_path, 0777, true );
-
 		$sink = new class() {
 			public $imported_entities = [];
 			public $imported_attachments = [];
@@ -69,7 +73,7 @@ class StreamImporterTest extends TestCase {
 		$importer = StreamImporter::create_for_wxr_file( __DIR__ . '/wxr/stylish-press.xml', [
 			'new_site_content_root_url' => 'http://127.0.0.1:9400',
 			'new_media_root_url' => 'http://127.0.0.1:9400/wp-content/uploads',
-			'uploads_path' => $uploads_path,
+			'uploads_path' => $this->tmp_dir,
 			'entity_sink' => $sink
 		] );
 		while ( $importer->next_step() || $importer->advance_to_next_stage() ) {
@@ -82,9 +86,6 @@ class StreamImporterTest extends TestCase {
 	 *
 	 */
 	public function test_stylish_press_remote_stream() {
-		$uploads_path = sys_get_temp_dir() . '/uploads';
-		@mkdir( $uploads_path, 0777, true );
-
 		$sink = new class() {
 			public $imported_entities = [];
 			public $imported_attachments = [];
@@ -112,7 +113,7 @@ class StreamImporterTest extends TestCase {
 		$importer = StreamImporter::create( $entity_reader_factory, [
 			'new_site_content_root_url' => 'http://127.0.0.1:9400',
 			'new_media_root_url' => 'http://127.0.0.1:9400/wp-content/uploads',
-			'uploads_path' => $uploads_path,
+			'uploads_path' => $this->tmp_dir,
 			'entity_sink' => $sink
 		] );
 		while ( $importer->next_step() || $importer->advance_to_next_stage() ) {
@@ -123,21 +124,32 @@ class StreamImporterTest extends TestCase {
 
 	public function test_frontloading() {
 		$wxr_path = __DIR__ . '/wxr/frontloading-1-attachment.xml';
-		$importer = StreamImporter::create_for_wxr_file( $wxr_path );
+		$importer = StreamImporter::create_for_wxr_file( $wxr_path, [
+			'new_site_content_root_url' => 'http://127.0.0.1:9400',
+			'new_media_root_url' => 'http://127.0.0.1:9400/wp-content/uploads',
+			'uploads_path' => $this->tmp_dir,
+		] );
 		$this->skip_to_stage( $importer, StreamImporter::STAGE_FRONTLOAD_ASSETS );
 		while ( $importer->next_step() ) {
 			// noop
 		}
-		$files = glob( '/wordpress/wp-content/uploads/*' );
+		$files = glob( $this->tmp_dir . '/*' );
 		$this->assertCount( 1, $files );
 		$this->assertStringEndsWith( '.jpg', $files[0] );
 	}
 
 	public function test_resume_frontloading() {
+		$this->markTestSkipped( 'The tested file is getting downloaded too quickly for this test to work. There is nothing to resume. @TODO: use a larger file or a smaller chunk size.' );
 		$wxr_path = __DIR__ . '/wxr/frontloading-1-attachment.xml';
-		$importer = StreamImporter::create_for_wxr_file( $wxr_path );
+		$importer = StreamImporter::create_for_wxr_file( $wxr_path, [
+			'entity_sink' => '',
+			'new_site_content_root_url' => 'http://127.0.0.1:9400',
+			'new_media_root_url' => 'http://127.0.0.1:9400/wp-content/uploads',
+			'uploads_path' => $this->tmp_dir,
+		] );
 		$this->skip_to_stage( $importer, StreamImporter::STAGE_FRONTLOAD_ASSETS );
 
+		$progress = $importer->get_frontloading_progress();
 		$progress_url   = null;
 		$progress_value = null;
 		for ( $i = 0; $i < 20; ++ $i ) {
@@ -160,14 +172,17 @@ class StreamImporterTest extends TestCase {
 		$this->assertGreaterThan( 0, $progress_value['total'] );
 
 		$cursor   = $importer->get_reentrancy_cursor();
-		$importer = StreamImporter::create_for_wxr_file( $wxr_path, array(), $cursor );
+		$importer = StreamImporter::create_for_wxr_file( $wxr_path, [
+			'new_site_content_root_url' => 'http://127.0.0.1:9400',
+			'new_media_root_url' => 'http://127.0.0.1:9400/wp-content/uploads',
+			'uploads_path' => $this->tmp_dir,
+		], $cursor );
 		// Rewind back to the entity we were on.
 		$this->assertTrue( $importer->next_step() );
 
 		// Restart the download of the same entity – from scratch.
 		$progress_value = array();
 		for ( $i = 0; $i < 20; ++ $i ) {
-			$importer->next_step();
 			$progress = $importer->get_frontloading_progress();
 			if ( count( $progress ) === 0 ) {
 				continue;
@@ -175,6 +190,7 @@ class StreamImporterTest extends TestCase {
 			$progress_url   = array_keys( $progress )[0];
 			$progress_value = array_values( $progress )[0];
 			if ( null === $progress_value['received'] ) {
+				$importer->next_step();
 				continue;
 			}
 			break;
@@ -190,13 +206,35 @@ class StreamImporterTest extends TestCase {
 	 */
 	public function test_resume_entity_import() {
 		$wxr_path = __DIR__ . '/wxr/entities-options-and-posts.xml';
-		$importer = StreamImporter::create_for_wxr_file( $wxr_path );
+		$importer = StreamImporter::create_for_wxr_file( $wxr_path, [
+			'new_site_content_root_url' => 'http://127.0.0.1:9400',
+			'new_media_root_url' => 'http://127.0.0.1:9400/wp-content/uploads',
+			'uploads_path' => sys_get_temp_dir() . '/uploads',
+			'entity_sink' => new class() {
+				public $imported_entities = [];
+				public function import_entity( $entity ) {
+					$this->imported_entities[] = $entity;
+					return true;
+				}
+			},
+		] );
 		$this->skip_to_stage( $importer, StreamImporter::STAGE_IMPORT_ENTITIES );
 
 		for ( $i = 0; $i < 11; ++ $i ) {
 			$this->assertTrue( $importer->next_step() );
 			$cursor   = $importer->get_reentrancy_cursor();
-			$importer = StreamImporter::create_for_wxr_file( $wxr_path, array(), $cursor );
+			$importer = StreamImporter::create_for_wxr_file( $wxr_path, [
+				'new_site_content_root_url' => 'http://127.0.0.1:9400',
+				'new_media_root_url' => 'http://127.0.0.1:9400/wp-content/uploads',
+				'uploads_path' => sys_get_temp_dir() . '/uploads',
+				'entity_sink' => new class() {
+					public $imported_entities = [];
+					public function import_entity( $entity ) {
+						$this->imported_entities[] = $entity;
+						return true;
+					}
+				},
+			], $cursor );
 			// Rewind back to the entity we were on.
 			// Note this means we may attempt to insert it twice. It's
 			// the importer's job to detect that and skip the duplicate

--- a/components/DataLiberation/Tests/StreamImporterTest.php
+++ b/components/DataLiberation/Tests/StreamImporterTest.php
@@ -1,7 +1,12 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use WordPress\Blueprints\DataReference\DataReference;
+use WordPress\DataLiberation\EntityReader\WXREntityReader;
 use WordPress\DataLiberation\Importer\StreamImporter;
+use WordPress\HttpClient\ByteStream\RequestReadStream;
+use WordPress\HttpClient\ByteStream\SeekableRequestReadStream;
+use WordPress\HttpClient\Request;
 
 /**
  * Tests for the WPStreamImporter class.
@@ -12,7 +17,7 @@ class StreamImporterTest extends TestCase {
 		parent::setUp();
 
 		if ( ! isset( $_SERVER['SERVER_SOFTWARE'] ) || $_SERVER['SERVER_SOFTWARE'] !== 'PHP.wasm' ) {
-			$this->markTestSkipped( 'Test only runs in Playground' );
+			// $this->markTestSkipped( 'Test only runs in Playground' );
 		}
 	}
 
@@ -38,6 +43,82 @@ class StreamImporterTest extends TestCase {
 		$import = data_liberation_import( __DIR__ . '/wxr/small-export.xml' );
 
 		$this->assertTrue( $import );
+	}
+
+	/**
+	 *
+	 */
+	public function test_stylish_press_local_file() {
+		$uploads_path = sys_get_temp_dir() . '/uploads';
+		@mkdir( $uploads_path, 0777, true );
+
+		$sink = new class() {
+			public $imported_entities = [];
+			public $imported_attachments = [];
+
+			public function import_entity( $entity ) {
+				$this->imported_entities[] = $entity;
+				return true;
+			}
+			public function import_attachment( $filepath, $post_id = null ) {
+				$this->imported_attachments[] = $filepath;
+				return true;
+			}
+		};
+
+		$importer = StreamImporter::create_for_wxr_file( __DIR__ . '/wxr/stylish-press.xml', [
+			'new_site_content_root_url' => 'http://127.0.0.1:9400',
+			'new_media_root_url' => 'http://127.0.0.1:9400/wp-content/uploads',
+			'uploads_path' => $uploads_path,
+			'entity_sink' => $sink
+		] );
+		while ( $importer->next_step() || $importer->advance_to_next_stage() ) {
+			// noop
+		}
+		$this->assertCount( 10, $sink->imported_entities );
+	}
+
+	/**
+	 *
+	 */
+	public function test_stylish_press_remote_stream() {
+		$uploads_path = sys_get_temp_dir() . '/uploads';
+		@mkdir( $uploads_path, 0777, true );
+
+		$sink = new class() {
+			public $imported_entities = [];
+			public $imported_attachments = [];
+
+			public function import_entity( $entity ) {
+				$this->imported_entities[] = $entity;
+				return true;
+			}
+			public function import_attachment( $filepath, $post_id = null ) {
+				$this->imported_attachments[] = $filepath;
+				return true;
+			}
+		};
+
+		$entity_reader_factory = function ( $cursor ) {
+			$stream = new RequestReadStream(new Request(
+				'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/stylish-press/site-content.wxr'
+			));
+			return WXREntityReader::create(
+				$stream,
+				$cursor
+			);
+		};
+
+		$importer = StreamImporter::create( $entity_reader_factory, [
+			'new_site_content_root_url' => 'http://127.0.0.1:9400',
+			'new_media_root_url' => 'http://127.0.0.1:9400/wp-content/uploads',
+			'uploads_path' => $uploads_path,
+			'entity_sink' => $sink
+		] );
+		while ( $importer->next_step() || $importer->advance_to_next_stage() ) {
+			// noop
+		}
+		$this->assertCount( 10, $sink->imported_entities );
 	}
 
 	public function test_frontloading() {

--- a/components/DataLiberation/Tests/WXRReaderTest.php
+++ b/components/DataLiberation/Tests/WXRReaderTest.php
@@ -3,6 +3,9 @@
 use PHPUnit\Framework\TestCase;
 use WordPress\ByteStream\ReadStream\FileReadStream;
 use WordPress\DataLiberation\EntityReader\WXREntityReader;
+use WordPress\DataLiberation\ImportEntity;
+use WordPress\HttpClient\ByteStream\RequestReadStream;
+use WordPress\HttpClient\Request;
 
 class WXRReaderTest extends TestCase {
 
@@ -272,6 +275,99 @@ XML
 			),
 			$importer->get_entity()->get_data()
 		);
+	}
+
+	public function test_stylish_press_wxr_local() {
+		$importer = WXREntityReader::create();
+		$importer->append_bytes( file_get_contents( __DIR__ . '/wxr/stylish-press.xml' ) );
+		$importer->input_finished();
+		$this->assert_stylish_press_wxr( $importer );
+	}
+
+	public function test_stylish_press_wxr_remote() {
+		$importer = WXREntityReader::create();
+		$importer->connect_upstream(
+			new RequestReadStream(new Request(
+				'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/stylish-press/site-content.wxr'
+			))
+		);
+		$this->assert_stylish_press_wxr( $importer );
+	}
+
+	private function assert_stylish_press_wxr( $importer ) {
+		$this->assertTrue( $importer->next_entity() );
+		$this->assert_entity_equals(
+			new ImportEntity( 'site_option', array(
+				'option_name'  => 'blogname',
+				'option_value' => 'Stylish Press',
+			) ),
+			$importer->get_entity()
+		);
+
+		$this->assertTrue( $importer->next_entity() );
+		$this->assert_entity_equals(
+			new ImportEntity( 'site_option', array(
+				'option_name'  => 'siteurl',
+				'option_value' => 'http://www.stylishpress.wordpress.org'
+			) ),
+			$importer->get_entity()
+		);
+
+		$this->assertTrue( $importer->next_entity() );
+		$this->assert_entity_equals(
+			new ImportEntity( 'site_option', array(
+				'option_name'  => 'home',
+				'option_value' => 'http://www.stylishpress.wordpress.org'
+			) ),
+			$importer->get_entity()
+		);
+
+		$this->assertTrue( $importer->next_entity() );
+		$this->assert_entity_equals(
+			new ImportEntity( 'user', array(
+				'ID'           => 1,
+				'user_login'   => 'admin',
+				'user_email'   => 'admin@stylishpress.wordpress.org',
+				'display_name' => 'Admin',
+				'first_name'   => 'John',
+				'last_name'    => 'Doe',
+			) ),
+			$importer->get_entity()
+		);
+
+		$this->assertTrue( $importer->next_entity() );
+		$entity = $importer->get_entity();
+		$this->assertEquals( 'post', $entity->get_type() );
+		$this->assertEquals( 'page', $entity->get_data()['post_type'] );
+		$this->assertEquals( 'home', $entity->get_data()['post_name'] );
+		$this->assertEquals( 'publish', $entity->get_data()['post_status'] );
+		$this->assertEquals( '1', $entity->get_data()['post_id'] );
+		$this->assertEquals( 'Homepage', $entity->get_data()['post_title'] );
+
+		$this->assertTrue( $importer->next_entity() );
+		$this->assert_entity_equals(
+			new ImportEntity( 'post_meta', array(
+				'meta_key'   => '_edit_last',
+				'meta_value' => '1',
+				'post_id' => 1
+			) ),
+			$importer->get_entity()
+		);
+
+		$this->assertTrue( $importer->next_entity() );
+
+		$entity = $importer->get_entity();
+		$this->assertEquals( 'post', $entity->get_type() );
+		$this->assertEquals( 'page', $entity->get_data()['post_type'] );
+		$this->assertEquals( 'the-stylish-story', $entity->get_data()['post_name'] );
+		$this->assertEquals( 'publish', $entity->get_data()['post_status'] );
+		$this->assertEquals( '2', $entity->get_data()['post_id'] );
+		$this->assertEquals( 'The Stylish Story', $entity->get_data()['post_title'] );
+	}
+
+	private function assert_entity_equals( $expected, $actual ) {
+		$this->assertEquals( $expected->get_type(), $actual->get_type() );
+		$this->assertEquals( $expected->get_data(), $actual->get_data() );
 	}
 
 	public function test_terms() {

--- a/components/DataLiberation/Tests/wxr/stylish-press.xml
+++ b/components/DataLiberation/Tests/wxr/stylish-press.xml
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+    xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+    xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:wp="http://wordpress.org/export/1.2/"
+>
+<channel>
+    <title>Stylish Press</title>
+    <link>http://www.stylishpress.wordpress.org</link>
+    <description>Fashion-forward apparel for everyone!</description>
+    <pubDate>Tue, 05 Jun 2024 12:00:00 +0000</pubDate>
+    <language>en-US</language>
+    <wp:wxr_version>1.2</wp:wxr_version>
+    <wp:base_site_url>http://www.stylishpress.wordpress.org</wp:base_site_url>
+    <wp:base_blog_url>http://www.stylishpress.wordpress.org</wp:base_blog_url>
+
+    <wp:author>
+        <wp:author_id>1</wp:author_id>
+        <wp:author_login>admin</wp:author_login>
+        <wp:author_email>admin@stylishpress.wordpress.org</wp:author_email>
+        <wp:author_display_name><![CDATA[Admin]]></wp:author_display_name>
+        <wp:author_first_name><![CDATA[John]]></wp:author_first_name>
+        <wp:author_last_name><![CDATA[Doe]]></wp:author_last_name>
+    </wp:author>
+
+    <!-- Page 1: Home - Welcome to Stylish Press -->
+    <item>
+        <title>Homepage</title>
+        <link>http://www.stylishpress.wordpress.org/home</link>
+        <pubDate>Tue, 05 Jun 2024 12:00:00 +0000</pubDate>
+        <dc:creator><![CDATA[admin]]></dc:creator>
+        <category domain="category" nicename="pages"><![CDATA[Pages]]></category>
+        <guid isPermaLink="false">http://www.stylishpress.wordpress.org/?p=1</guid>
+        <description></description>
+        <content:encoded><![CDATA[
+            <!-- wp:cover {"url":"https://pd.w.org/2024/06/398665facdd5a0ea5.69441088-1536x1370.jpeg","dimRatio":50,"overlayColor":"black"} -->
+            <div class="wp-block-cover" style="background-image:url(https://pd.w.org/2024/06/398665facdd5a0ea5.69441088-1536x1370.jpeg);background-size:cover;height:600px;">
+                <span aria-hidden="true" class="wp-block-cover__background has-black-background-color has-background-dim"></span>
+                <div class="wp-block-cover__inner-container">
+                    <!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontSize":"48px"}}} -->
+                    <h1 class="has-text-align-center" style="font-size:48px;color:#fff">Welcome to Stylish Press</h1>
+                    <!-- /wp:heading -->
+                    <!-- wp:paragraph {"align":"center"} -->
+                    <p class="has-text-align-center" style="color:#fff">Discover the latest in fashion and style.</p>
+                    <!-- /wp:paragraph -->
+                </div>
+            </div>
+            <!-- /wp:cover -->
+
+            <!-- wp:columns -->
+            <div class="wp-block-columns">
+                <!-- wp:column -->
+                <div class="wp-block-column">
+                    <!-- wp:image {"id":1,"sizeSlug":"large"} -->
+                    <figure class="wp-block-image size-large"><img src="https://pd.w.org/2024/06/463665c9cc5d4a598.44930142-768x576.jpeg" alt="Trendy Outfit"/></figure>
+                    <!-- /wp:image -->
+                </div>
+                <!-- /wp:column -->
+                <!-- wp:column -->
+                <div class="wp-block-column">
+                    <!-- wp:paragraph -->
+                    <p>At Stylish Press, we're dedicated to bringing you the latest trends in fashion. Our collection is carefully curated to ensure you look your best, whether you're hitting the streets or the runway. Explore our site to find out more about our latest collections, fashion tips, and exclusive offers.</p>
+                    <!-- /wp:paragraph -->
+                    <!-- wp:paragraph -->
+                    <p>Browse through our diverse range of apparel, featuring everything from chic tops to stylish bottoms, and accessories that complete your look. Our pieces are designed to make you feel confident and fashionable, day or night.</p>
+                    <!-- /wp:paragraph -->
+                </div>
+                <!-- /wp:column -->
+            </div>
+            <!-- /wp:columns -->
+
+            <!-- wp:spacer {"height":40} -->
+            <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+            <!-- /wp:spacer -->
+
+            <!-- wp:heading {"style":{"typography":{"fontSize":"36px"}}} -->
+            <h2 style="font-size:36px;color:#ff6e40">Our Mission</h2>
+            <!-- /wp:heading -->
+            <!-- wp:paragraph -->
+            <p>Stylish Press was founded with a firm belief that fashion should be accessible, inclusive, and always evolving. We aim to empower our customers to express themselves through bold and contemporary designs that speak volumes about their unique style.</p>
+            <!-- /wp:paragraph -->
+        ]]></content:encoded>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+        <wp:post_id>1</wp:post_id>
+        <wp:post_date>2024-06-05 12:00:00</wp:post_date>
+        <wp:post_date_gmt>2024-06-05 12:00:00</wp:post_date_gmt>
+        <wp:comment_status>closed</wp:comment_status>
+        <wp:ping_status>closed</wp:ping_status>
+        <wp:post_name>home</wp:post_name>
+        <wp:status>publish</wp:status>
+        <wp:post_type>page</wp:post_type>
+        <wp:post_parent>0</wp:post_parent>
+        <wp:menu_order>1</wp:menu_order>
+        <wp:postmeta>
+            <wp:meta_key>_edit_last</wp:meta_key>
+            <wp:meta_value>1</wp:meta_value>
+        </wp:postmeta>
+    </item>
+
+    <!-- Page 2: The Stylish Story -->
+    <item>
+        <title>The Stylish Story</title>
+        <link>http://www.stylishpress.wordpress.org/the-stylish-story</link>
+        <pubDate>Tue, 05 Jun 2024 12:00:00 +0000</pubDate>
+        <dc:creator><![CDATA[admin]]></dc:creator>
+        <category domain="category" nicename="pages"><![CDATA[Pages]]></category>
+        <guid isPermaLink="false">http://www.stylishpress.wordpress.org/?p=2</guid>
+        <description></description>
+        <content:encoded><![CDATA[
+            <!-- wp:cover {"url":"https://pd.w.org/2024/06/398665facdd5a0ea5.69441088-1536x1370.jpeg","dimRatio":50,"overlayColor":"black"} -->
+            <div class="wp-block-cover" style="background-image:url(https://pd.w.org/2024/06/398665facdd5a0ea5.69441088-1536x1370.jpeg);background-size:cover;height:400px;">
+                <span aria-hidden="true" class="wp-block-cover__background has-black-background-color has-background-dim"></span>
+                <div class="wp-block-cover__inner-container">
+                    <!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontSize":"48px"}}} -->
+                    <h1 class="has-text-align-center" style="font-size:48px;color:#fff">The Stylish Story</h1>
+                    <!-- /wp:heading -->
+                </div>
+            </div>
+            <!-- /wp:cover -->
+
+            <!-- wp:heading {"style":{"typography":{"fontSize":"36px"}}} -->
+            <h2 style="font-size:36px;color:#ff6e40">Our Beginnings</h2>
+            <!-- /wp:heading -->
+            <!-- wp:paragraph -->
+            <p>Stylish Press was founded in 2020 by a group of fashion enthusiasts who wanted to bring a fresh perspective to the fashion industry. We began as a small online store, focusing on minimalist designs with a bold twist. Our unique approach quickly gained a loyal following, and we have been expanding our collection ever since.</p>
+            <!-- /wp:paragraph -->
+
+            <!-- wp:gallery {"ids":[1,2,3,4,5],"columns":3} -->
+            <figure class="wp-block-gallery columns-3 is-cropped">
+                <ul class="blocks-gallery-grid">
+                    <li class="blocks-gallery-item">
+                        <figure>
+                            <img src="https://pd.w.org/2024/06/463665c9cc5d4a598.44930142-768x576.jpeg" alt="Founders"/>
+                        </figure>
+                    </li>
+                    <li class="blocks-gallery-item">
+                        <figure>
+                            <img src="https://pd.w.org/2024/06/463665c9cc5d4a598.44930142-768x576.jpeg" alt="Fashion Show"/>
+                        </figure>
+                    </li>
+                    <li class="blocks-gallery-item">
+                        <figure>
+                            <img src="https://pd.w.org/2024/06/463665c9cc5d4a598.44930142-768x576.jpeg" alt="Design Process"/>
+                        </figure>
+                    </li>
+                </ul>
+            </figure>
+            <!-- /wp:gallery -->
+
+            <!-- wp:spacer {"height":40} -->
+            <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+            <!-- /wp:spacer -->
+
+            <!-- wp:heading {"style":{"typography":{"fontSize":"36px"}}} -->
+            <h2 style="font-size:36px;color:#ff6e40">Our Commitment</h2>
+            <!-- /wp:heading -->
+            <!-- wp:paragraph -->
+            <p>We believe in sustainable fashion practices and ethical sourcing. Every piece in our collection is made with care, ensuring minimal impact on the environment. Our commitment to quality craftsmanship means that each item is built to last, keeping you stylish and sustainable.</p>
+            <!-- /wp:paragraph -->
+
+            <!-- wp:quote -->
+            <blockquote class="wp-block-quote">
+                <p>"Fashion is not just about looking good, it's about feeling good and doing good." - Founders of Stylish Press</p>
+            </blockquote>
+            <!-- /wp:quote -->
+
+            <!-- wp:paragraph -->
+            <p>Join us on our journey to revolutionize the fashion industry, one stylish piece at a time. Together, we can make fashion more inclusive, innovative, and inspiring.</p>
+            <!-- /wp:paragraph -->
+        ]]></content:encoded>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+        <wp:post_id>2</wp:post_id>
+        <wp:post_date>2024-06-05 12:00:00</wp:post_date>
+        <wp:post_date_gmt>2024-06-05 12:00:00</wp:post_date_gmt>
+        <wp:comment_status>closed</wp:comment_status>
+        <wp:ping_status>closed</wp:ping_status>
+        <wp:post_name>the-stylish-story</wp:post_name>
+        <wp:status>publish</wp:status>
+        <wp:post_type>page</wp:post_type>
+        <wp:post_parent>0</wp:post_parent>
+        <wp:menu_order>2</wp:menu_order>
+        <wp:postmeta>
+            <wp:meta_key>_edit_last</wp:meta_key>
+            <wp:meta_value>1</wp:meta_value>
+        </wp:postmeta>
+    </item>
+
+    <!-- Page 4: Connect with Us -->
+    <item>
+        <title>Connect</title>
+        <link>http://www.stylishpress.wordpress.org/contact-us</link>
+        <pubDate>Tue, 05 Jun 2024 12:00:00 +0000</pubDate>
+        <dc:creator><![CDATA[admin]]></dc:creator>
+        <category domain="category" nicename="pages"><![CDATA[Pages]]></category>
+        <guid isPermaLink="false">http://www.stylishpress.wordpress.org/?p=5</guid>
+        <description></description>
+        <content:encoded><![CDATA[
+            <!-- wp:cover {"url":"https://pd.w.org/2024/06/398665facdd5a0ea5.69441088-1536x1370.jpeg","dimRatio":50,"overlayColor":"black"} -->
+            <div class="wp-block-cover" style="background-image:url(https://pd.w.org/2024/06/398665facdd5a0ea5.69441088-1536x1370.jpeg);background-size:cover;height:400px;">
+                <span aria-hidden="true" class="wp-block-cover__background has-black-background-color has-background-dim"></span>
+                <div class="wp-block-cover__inner-container">
+                    <!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontSize":"48px"}}} -->
+                    <h1 class="has-text-align-center" style="font-size:48px;color:#fff">Connect with Us</h1>
+                    <!-- /wp:heading -->
+                </div>
+            </div>
+            <!-- /wp:cover -->
+
+            <!-- wp:paragraph -->
+            <p>We love hearing from our customers! Whether you have questions about our products, need styling advice, or just want to share your own fashion journey, we're here for you. Reach out to us through our various contact points listed below, and let’s stay connected.</p>
+            <!-- /wp:paragraph -->
+
+            <!-- wp:columns -->
+            <div class="wp-block-columns">
+                <!-- wp:column -->
+                <div class="wp-block-column">
+                    <!-- wp:contact-form-7/contact-form-selector {"id":1} /-->
+                </div>
+                <!-- /wp:column -->
+                <!-- wp:column -->
+                <div class="wp-block-column">
+                    <!-- wp:heading {"style":{"typography":{"fontSize":"24px"}}} -->
+                    <h3 style="font-size:24px;color:#ff6e40">Find Us Here</h3>
+                    <!-- /wp:heading -->
+                    <!-- wp:paragraph -->
+                    <p><strong>Email:</strong> <a href="mailto:support@stylishpress.wordpress.org">support@stylishpress.wordpress.org</a></p>
+                    <!-- /wp:paragraph -->
+                    <!-- wp:paragraph -->
+                    <p><strong>Phone:</strong> +1 (234) 567-890</p>
+                    <!-- /wp:paragraph -->
+                    <!-- wp:paragraph -->
+                    <p><strong>Address:</strong> 123 Fashion Street, Trend City, ST 56789</p>
+                    <!-- /wp:paragraph -->
+                    <!-- wp:heading {"style":{"typography":{"fontSize":"24px"}}} -->
+                    <h3 style="font-size:24px;color:#ff6e40">Follow Us</h3>
+                    <!-- /wp:heading -->
+                    <!-- wp:social-links {"className":"is-style-default"} -->
+                    <ul class="wp-block-social-links is-style-default">
+                        <li class="wp-social-link wp-social-link-facebook"><a href="https://stylishpress.wordpress.org" target="_blank" aria-label="Facebook"></a></li>
+                        <li class="wp-social-link wp-social-link-instagram"><a href="https://stylishpress.wordpress.org" target="_blank" aria-label="Instagram"></a></li>
+                        <li class="wp-social-link wp-social-link-twitter"><a href="https://stylishpress.wordpress.org" target="_blank" aria-label="Twitter"></a></li>
+                    </ul>
+                    <!-- /wp:social-links -->
+                </div>
+                <!-- /wp:column -->
+            </div>
+            <!-- /wp:columns -->
+
+            <!-- wp:quote -->
+            <blockquote class="wp-block-quote">
+                <p>"Fashion is instant language." - Miuccia Prada</p>
+            </blockquote>
+            <!-- /wp:quote -->
+
+            <!-- wp:paragraph -->
+            <p>Connect with Stylish Press today and become a part of our vibrant community where fashion meets passion.</p>
+            <!-- /wp:paragraph -->
+        ]]></content:encoded>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+        <wp:post_id>5</wp:post_id>
+        <wp:post_date>2024-06-05 12:00:00</wp:post_date>
+        <wp:post_date_gmt>2024-06-05 12:00:00</wp:post_date_gmt>
+        <wp:comment_status>closed</wp:comment_status>
+        <wp:ping_status>closed</wp:ping_status>
+        <wp:post_name>contact-us</wp:post_name>
+        <wp:status>publish</wp:status>
+        <wp:post_type>page</wp:post_type>
+        <wp:post_parent>0</wp:post_parent>
+        <wp:menu_order>5</wp:menu_order>
+        <wp:postmeta>
+            <wp:meta_key>_edit_last</wp:meta_key>
+            <wp:meta_value>1</wp:meta_value>
+        </wp:postmeta>
+    </item>
+
+</channel>
+</rss>

--- a/components/Filesystem/LocalFilesystem.php
+++ b/components/Filesystem/LocalFilesystem.php
@@ -39,7 +39,7 @@ class LocalFilesystem implements Filesystem {
 
 		if ( ! is_dir( $root ) ) {
 			if ( false === mkdir( $root, 0755, true ) ) {
-				throw new FilesystemException( sprintf( 'Root directory did not exist and could not be created: %s', $root ) );
+				throw new FilesystemException( sprintf( 'Root directory did not exist and could not be created: %s', var_export($root, true) ) );
 			}
 		}
 

--- a/components/Git/GitRemote.php
+++ b/components/Git/GitRemote.php
@@ -533,8 +533,11 @@ class GitRemote {
 
 		$response = $reader->await_response();
 		if ( $response->status_code > 299 || $response->status_code < 200 ) {
-			$reader->pull( 100 );
-			throw new GitRemoteException( 'HTTP request failed with status code ' . $response->status_code . '. First 100 body bytes: ' . $reader->peek( 100 ) );
+			// GitHub sometimes responds with 100 status code when the request is successful.
+			if ( $response->status_code !== 100 ) {
+				$reader->pull( 100 );
+				throw new GitRemoteException( 'HTTP request failed with status code ' . $response->status_code . '. First 100 body bytes: ' . $reader->peek( 100 ) );
+			}
 		}
 
 		return $reader;

--- a/components/HttpClient/ByteStream/RequestReadStream.php
+++ b/components/HttpClient/ByteStream/RequestReadStream.php
@@ -118,13 +118,29 @@ class RequestReadStream extends BaseByteReadStream {
 					$content_length = $response->get_header( 'Content-Length' );
 					if ( null !== $content_length ) {
 						/**
-						 * Set the content-length based on the header, but make sure it stays null
-						 * when the Content-Length header is not set.
+						 * Best-effort attempt to guess the content-length of the response.
 						 *
-						 * Important: Don't set the content-length to 0 if the header is missing! This
-						 * would tell the streaming machinery there's no body to consume.
+						 * Web servers often respond with a combination of Content-Length
+						 * and Content-Encoding. For example, a 16kb text file may be compressed
+						 * to 4kb with gzip and served with a Content-Encoding of `gzip` and a
+						 * Content-Length of 4KB.
+						 *
+						 * If we just use that value, we'd truncate a 16KB body stream with at a
+						 * Content-Length of 4KB.
+						 *
+						 * To correct that behavior, we're discarding the Content-Length header when
+						 * it's used alongside a compressed response stream.
 						 */
-						$this->remote_file_length = (int) $content_length;
+						if ( ! $response->get_header( 'Content-Encoding' ) ) {
+							/**
+							 * Set the content-length based on the header, but make sure it stays null
+							 * when the Content-Length header is not set.
+							 *
+							 * Important: Don't set the content-length to 0 if the header is missing! This
+							 * would tell the streaming machinery there's no body to consume.
+							 */
+							$this->remote_file_length = (int) $content_length;
+						}
 					}
 					if ( $stop_at_event === Client::EVENT_GOT_HEADERS ) {
 						return true;

--- a/components/HttpClient/Client.php
+++ b/components/HttpClient/Client.php
@@ -44,6 +44,7 @@ class Client {
 			case 'curl':
 				$transport = new CurlTransport( $this->state );
 				break;
+			case 'socket':
 			case 'sockets':
 				$transport = new SocketTransport( $this->state );
 				break;

--- a/components/HttpClient/Client.php
+++ b/components/HttpClient/Client.php
@@ -39,6 +39,7 @@ class Client {
 		if(empty($options['transport']) || $options['transport'] === 'auto') {
 			$options['transport'] = extension_loaded( 'curl' ) ? 'curl' : 'socket';
 		}
+		$options['transport'] = 'socket';
 
 		switch ( $options['transport'] ) {
 			case 'curl':
@@ -74,7 +75,10 @@ class Client {
 	 *
 	 * @return RequestReadStream
 	 */
-	public function fetch( Request $request, array $options = [] ) {
+	public function fetch( $request, array $options = [] ) {
+		if(is_string($request)) {
+			$request = new Request($request);
+		}
 		return new RequestReadStream(
 			$request,
 			array_merge( [ 'client' => $this ],

--- a/components/HttpClient/Client.php
+++ b/components/HttpClient/Client.php
@@ -37,15 +37,14 @@ class Client {
 	public function __construct( $options = array() ) {
 		$this->state = new ClientState( $options );
 		if(empty($options['transport']) || $options['transport'] === 'auto') {
-			$options['transport'] = extension_loaded( 'curl' ) ? 'curl' : 'socket';
+			$options['transport'] = extension_loaded( 'curl' ) ? 'curl' : 'sockets';
 		}
-		$options['transport'] = 'socket';
 
 		switch ( $options['transport'] ) {
 			case 'curl':
 				$transport = new CurlTransport( $this->state );
 				break;
-			case 'socket':
+			case 'sockets':
 				$transport = new SocketTransport( $this->state );
 				break;
 			default:

--- a/components/Polyfill/wordpress.php
+++ b/components/Polyfill/wordpress.php
@@ -220,3 +220,9 @@ if ( ! function_exists( 'serialize_block_attributes' ) ) {
 		return $encoded_attributes;
 	}
 }
+
+if(!function_exists('wp_read_audio_metadata')) {
+	function wp_read_audio_metadata($file) {
+		return array();
+	}
+}

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -878,7 +878,7 @@ class XMLProcessor {
 				'6.4.0'
 			);
 		}
-		$this->xml                    = $xml;
+		$this->xml                    = $xml ?? '';
 		$this->document_namespaces    = array_merge(
 			$document_namespaces,
 			// These initial namespaces cannot be overridden.

--- a/phar-blueprints.json
+++ b/phar-blueprints.json
@@ -27,5 +27,8 @@
     ],
 	"directories": [
         "vendor/composer"
+	],
+	"files": [
+		"dist/php-toolkit.phar"
 	]
 }


### PR DESCRIPTION
Implements a series of bugfixes and improvements to enable integration with WordPress Playground. Some highlights:

* Add `blueprint.http_client` filter so Playground can setup its own HTTP Client instance
* Add `blueprint.resolved` filter to enable injecting additional steps in Playground
* `RequestReadStream` doesn't expect `Content-Length` when `Content-Encoding` is present.
* `WPCLIStep` now gets an explicit `--path` argument to avoid relying on WordPress autodetection heuristics
* Restored 64KB as the default byte stream chunk size
* `latest` is now a valid WordPress version identifier
* Importing content is now supported even when running as phar
* StreamImporter now requires `new_site_content_root_url` and a few other options when they can't be backfilled via WordPress functions. For example, when WordPress hasn't yet been loaded
* Magic strings, such as `create-new-site`, are replaced with constants, such as `self::EXECUTION_MODE_CREATE_NEW_SITE`
* ...a lot more other tiny improvements.

## Testing instructions

Confirm the CLI failures are in line with `trunk` (most successes, some flaky failures)