### PR TITLE
Wrap polyfills in namespaces

### DIFF
--- a/components/BlockParser/class-wp-block-parser-block.php
+++ b/components/BlockParser/class-wp-block-parser-block.php
@@ -1,4 +1,5 @@
 <?php
+namespace WordPress\BlockParser;
 /**
  * Block Serialization Parser
  *

--- a/components/BlockParser/class-wp-block-parser-error.php
+++ b/components/BlockParser/class-wp-block-parser-error.php
@@ -1,4 +1,7 @@
 <?php
+namespace WordPress\BlockParser;
+use Exception;
+
 /**
  * @package WordPress
  */

--- a/components/BlockParser/class-wp-block-parser-frame.php
+++ b/components/BlockParser/class-wp-block-parser-frame.php
@@ -1,4 +1,5 @@
 <?php
+namespace WordPress\BlockParser;
 /**
  * Block Serialization Parser
  *

--- a/components/BlockParser/class-wp-block-parser.php
+++ b/components/BlockParser/class-wp-block-parser.php
@@ -1,4 +1,6 @@
 <?php
+namespace WordPress\BlockParser;
+
 /**
  * Block Serialization Parser
  *

--- a/components/Blueprints/Steps/scripts/import-content.php
+++ b/components/Blueprints/Steps/scripts/import-content.php
@@ -19,6 +19,7 @@ use WordPress\Filesystem\LocalFilesystem;
 use WordPress\Zip\ZipFilesystem;
 
 use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Filesystem\add_filter;
 
 require_once getenv('DOCROOT') . '/wp-load.php';
 require_once getenv('DOCROOT') . '/php-toolkit.phar';

--- a/components/DataLiberation/BlockMarkup/BlockMarkupProcessor.php
+++ b/components/DataLiberation/BlockMarkup/BlockMarkupProcessor.php
@@ -2,8 +2,8 @@
 
 namespace WordPress\DataLiberation\BlockMarkup;
 
-use WP_Block_Parser_Error;
-use WP_HTML_Tag_Processor;
+use WordPress\BlockParser\WP_Block_Parser_Error;
+use WordPress\HTML\WP_HTML_Tag_Processor;
 
 /**
  * A processor class capable of reading and rewriting block markup.

--- a/components/DataLiberation/DataFormatConsumer/AnnotatedBlockMarkupConsumer.php
+++ b/components/DataLiberation/DataFormatConsumer/AnnotatedBlockMarkupConsumer.php
@@ -3,6 +3,8 @@
 namespace WordPress\DataLiberation\DataFormatConsumer;
 
 use WP_HTML_Processor;
+use function WordPress\Polyfill\parse_blocks;
+use function WordPress\Polyfill\serialize_block;
 
 /**
  * Converts a metadata-annotated block markup into block markup+metadata pair.

--- a/components/DataLiberation/DataFormatConsumer/AnnotatedBlockMarkupConsumer.php
+++ b/components/DataLiberation/DataFormatConsumer/AnnotatedBlockMarkupConsumer.php
@@ -2,7 +2,7 @@
 
 namespace WordPress\DataLiberation\DataFormatConsumer;
 
-use WP_HTML_Processor;
+use WordPress\HTML\WP_HTML_Processor;
 use function WordPress\Polyfill\parse_blocks;
 use function WordPress\Polyfill\serialize_block;
 
@@ -50,7 +50,7 @@ class AnnotatedBlockMarkupConsumer implements DataFormatConsumer {
 			$metadata     = array();
 			foreach ( parse_blocks( $this->original_html ) as $block ) {
 				if ( $block['blockName'] === null ) {
-					$html_converter = new MarkupProcessorConsumer( WP_HTML_Processor::create_fragment( $block['innerHTML'] ) );
+					$html_converter = new MarkupProcessorConsumer( \WordPress\HTML\WP_HTML_Processor::create_fragment( $block['innerHTML'] ) );
 					$result         = $html_converter->consume();
 					$block_markup   .= $result->get_block_markup() . "\n";
 					$metadata       = array_merge( $metadata, $result->get_all_metadata() );

--- a/components/DataLiberation/DataFormatConsumer/MarkupProcessorConsumer.php
+++ b/components/DataLiberation/DataFormatConsumer/MarkupProcessorConsumer.php
@@ -6,8 +6,8 @@ use WordPress\DataLiberation\BlockMarkup\BlockObject;
 use WordPress\DataLiberation\DataLiberationException;
 use WordPress\DataLiberation\Importer\ImportUtils;
 use WordPress\XML\XMLProcessor;
-use WP_HTML_Processor;
-use WP_HTML_Tag_Processor;
+use WordPress\HTML\WP_HTML_Processor;
+use WordPress\HTML\WP_HTML_Tag_Processor;
 
 /**
  * Creates block markup from a WP_HTML_Processor or WP_XML_Processor instance.

--- a/components/DataLiberation/DataFormatProducer/AnnotatedBlockMarkupProducer.php
+++ b/components/DataLiberation/DataFormatProducer/AnnotatedBlockMarkupProducer.php
@@ -3,7 +3,7 @@
 namespace WordPress\DataLiberation\DataFormatProducer;
 
 use WordPress\DataLiberation\DataFormatConsumer\BlocksWithMetadata;
-use WP_HTML_Tag_Processor;
+use WordPress\HTML\WP_HTML_Tag_Processor;
 
 /**
  * Turns Block Markup + Metadata into a metadata-annotated Block Markup.

--- a/components/DataLiberation/DataLiberationHTMLProcessor.php
+++ b/components/DataLiberation/DataLiberationHTMLProcessor.php
@@ -2,8 +2,8 @@
 
 namespace WordPress\DataLiberation;
 
-use WP_HTML_Processor;
-use WP_HTML_Tag_Processor;
+use WordPress\HTML\WP_HTML_Processor;
+use WordPress\HTML\WP_HTML_Tag_Processor;
 
 class DataLiberationHTMLProcessor extends WP_HTML_Processor {
 

--- a/components/DataLiberation/EntityReader/EPubEntityReader.php
+++ b/components/DataLiberation/EntityReader/EPubEntityReader.php
@@ -8,6 +8,7 @@ use WordPress\Filesystem\Filesystem;
 use WordPress\XML\XMLProcessor;
 
 use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Polyfill\_doing_it_wrong;
 
 /**
  * https://www.w3.org/AudioVideo/ebook/

--- a/components/DataLiberation/EntityReader/FilesystemEntityReader.php
+++ b/components/DataLiberation/EntityReader/FilesystemEntityReader.php
@@ -12,7 +12,7 @@ use WordPress\Filesystem\Filesystem;
 use WordPress\Filesystem\Visitor\FilesystemVisitor;
 use WordPress\Markdown\MarkdownConsumer;
 use WordPress\XML\XMLProcessor;
-use WP_HTML_Processor;
+use WordPress\HTML\WP_HTML_Processor;
 
 use function WordPress\Filesystem\wp_join_unix_paths;
 
@@ -277,7 +277,7 @@ class FilesystemEntityReader implements EntityReader {
 						$result    = $converter->consume();
 						break;
 					case 'html':
-						$converter = new MarkupProcessorConsumer( WP_HTML_Processor::create_fragment( $content ) );
+						$converter = new MarkupProcessorConsumer( \WordPress\HTML\WP_HTML_Processor::create_fragment( $content ) );
 						$result    = $converter->consume();
 						break;
 					default:

--- a/components/DataLiberation/EntityReader/WXREntityReader.php
+++ b/components/DataLiberation/EntityReader/WXREntityReader.php
@@ -6,6 +6,7 @@ use WordPress\ByteStream\ReadStream\ByteReadStream;
 use WordPress\DataLiberation\ImportEntity;
 use WordPress\XML\XMLProcessor;
 use WordPress\XML\XMLUnsupportedException;
+use function WordPress\Polyfill\_doing_it_wrong;
 
 /**
  * Data Liberation API: WP_WXR_Entity_Reader class

--- a/components/DataLiberation/Importer/AttachmentDownloader.php
+++ b/components/DataLiberation/Importer/AttachmentDownloader.php
@@ -8,6 +8,7 @@ use WordPress\HttpClient\Client;
 use WordPress\HttpClient\Request;
 
 use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Polyfill\_doing_it_wrong;
 
 class AttachmentDownloader {
 	private $client;

--- a/components/DataLiberation/Importer/EntityImporter.php
+++ b/components/DataLiberation/Importer/EntityImporter.php
@@ -24,6 +24,10 @@ namespace WordPress\DataLiberation\Importer;
 use InvalidArgumentException;
 use WordPress\DataLiberation\DataLiberationException;
 use WordPress\DataLiberation\ImportEntity;
+use function WordPress\Polyfill\_doing_it_wrong;
+use function WordPress\Polyfill\__;
+use function WordPress\Polyfill\apply_filters;
+use function WordPress\Polyfill\do_action;
 
 class EntityImporter {
 

--- a/components/DataLiberation/Importer/ImportSession.php
+++ b/components/DataLiberation/Importer/ImportSession.php
@@ -7,6 +7,7 @@ use WP_Query;
 
 use function get_all_post_meta_flat;
 use function is_wp_error;
+use function WordPress\Polyfill\_doing_it_wrong;
 
 /**
  * Manages import session data in the WordPress database.

--- a/components/DataLiberation/Importer/StreamImporter.php
+++ b/components/DataLiberation/Importer/StreamImporter.php
@@ -11,6 +11,9 @@ use WordPress\DataLiberation\URL\WPURL;
 use WordPress\HttpClient\ByteStream\RequestReadStream;
 
 use function WordPress\DataLiberation\URL\is_child_url_of;
+use function WordPress\Polyfill\_doing_it_wrong;
+use function WordPress\Polyfill\apply_filters;
+use function WordPress\Polyfill\do_action;
 
 /**
  * Idea:

--- a/components/DataLiberation/Tests/FilesystemEntityReaderTest.php
+++ b/components/DataLiberation/Tests/FilesystemEntityReaderTest.php
@@ -153,7 +153,7 @@ class FilesystemEntityReaderTest extends TestCase {
 	}
 
 	private function normalize_markup( $markup ) {
-		return WP_HTML_Processor::create_fragment(
+		return \WordPress\HTML\WP_HTML_Processor::create_fragment(
 			preg_replace( '/\s+/', ' ', trim( $markup ) )
 		)->serialize();
 	}

--- a/components/DataLiberation/Tests/HTMLEntityReaderTest.php
+++ b/components/DataLiberation/Tests/HTMLEntityReaderTest.php
@@ -15,7 +15,7 @@ class HTMLEntityReaderTest extends TestCase {
 <h1>It is our pleasure to announce that WordPress 6.8 was released</h1>
 <p>Last week, WordPress 6.8 was released.</p>
 HTML;
-		$html_processor   = WP_HTML_Processor::create_fragment( $html );
+		$html_processor   = \WordPress\HTML\WP_HTML_Processor::create_fragment( $html );
 		$producer         = new MarkupProcessorConsumer( $html_processor );
 		$blocks_with_meta = $producer->consume();
 
@@ -70,7 +70,7 @@ HTML
 	}
 
 	private function normalize_markup( $markup ) {
-		$processor  = WP_HTML_Processor::create_fragment( $markup );
+		$processor  = \WordPress\HTML\WP_HTML_Processor::create_fragment( $markup );
 		$serialized = $processor->serialize();
 
 		return $serialized;

--- a/components/DataLiberation/Tests/MarkupProcessorConsumerTest.php
+++ b/components/DataLiberation/Tests/MarkupProcessorConsumerTest.php
@@ -18,7 +18,7 @@ class MarkupProcessorConsumerTest extends TestCase {
 <h1>WordPress 6.8 was released</h1>
 <p>Last week, WordPress 6.8 was released. This release includes a new default theme, a new block editor experience, and a new block library. It also includes a new block editor experience, and a new block library.</p>
 HTML;
-		$consumer          = new MarkupProcessorConsumer( new WP_HTML_Processor( $html ) );
+		$consumer          = new MarkupProcessorConsumer( \WordPress\HTML\WP_HTML_Processor::create_fragment( $html ) );
 		$blocks_with_meta  = $consumer->consume();
 		$metadata          = $blocks_with_meta->get_all_metadata();
 		$expected_metadata = array(
@@ -37,14 +37,14 @@ HTML;
 	 * @dataProvider provider_test_conversion
 	 */
 	public function test_html_to_blocks_conversion( $html, $expected ) {
-		$consumer         = new MarkupProcessorConsumer( new WP_HTML_Processor( $html ) );
+		$consumer         = new MarkupProcessorConsumer( \WordPress\HTML\WP_HTML_Processor::create_fragment( $html ) );
 		$blocks_with_meta = $consumer->consume();
 
 		$this->assertEquals( $this->normalize_markup( $expected ), $this->normalize_markup( $blocks_with_meta->get_block_markup() ) );
 	}
 
 	private function normalize_markup( $markup ) {
-		$processor  = WP_HTML_Processor::create_fragment( $markup );
+		$processor  = \WordPress\HTML\WP_HTML_Processor::create_fragment( $markup );
 		$serialized = $processor->serialize();
 		$serialized = trim(
 			str_replace(
@@ -137,7 +137,7 @@ HTML
 
 	public function test_html_to_blocks_excerpt() {
 		$this->markTestSkipped( 'Skipping this test because of outdated fixture.' );
-		// $consumer         = new MarkupProcessorConsumer( WP_HTML_Processor::create_fragment( $input ) );
+		// $consumer         = new MarkupProcessorConsumer( \WordPress\HTML\WP_HTML_Processor::create_fragment( $input ) );
 		// $blocks_with_meta = $consumer->consume();
 		// $blocks           = $blocks_with_meta->get_block_markup();
 

--- a/components/DataLiberation/URL/URLInTextProcessor.php
+++ b/components/DataLiberation/URL/URLInTextProcessor.php
@@ -3,7 +3,7 @@
 namespace WordPress\DataLiberation\URL;
 
 use WordPress\DataLiberation\BlockMarkup\URL;
-use WP_HTML_Text_Replacement;
+use WordPress\HTML\WP_HTML_Text_Replacement;
 
 /**
  * Finds string fragments that look like URLs and allow replacing them.
@@ -278,7 +278,7 @@ class URLInTextProcessor {
 			$new_url = substr( $new_url, strpos( $new_url, '://' ) + 3 );
 		}
 		$this->raw_url                                 = $new_url;
-		$this->lexical_updates[ $this->url_starts_at ] = new WP_HTML_Text_Replacement(
+		$this->lexical_updates[ $this->url_starts_at ] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 			$this->url_starts_at,
 			$this->url_length,
 			$new_url

--- a/components/Filesystem/Tests/FunctionsTest.php
+++ b/components/Filesystem/Tests/FunctionsTest.php
@@ -4,7 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_dirname;
-use ValueError;
 
 class FunctionsTest extends TestCase {
 	public function testBasicPathJoining() {

--- a/components/Git/GitRepository.php
+++ b/components/Git/GitRepository.php
@@ -14,6 +14,7 @@ use WordPress\Merge\MergeStrategy;
 use function WordPress\Filesystem\wp_unix_dirname;
 use function WordPress\Filesystem\wp_join_unix_paths;
 use function WordPress\Filesystem\wp_unix_path_resolve_dots;
+use function WordPress\Polyfill\_doing_it_wrong;
 
 class GitRepository {
 

--- a/components/HTML/class-wp-html-active-formatting-elements.php
+++ b/components/HTML/class-wp-html-active-formatting-elements.php
@@ -1,4 +1,6 @@
 <?php
+
+namespace WordPress\HTML;
 /**
  * HTML API: WP_HTML_Active_Formatting_Elements class
  *

--- a/components/HTML/class-wp-html-attribute-token.php
+++ b/components/HTML/class-wp-html-attribute-token.php
@@ -1,4 +1,6 @@
 <?php
+
+namespace WordPress\HTML;
 /**
  * HTML API: WP_HTML_Attribute_Token class
  *

--- a/components/HTML/class-wp-html-decoder.php
+++ b/components/HTML/class-wp-html-decoder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace WordPress\HTML;
+
 /**
  * HTML API: WP_HTML_Decoder class
  *

--- a/components/HTML/class-wp-html-doctype-info.php
+++ b/components/HTML/class-wp-html-doctype-info.php
@@ -1,4 +1,6 @@
 <?php
+
+namespace WordPress\HTML;
 /**
  * HTML API: WP_HTML_Doctype_Info class
  *

--- a/components/HTML/class-wp-html-open-elements.php
+++ b/components/HTML/class-wp-html-open-elements.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace WordPress\HTML;
+use Closure;
+use LogicException;
+
 /**
  * HTML API: WP_HTML_Open_Elements class
  *

--- a/components/HTML/class-wp-html-processor-state.php
+++ b/components/HTML/class-wp-html-processor-state.php
@@ -1,4 +1,6 @@
 <?php
+
+namespace WordPress\HTML;
 /**
  * HTML API: WP_HTML_Processor_State class
  *

--- a/components/HTML/class-wp-html-processor.php
+++ b/components/HTML/class-wp-html-processor.php
@@ -1,4 +1,6 @@
 <?php
+
+namespace WordPress\HTML;
 use function WordPress\Polyfill\__;
 use function WordPress\Polyfill\_doing_it_wrong;
 use function WordPress\Polyfill\wp_trigger_error;
@@ -43,7 +45,7 @@ use function WordPress\Polyfill\wp_trigger_error;
  *
  * Example:
  *
- *     $processor = WP_HTML_Processor::create_fragment( $html );
+ *     $processor = \WordPress\HTML\WP_HTML_Processor::create_fragment( $html );
  *     if ( $processor->next_tag( array( 'breadcrumbs' => array( 'DIV', 'FIGURE', 'IMG' ) ) ) ) {
  *         $processor->add_class( 'responsive-image' );
  *     }
@@ -52,7 +54,7 @@ use function WordPress\Polyfill\wp_trigger_error;
  *
  * Breadcrumbs represent the stack of open elements from the root
  * of the document or fragment down to the currently-matched node,
- * if one is currently selected. Call WP_HTML_Processor::get_breadcrumbs()
+ * if one is currently selected. Call \WordPress\HTML\WP_HTML_Processor::get_breadcrumbs()
  * to inspect the breadcrumbs for a matched tag.
  *
  * Breadcrumbs can specify nested HTML structure and are equivalent
@@ -179,7 +181,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.4.0
 	 *
-	 * @see WP_HTML_Processor::$release_internal_bookmark_on_destruct
+	 * @see \WordPress\HTML\WP_HTML_Processor::$release_internal_bookmark_on_destruct
 	 *
 	 * @var int
 	 */
@@ -373,7 +375,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.4.0
 	 *
-	 * @see WP_HTML_Processor::create_fragment()
+	 * @see \WordPress\HTML\WP_HTML_Processor::create_fragment()
 	 *
 	 */
 	public function __construct( $html, $use_the_static_create_methods_instead = null ) {
@@ -383,9 +385,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
-				/* translators: %s: WP_HTML_Processor::create_fragment(). */
+				/* translators: %s: \WordPress\HTML\WP_HTML_Processor::create_fragment(). */
 					__( 'Call %s to create an HTML Processor instead of calling the constructor directly.' ),
-					'<code>WP_HTML_Processor::create_fragment()</code>'
+					'<code>\WordPress\HTML\WP_HTML_Processor::create_fragment()</code>'
 				),
 				'6.4.0'
 			);
@@ -481,9 +483,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * Example
 	 *
-	 *     $processor = WP_HTML_Processor::create_fragment( '<template><strong><button><em><p><em>' );
+	 *     $processor = \WordPress\HTML\WP_HTML_Processor::create_fragment( '<template><strong><button><em><p><em>' );
 	 *     false === $processor->next_tag();
-	 *     WP_HTML_Processor::ERROR_UNSUPPORTED === $processor->get_last_error();
+	 *     \WordPress\HTML\WP_HTML_Processor::ERROR_UNSUPPORTED === $processor->get_last_error();
 	 *
 	 * @return string|null The last error, if one exists, otherwise null.
 	 * @see self::ERROR_UNSUPPORTED
@@ -689,7 +691,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * Example:
 	 *
-	 *     $p = WP_HTML_Processor::create_fragment( '<div></div>' );
+	 *     $p = \WordPress\HTML\WP_HTML_Processor::create_fragment( '<div></div>' );
 	 *     $p->next_tag( array( 'tag_name' => 'div', 'tag_closers' => 'visit' ) );
 	 *     $p->is_tag_closer() === false;
 	 *
@@ -733,7 +735,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * Example:
 	 *
-	 *     $processor = WP_HTML_Processor::create_fragment( '<div><span><figure><img></figure></span></div>' );
+	 *     $processor = \WordPress\HTML\WP_HTML_Processor::create_fragment( '<div><span><figure><img></figure></span></div>' );
 	 *     $processor->next_tag( 'img' );
 	 *     true  === $processor->matches_breadcrumbs( array( 'figure', 'img' ) );
 	 *     true  === $processor->matches_breadcrumbs( array( 'span', 'figure', 'img' ) );
@@ -1006,7 +1008,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * Example
 	 *
-	 *     $processor = WP_HTML_Processor::create_fragment( '<p><strong><em><img></em></strong></p>' );
+	 *     $processor = \WordPress\HTML\WP_HTML_Processor::create_fragment( '<p><strong><em><img></em></strong></p>' );
 	 *     $processor->next_tag( 'IMG' );
 	 *     $processor->get_breadcrumbs() === array( 'HTML', 'BODY', 'P', 'STRONG', 'EM', 'IMG' );
 	 *
@@ -1020,7 +1022,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * Example:
 	 *
-	 *     $processor = WP_HTML_Processor::create_fragment( '<div><p></p></div>' );
+	 *     $processor = \WordPress\HTML\WP_HTML_Processor::create_fragment( '<div><p></p></div>' );
 	 *     // The processor starts in the BODY context, meaning it has depth from the start: HTML > BODY.
 	 *     2 === $processor->get_current_depth();
 	 *
@@ -1049,8 +1051,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * This method assumes that the given HTML snippet is found in BODY context.
 	 * For normalizing full documents or fragments found in other contexts, create
-	 * a new processor using {@see WP_HTML_Processor::create_fragment} or
-	 * {@see WP_HTML_Processor::create_full_parser} and call {@see WP_HTML_Processor::serialize}
+	 * a new processor using {@see \WordPress\HTML\WP_HTML_Processor::create_fragment} or
+	 * {@see \WordPress\HTML\WP_HTML_Processor::create_full_parser} and call {@see \WordPress\HTML\WP_HTML_Processor::serialize}
 	 * on the created instances.
 	 *
 	 * Many aspects of an input HTML fragment may be changed during normalization.
@@ -1067,13 +1069,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * Example:
 	 *
-	 *     echo WP_HTML_Processor::normalize( '<a href=#anchor v=5 href="/" enabled>One</a another v=5><!--' );
+	 *     echo \WordPress\HTML\WP_HTML_Processor::normalize( '<a href=#anchor v=5 href="/" enabled>One</a another v=5><!--' );
 	 *     // <a href="#anchor" v="5" enabled>One</a>
 	 *
-	 *     echo WP_HTML_Processor::normalize( '<div></p>fun<table><td>cell</div>' );
+	 *     echo \WordPress\HTML\WP_HTML_Processor::normalize( '<div></p>fun<table><td>cell</div>' );
 	 *     // <div><p></p>fun<table><tbody><tr><td>cell</td></tr></tbody></table></div>
 	 *
-	 *     echo WP_HTML_Processor::normalize( '<![CDATA[invalid comment]]> syntax < <> "oddities"' );
+	 *     echo \WordPress\HTML\WP_HTML_Processor::normalize( '<![CDATA[invalid comment]]> syntax < <> "oddities"' );
 	 *     // <!--[CDATA[invalid comment]]--> syntax &lt; &lt;&gt; &quot;oddities&quot;
 	 *
 	 * @param  string  $html  Input HTML to normalize.
@@ -1089,7 +1091,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Returns normalized HTML for a fragment by serializing it.
 	 *
-	 * This differs from {@see WP_HTML_Processor::normalize} in that it starts with
+	 * This differs from {@see \WordPress\HTML\WP_HTML_Processor::normalize} in that it starts with
 	 * a specific HTML Processor, which _must_ not have already started scanning;
 	 * it must be in the initial ready state and will be in the completed state once
 	 * serialization is complete.
@@ -1108,15 +1110,15 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * Example:
 	 *
-	 *     $processor = WP_HTML_Processor::create_fragment( '<a href=#anchor v=5 href="/" enabled>One</a another v=5><!--' );
+	 *     $processor = \WordPress\HTML\WP_HTML_Processor::create_fragment( '<a href=#anchor v=5 href="/" enabled>One</a another v=5><!--' );
 	 *     echo $processor->serialize();
 	 *     // <a href="#anchor" v="5" enabled>One</a>
 	 *
-	 *     $processor = WP_HTML_Processor::create_fragment( '<div></p>fun<table><td>cell</div>' );
+	 *     $processor = \WordPress\HTML\WP_HTML_Processor::create_fragment( '<div></p>fun<table><td>cell</div>' );
 	 *     echo $processor->serialize();
 	 *     // <div><p></p>fun<table><tbody><tr><td>cell</td></tr></tbody></table></div>
 	 *
-	 *     $processor = WP_HTML_Processor::create_fragment( '<![CDATA[invalid comment]]> syntax < <> "oddities"' );
+	 *     $processor = \WordPress\HTML\WP_HTML_Processor::create_fragment( '<![CDATA[invalid comment]]> syntax < <> "oddities"' );
 	 *     echo $processor->serialize();
 	 *     // <!--[CDATA[invalid comment]]--> syntax &lt; &lt;&gt; &quot;oddities&quot;
 	 *
@@ -1286,13 +1288,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'initial' insertion mode.
 	 *
 	 * This internal function performs the 'initial' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#the-initial-insertion-mode
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -1360,13 +1362,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'before html' insertion mode.
 	 *
 	 * This internal function performs the 'before html' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#the-before-html-insertion-mode
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -1460,13 +1462,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'before head' insertion mode.
 	 *
 	 * This internal function performs the 'before head' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#the-before-head-insertion-mode
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -1560,13 +1562,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in head' insertion mode.
 	 *
 	 * This internal function performs the 'in head' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhead
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -1789,13 +1791,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in head noscript' insertion mode.
 	 *
 	 * This internal function performs the 'in head noscript' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-inheadnoscript
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -1893,13 +1895,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'after head' insertion mode.
 	 *
 	 * This internal function performs the 'after head' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#the-after-head-insertion-mode
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -2042,13 +2044,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in body' insertion mode.
 	 *
 	 * This internal function performs the 'in body' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-inbody
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.4.0
 	 *
@@ -3097,13 +3099,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in table' insertion mode.
 	 *
 	 * This internal function performs the 'in table' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-intable
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -3364,13 +3366,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in table text' insertion mode.
 	 *
 	 * This internal function performs the 'in table text' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-intabletext
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -3383,13 +3385,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in caption' insertion mode.
 	 *
 	 * This internal function performs the 'in caption' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-incaption
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -3468,13 +3470,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in column group' insertion mode.
 	 *
 	 * This internal function performs the 'in column group' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-incolgroup
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -3580,13 +3582,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in table body' insertion mode.
 	 *
 	 * This internal function performs the 'in table body' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-intbody
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -3688,13 +3690,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in row' insertion mode.
 	 *
 	 * This internal function performs the 'in row' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-intr
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -3803,13 +3805,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in cell' insertion mode.
 	 *
 	 * This internal function performs the 'in cell' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-intd
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -3911,13 +3913,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in select' insertion mode.
 	 *
 	 * This internal function performs the 'in select' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inselect
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -4095,13 +4097,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in select in table' insertion mode.
 	 *
 	 * This internal function performs the 'in select in table' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-inselectintable
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0
 	 *
@@ -4162,13 +4164,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in template' insertion mode.
 	 *
 	 * This internal function performs the 'in template' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-intemplate
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -4297,13 +4299,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'after body' insertion mode.
 	 *
 	 * This internal function performs the 'after body' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-afterbody
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -4381,13 +4383,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in frameset' insertion mode.
 	 *
 	 * This internal function performs the 'in frameset' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-inframeset
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -4503,13 +4505,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'after frameset' insertion mode.
 	 *
 	 * This internal function performs the 'after frameset' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-afterframeset
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -4583,13 +4585,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'after after body' insertion mode.
 	 *
 	 * This internal function performs the 'after after body' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#the-after-after-body-insertion-mode
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -4647,13 +4649,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'after after frameset' insertion mode.
 	 *
 	 * This internal function performs the 'after after frameset' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#the-after-after-frameset-insertion-mode
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -4715,13 +4717,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Parses next element in the 'in foreign content' insertion mode.
 	 *
 	 * This internal function performs the 'in foreign content' insertion mode
-	 * logic for the generalized WP_HTML_Processor::step() function.
+	 * logic for the generalized \WordPress\HTML\WP_HTML_Processor::step() function.
 	 *
 	 * @return bool Whether an element was found.
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
 	 * @see https://html.spec.whatwg.org/#parsing-main-inforeign
-	 * @see WP_HTML_Processor::step
+	 * @see \WordPress\HTML\WP_HTML_Processor::step
 	 *
 	 * @since 6.7.0 Stub implementation.
 	 *
@@ -5216,7 +5218,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * Example:
 	 *
-	 *     $p = WP_HTML_Processor::create_fragment( '<div enabled class="test" data-test-id="14">Test</div>' );
+	 *     $p = \WordPress\HTML\WP_HTML_Processor::create_fragment( '<div enabled class="test" data-test-id="14">Test</div>' );
 	 *     $p->next_token() === true;
 	 *     $p->get_attribute( 'data-test-id' ) === '14';
 	 *     $p->get_attribute( 'enabled' ) === true;
@@ -5349,7 +5351,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * Example:
 	 *
-	 *     $p = WP_HTML_Processor::create_fragment( "<div class='free &lt;egg&lt;\tlang-en'>" );
+	 *     $p = \WordPress\HTML\WP_HTML_Processor::create_fragment( "<div class='free &lt;egg&lt;\tlang-en'>" );
 	 *     $p->next_tag();
 	 *     foreach ( $p->class_list() as $class_name ) {
 	 *         echo "{$class_name} ";
@@ -5695,7 +5697,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @since 6.4.0
 	 * @since 6.7.0 Full spec support.
 	 *
-	 * @see WP_HTML_Processor::generate_implied_end_tags
+	 * @see \WordPress\HTML\WP_HTML_Processor::generate_implied_end_tags
 	 * @see https://html.spec.whatwg.org/#generate-implied-end-tags
 	 */
 	private function generate_implied_end_tags_thoroughly(): void {
@@ -6571,5 +6573,5 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @access private
 	 */
-	const CONSTRUCTOR_UNLOCK_CODE = 'Use WP_HTML_Processor::create_fragment() instead of calling the class constructor directly.';
+	const CONSTRUCTOR_UNLOCK_CODE = 'Use \WordPress\HTML\WP_HTML_Processor::create_fragment() instead of calling the class constructor directly.';
 }

--- a/components/HTML/class-wp-html-processor.php
+++ b/components/HTML/class-wp-html-processor.php
@@ -1,4 +1,8 @@
 <?php
+use function WordPress\Polyfill\__;
+use function WordPress\Polyfill\_doing_it_wrong;
+use function WordPress\Polyfill\wp_trigger_error;
+
 /**
  * HTML API: WP_HTML_Processor class
  *

--- a/components/HTML/class-wp-html-span.php
+++ b/components/HTML/class-wp-html-span.php
@@ -1,4 +1,6 @@
 <?php
+
+namespace WordPress\HTML;
 /**
  * HTML API: WP_HTML_Span class
  *

--- a/components/HTML/class-wp-html-stack-event.php
+++ b/components/HTML/class-wp-html-stack-event.php
@@ -1,4 +1,6 @@
 <?php
+
+namespace WordPress\HTML;
 /**
  * HTML API: WP_HTML_Stack_Event class
  *

--- a/components/HTML/class-wp-html-tag-processor.php
+++ b/components/HTML/class-wp-html-tag-processor.php
@@ -1,4 +1,11 @@
 <?php
+
+use function WordPress\Polyfill\esc_attr;
+use function WordPress\Polyfill\esc_url;
+use function WordPress\Polyfill\wp_kses_uri_attributes;
+use function WordPress\Polyfill\__;
+use function WordPress\Polyfill\_doing_it_wrong;
+
 /**
  * HTML API: WP_HTML_Tag_Processor class
  *

--- a/components/HTML/class-wp-html-tag-processor.php
+++ b/components/HTML/class-wp-html-tag-processor.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace WordPress\HTML;
+
 use function WordPress\Polyfill\esc_attr;
 use function WordPress\Polyfill\esc_url;
 use function WordPress\Polyfill\wp_kses_uri_attributes;
@@ -797,7 +799,7 @@ class WP_HTML_Tag_Processor {
 	 *     // sourced from the lazily-parsed HTML recognizer.
 	 *     $start  = $attributes['src']->start;
 	 *     $length = $attributes['src']->length;
-	 *     $modifications[] = new WP_HTML_Text_Replacement( $start, $length, $new_value );
+	 *     $modifications[] = new \WordPress\HTML\WP_HTML_Text_Replacement( $start, $length, $new_value );
 	 *
 	 *     // Correspondingly, something like this will appear in this array.
 	 *     $lexical_updates = array(
@@ -3732,7 +3734,7 @@ class WP_HTML_Tag_Processor {
 	 */
 	public function set_modifiable_text( string $plaintext_content ): bool {
 		if ( self::STATE_TEXT_NODE === $this->parser_state ) {
-			$this->lexical_updates['modifiable text'] = new WP_HTML_Text_Replacement(
+			$this->lexical_updates['modifiable text'] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 				$this->text_starts_at,
 				$this->text_length,
 				htmlspecialchars( $plaintext_content, ENT_QUOTES | ENT_HTML5 )
@@ -3751,7 +3753,7 @@ class WP_HTML_Tag_Processor {
 				return false;
 			}
 
-			$this->lexical_updates['modifiable text'] = new WP_HTML_Text_Replacement(
+			$this->lexical_updates['modifiable text'] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 				$this->text_starts_at,
 				$this->text_length,
 				$plaintext_content
@@ -3780,7 +3782,7 @@ class WP_HTML_Tag_Processor {
 					return false;
 				}
 
-				$this->lexical_updates['modifiable text'] = new WP_HTML_Text_Replacement(
+				$this->lexical_updates['modifiable text'] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 					$this->text_starts_at,
 					$this->text_length,
 					$plaintext_content
@@ -3797,7 +3799,7 @@ class WP_HTML_Tag_Processor {
 					$plaintext_content
 				);
 
-				$this->lexical_updates['modifiable text'] = new WP_HTML_Text_Replacement(
+				$this->lexical_updates['modifiable text'] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 					$this->text_starts_at,
 					$this->text_length,
 					$plaintext_content
@@ -3823,7 +3825,7 @@ class WP_HTML_Tag_Processor {
 				 * @todo It would be useful to prefix a multiline replacement text
 				 *       with a newline, but not necessary. This is for aesthetics.
 				 */
-				$this->lexical_updates['modifiable text'] = new WP_HTML_Text_Replacement(
+				$this->lexical_updates['modifiable text'] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 					$this->text_starts_at,
 					$this->text_length,
 					$plaintext_content
@@ -3957,7 +3959,7 @@ class WP_HTML_Tag_Processor {
 			 *     Result: <div id="new"/>
 			 */
 			$existing_attribute                        = $this->attributes[ $comparable_name ];
-			$this->lexical_updates[ $comparable_name ] = new WP_HTML_Text_Replacement(
+			$this->lexical_updates[ $comparable_name ] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 				$existing_attribute->start,
 				$existing_attribute->length,
 				$updated_attribute
@@ -3975,7 +3977,7 @@ class WP_HTML_Tag_Processor {
 			 *
 			 *     Result: <div id="new"/>
 			 */
-			$this->lexical_updates[ $comparable_name ] = new WP_HTML_Text_Replacement(
+			$this->lexical_updates[ $comparable_name ] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 				$this->tag_name_starts_at + $this->tag_name_length,
 				0,
 				' ' . $updated_attribute
@@ -4055,7 +4057,7 @@ class WP_HTML_Tag_Processor {
 		 *
 		 *    Result: <div />
 		 */
-		$this->lexical_updates[ $name ] = new WP_HTML_Text_Replacement(
+		$this->lexical_updates[ $name ] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 			$this->attributes[ $name ]->start,
 			$this->attributes[ $name ]->length,
 			''
@@ -4063,7 +4065,7 @@ class WP_HTML_Tag_Processor {
 
 		// Removes any duplicated attributes if they were also present.
 		foreach ( $this->duplicate_attributes[ $name ] ?? array() as $attribute_token ) {
-			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+			$this->lexical_updates[] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 				$attribute_token->start,
 				$attribute_token->length,
 				''

--- a/components/HTML/class-wp-html-text-replacement.php
+++ b/components/HTML/class-wp-html-text-replacement.php
@@ -1,4 +1,6 @@
 <?php
+
+namespace WordPress\HTML;
 /**
  * HTML API: WP_HTML_Text_Replacement class
  *

--- a/components/HTML/class-wp-html-token.php
+++ b/components/HTML/class-wp-html-token.php
@@ -1,4 +1,8 @@
 <?php
+
+namespace WordPress\HTML;
+use LogicException;
+
 /**
  * HTML API: WP_HTML_Token class
  *
@@ -36,11 +40,11 @@ class WP_HTML_Token {
 	/**
 	 * Name of node; lowercase names such as "marker" are not HTML elements.
 	 *
-	 * For HTML elements/tags this value should come from WP_HTML_Processor::get_tag().
+	 * For HTML elements/tags this value should come from \WordPress\HTML\WP_HTML_Processor::get_tag().
 	 *
 	 * @since 6.4.0
 	 *
-	 * @see WP_HTML_Processor::get_tag()
+	 * @see \WordPress\HTML\WP_HTML_Processor::get_tag()
 	 *
 	 * @var string
 	 */

--- a/components/HTML/class-wp-html-unsupported-exception.php
+++ b/components/HTML/class-wp-html-unsupported-exception.php
@@ -1,4 +1,8 @@
 <?php
+
+namespace WordPress\HTML;
+use Exception;
+
 /**
  * HTML API: WP_HTML_Unsupported_Exception class
  *

--- a/components/HTML/class-wp-token-map.php
+++ b/components/HTML/class-wp-token-map.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace WordPress\HTML;
+
 use function WordPress\Polyfill\_doing_it_wrong;
 use function WordPress\Polyfill\__;
 

--- a/components/HTML/class-wp-token-map.php
+++ b/components/HTML/class-wp-token-map.php
@@ -1,5 +1,8 @@
 <?php
 
+use function WordPress\Polyfill\_doing_it_wrong;
+use function WordPress\Polyfill\__;
+
 /**
  * Class for efficiently looking up and mapping string keys to string values, with limits.
  *

--- a/components/HTML/composer.json
+++ b/components/HTML/composer.json
@@ -16,6 +16,9 @@
 		"php": ">=7.2"
 	},
 	"autoload": {
+		"psr-4": {
+			"WordPress\\HTML\\": "."
+		},
 		"classmap": [
 			"./"
 		],

--- a/components/HTML/html5-named-character-references.php
+++ b/components/HTML/html5-named-character-references.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace WordPress\HTML;
+
 /**
  * Auto-generated class for looking up HTML named character references.
  *

--- a/components/HttpClient/Middleware/HttpMiddleware.php
+++ b/components/HttpClient/Middleware/HttpMiddleware.php
@@ -4,12 +4,11 @@ namespace WordPress\HttpClient\Middleware;
 
 use WordPress\HttpClient\Client;
 use WordPress\HttpClient\ClientState;
-use WordPress\HttpClient\HttpClientException;
 use WordPress\HttpClient\Request;
 use WordPress\HttpClient\Connection;
-use WordPress\HttpClient\Transport\CurlTransport;
-use WordPress\HttpClient\Transport\SocketTransport;
 use WordPress\HttpClient\Transport\TransportInterface;
+
+use function WordPress\Polyfill\apply_filters;
 
 class HttpMiddleware implements MiddlewareInterface {
 

--- a/components/Markdown/MarkdownConsumer.php
+++ b/components/Markdown/MarkdownConsumer.php
@@ -18,7 +18,7 @@ use WordPress\DataLiberation\BlockMarkup\BlockObject;
 use WordPress\DataLiberation\DataFormatConsumer\BlocksWithMetadata;
 use WordPress\DataLiberation\DataFormatConsumer\DataFormatConsumer;
 use WordPress\DataLiberation\Importer\ImportUtils;
-use WP_HTML_Tag_Processor;
+use WordPress\HTML\WP_HTML_Tag_Processor;
 
 /**
  * Transforms markdown with frontmatter into a block markup and metadata pair.

--- a/components/Markdown/MarkdownImporter.php
+++ b/components/Markdown/MarkdownImporter.php
@@ -7,6 +7,8 @@ use WordPress\DataLiberation\EntityReader\FilesystemEntityReader;
 use WordPress\DataLiberation\Importer\StreamImporter;
 use WordPress\Filesystem\LocalFilesystem;
 
+use function WordPress\Polyfill\_doing_it_wrong;
+
 class MarkdownImporter extends StreamImporter {
 
 	public static function create_for_markdown_directory( $markdown_directory, $options = array(), $cursor = null ) {

--- a/components/Markdown/MarkdownProducer.php
+++ b/components/Markdown/MarkdownProducer.php
@@ -5,6 +5,8 @@ namespace WordPress\Markdown;
 use WordPress\DataLiberation\DataFormatConsumer\BlocksWithMetadata;
 use WordPress\DataLiberation\DataFormatProducer\DataFormatProducer;
 use WordPress\DataLiberation\DataLiberationHTMLProcessor;
+use function WordPress\Polyfill\parse_blocks;
+use function WordPress\Polyfill\serialize_block;
 
 /**
  * Converts WordPress blocks and metadata to Markdown with frontmatter.
@@ -283,7 +285,7 @@ class MarkdownProducer implements DataFormatProducer {
 				$markdown   = array();
 				$markdown[] = '';
 				$markdown[] = '```block';
-				$markdown[] = \serialize_block( $block );
+				$markdown[] = serialize_block( $block );
 				$markdown[] = '```';
 				$markdown[] = '';
 				return implode( "\n", $markdown );

--- a/components/Markdown/Tests/MarkdownConsumerTest.php
+++ b/components/Markdown/Tests/MarkdownConsumerTest.php
@@ -67,7 +67,7 @@ MD;
 	}
 
 	private function normalize_markup( $markup ) {
-		$processor  = WP_HTML_Processor::create_fragment( $markup );
+		$processor  = \WordPress\HTML\WP_HTML_Processor::create_fragment( $markup );
 		$serialized = $processor->serialize();
 		$serialized = trim(
 			str_replace(

--- a/components/Merge/Validate/BlockMarkupMergeValidator.php
+++ b/components/Merge/Validate/BlockMarkupMergeValidator.php
@@ -4,7 +4,7 @@ namespace WordPress\Merge\Validate;
 
 use ReflectionClass;
 use WordPress\DataLiberation\BlockMarkup\BlockMarkupProcessor;
-use WP_HTML_Processor;
+use WordPress\HTML\WP_HTML_Processor;
 
 class BlockMarkupMergeValidator implements MergeValidator {
 
@@ -55,7 +55,7 @@ class BlockMarkupMergeValidator implements MergeValidator {
 
 	private function assert_html_is_structurally_sound( $html ) {
 		$html           .= '<TERMINATE-PROCESSING>';
-		$html_processor = WP_HTML_Processor::create_fragment( $html );
+		$html_processor = \WordPress\HTML\WP_HTML_Processor::create_fragment( $html );
 
 		/**
 		 * Make the is_virtual() method public to enable deeper inspection.

--- a/components/Polyfill/wordpress.php
+++ b/components/Polyfill/wordpress.php
@@ -160,7 +160,7 @@ function parse_blocks( $input ) {
 	if ( function_exists( '\\parse_blocks' ) ) {
 		return call_user_func_array( '\\parse_blocks', func_get_args() );
 	}
-	$parser = new \WP_Block_Parser();
+	$parser = new \WordPress\BlockParser\WP_Block_Parser();
 
 	return $parser->parse( $input );
 }

--- a/components/Polyfill/wordpress.php
+++ b/components/Polyfill/wordpress.php
@@ -2,7 +2,10 @@
 /**
  * Polyfills WordPress core functions for running in non-WordPress environments
  */
+namespace WordPress\Polyfill;
 
+// This may be loaded twice if Polyfills are included before WordPress, but that's fine.
+// There are no function declarations in that file, only a global variable.
 if (
 	! isset( $html5_named_character_references ) &&
 	file_exists( __DIR__ . '/../HTML/html5-named-character-references.php' )
@@ -10,213 +13,233 @@ if (
 	require_once __DIR__ . '/../HTML/html5-named-character-references.php';
 }
 
+// @TODO: Wrap in namespaces before merging:
 if ( ! class_exists( 'WP_Block_Parser' ) ) {
 	require_once __DIR__ . '/../BlockParser/class-wp-block-parser-block.php';
 	require_once __DIR__ . '/../BlockParser/class-wp-block-parser-frame.php';
 	require_once __DIR__ . '/../BlockParser/class-wp-block-parser.php';
 }
 
-if ( ! function_exists( '_doing_it_wrong' ) ) {
-	$GLOBALS['_doing_it_wrong_messages'] = array();
-	function _doing_it_wrong( $method, $message, $version ) {
-		$GLOBALS['_doing_it_wrong_messages'][] = $message;
+$GLOBALS['_doing_it_wrong_messages'] = array();
+function _doing_it_wrong( $method, $message, $version ) {
+	if ( function_exists( '\\_doing_it_wrong' ) ) {
+		return call_user_func_array( '\\_doing_it_wrong', func_get_args() );
 	}
+	$GLOBALS['_doing_it_wrong_messages'][] = $message;
 }
 
-if ( ! class_exists( 'WP_Exception' ) ) {
-	class WP_Exception extends Exception {
+function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTICE ) {
+	if ( function_exists( '\\wp_trigger_error' ) ) {
+		return call_user_func_array( '\\wp_trigger_error', func_get_args() );
 	}
-}
 
-if ( ! function_exists( 'wp_trigger_error' ) ) {
-	function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTICE ) {
-		if ( ! empty( $function_name ) ) {
-			$message = sprintf( '%s(): %s', $function_name, $message );
-		}
-
-		if ( E_USER_ERROR === $error_level ) {
-			throw new WP_Exception( $message );
-		}
-
-		trigger_error( $message, $error_level );
+	if ( ! empty( $function_name ) ) {
+		$message = sprintf( '%s(): %s', $function_name, $message );
 	}
-}
 
-if ( ! function_exists( 'wp_kses_uri_attributes' ) ) {
-	function wp_kses_uri_attributes() {
-		return array();
-	}
-}
-
-if ( ! function_exists( '__' ) ) {
-	function __( $input ) {
-		return $input;
-	}
-}
-
-if ( ! function_exists( 'esc_attr' ) ) {
-	function esc_attr( $input ) {
-		return htmlspecialchars( $input );
-	}
-}
-
-if ( ! function_exists( 'esc_html' ) ) {
-	function esc_html( $input ) {
-		return htmlspecialchars( $input );
-	}
-}
-
-if ( ! function_exists( 'esc_url' ) ) {
-	function esc_url( $url ) {
-		return htmlspecialchars( $url );
-	}
-}
-
-if ( ! function_exists( 'add_filter' ) ) {
-	function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
-		global $wp_filter;
-		if ( ! isset( $wp_filter ) ) {
-			$wp_filter = array();
-		}
-		if ( ! isset( $wp_filter[ $hook_name ] ) ) {
-			$wp_filter[ $hook_name ] = array();
-		}
-		if ( ! isset( $wp_filter[ $hook_name ][ $priority ] ) ) {
-			$wp_filter[ $hook_name ][ $priority ] = array();
-		}
-		$wp_filter[ $hook_name ][ $priority ][] = array(
-			'function'      => $callback,
-			'accepted_args' => $accepted_args,
-		);
-
-		return true;
-	}
-}
-
-if ( ! function_exists( 'add_action' ) ) {
-	function add_action( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
-		return add_filter( $hook_name, $callback, $priority, $accepted_args );
-	}
-}
-
-if ( ! function_exists( 'apply_filters' ) ) {
-	function apply_filters( $hook_name, $value ) {
-		global $wp_filter;
-		if ( ! isset( $wp_filter[ $hook_name ] ) ) {
-			return $value;
-		}
-		$args = func_get_args();
-		array_shift( $args ); // Remove hook name
-
-		ksort( $wp_filter[ $hook_name ] );
-		foreach ( $wp_filter[ $hook_name ] as $priority => $functions ) {
-			foreach ( $functions as $function ) {
-				$args[0] = $value;
-				$value   = call_user_func_array( $function['function'], array_slice( $args, 0, $function['accepted_args'] ) );
+	if ( E_USER_ERROR === $error_level ) {
+		if ( ! class_exists( '\WP_Exception' ) ) {
+			class WP_Exception extends \Exception {
 			}
 		}
+		throw new WP_Exception( $message );
+	}
 
+	trigger_error( $message, $error_level );
+}
+
+function wp_kses_uri_attributes() {
+	if ( function_exists( '\\wp_kses_uri_attributes' ) ) {
+		return call_user_func_array( '\\wp_kses_uri_attributes', func_get_args() );
+	}
+	return array();
+}
+
+function __( $input ) {
+	if ( function_exists( '\\__' ) ) {
+		return call_user_func_array( '\\__', func_get_args() );
+	}
+	return $input;
+}
+
+function esc_attr( $input ) {
+	if ( function_exists( '\\esc_attr' ) ) {
+		return call_user_func_array( '\\esc_attr', func_get_args() );
+	}
+	return htmlspecialchars( $input );
+}
+
+function esc_html( $input ) {
+	if ( function_exists( '\\esc_html' ) ) {
+		return call_user_func_array( '\\esc_html', func_get_args() );
+	}
+	return htmlspecialchars( $input );
+}
+
+function esc_url( $url ) {
+	if ( function_exists( '\\esc_url' ) ) {
+		return call_user_func_array( '\\esc_url', func_get_args() );
+	}
+	return htmlspecialchars( $url );
+}
+
+function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+	global $wp_filter;
+	if ( function_exists( '\\add_filter' ) ) {
+		return call_user_func_array( '\\add_filter', func_get_args() );
+	}
+
+	if ( ! isset( $wp_filter ) ) {
+		$wp_filter = array();
+	}
+	if ( ! isset( $wp_filter[ $hook_name ] ) ) {
+		$wp_filter[ $hook_name ] = array();
+	}
+	if ( ! isset( $wp_filter[ $hook_name ][ $priority ] ) ) {
+		$wp_filter[ $hook_name ][ $priority ] = array();
+	}
+	$wp_filter[ $hook_name ][ $priority ][] = array(
+		'function'      => $callback,
+		'accepted_args' => $accepted_args,
+	);
+
+	return true;
+}
+
+function add_action( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+	if ( function_exists( '\\add_action' ) ) {
+		return call_user_func_array( '\\add_action', func_get_args() );
+	}
+	return add_filter( $hook_name, $callback, $priority, $accepted_args );
+}
+
+function apply_filters( $hook_name, $value ) {
+	global $wp_filter;
+	if ( function_exists( '\\apply_filters' ) ) {
+		return call_user_func_array( '\\apply_filters', func_get_args() );
+	}
+
+	if ( ! isset( $wp_filter[ $hook_name ] ) ) {
 		return $value;
 	}
+	$args = func_get_args();
+	array_shift( $args ); // Remove hook name
+
+	ksort( $wp_filter[ $hook_name ] );
+	foreach ( $wp_filter[ $hook_name ] as $priority => $functions ) {
+		foreach ( $functions as $function ) {
+			$args[0] = $value;
+			$value   = call_user_func_array( $function['function'], array_slice( $args, 0, $function['accepted_args'] ) );
+		}
+	}
+
+	return $value;
 }
 
-if ( ! function_exists( 'do_action' ) ) {
-	function do_action( $hook_name ) {
-		global $wp_filter;
-		if ( ! isset( $wp_filter[ $hook_name ] ) ) {
-			return;
-		}
-		$args = func_get_args();
-		array_shift( $args ); // Remove hook name
+function do_action( $hook_name ) {
+	global $wp_filter;
+	if ( function_exists( '\\do_action' ) ) {
+		return call_user_func_array( '\\do_action', func_get_args() );
+	}
 
-		ksort( $wp_filter[ $hook_name ] );
-		foreach ( $wp_filter[ $hook_name ] as $priority => $functions ) {
-			foreach ( $functions as $function ) {
-				call_user_func_array( $function['function'], array_slice( $args, 0, $function['accepted_args'] ) );
-			}
+	if ( ! isset( $wp_filter[ $hook_name ] ) ) {
+		return;
+	}
+	$args = func_get_args();
+	array_shift( $args ); // Remove hook name
+
+	ksort( $wp_filter[ $hook_name ] );
+	foreach ( $wp_filter[ $hook_name ] as $priority => $functions ) {
+		foreach ( $functions as $function ) {
+			call_user_func_array( $function['function'], array_slice( $args, 0, $function['accepted_args'] ) );
 		}
 	}
 }
 
-if ( ! function_exists( 'parse_blocks' ) ) {
-	function parse_blocks( $input ) {
-		$parser = new WP_Block_Parser();
-
-		return $parser->parse( $input );
+function parse_blocks( $input ) {
+	if ( function_exists( '\\parse_blocks' ) ) {
+		return call_user_func_array( '\\parse_blocks', func_get_args() );
 	}
+	$parser = new \WP_Block_Parser();
+
+	return $parser->parse( $input );
 }
 
-if ( ! function_exists( 'serialize_blocks' ) ) {
-	function serialize_blocks( $blocks ) {
-		return implode( '', array_map( 'serialize_block', $blocks ) );
+function serialize_blocks( $blocks ) {
+	if ( function_exists( '\\serialize_blocks' ) ) {
+		return call_user_func_array( '\\serialize_blocks', func_get_args() );
 	}
+	return implode( '', array_map( 'serialize_block', $blocks ) );
 }
 
-if ( ! function_exists( 'serialize_block' ) ) {
-	function serialize_block( $block ) {
-		$block_content = '';
-
-		$index = 0;
-		foreach ( $block['innerContent'] as $chunk ) {
-			$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $block['innerBlocks'][ $index ++ ] );
-		}
-
-		if ( ! is_array( $block['attrs'] ) ) {
-			$block['attrs'] = array();
-		}
-
-		return get_comment_delimited_block_content(
-			$block['blockName'],
-			$block['attrs'],
-			$block_content
-		);
+function serialize_block( $block ) {
+	if ( function_exists( '\\serialize_block' ) ) {
+		return call_user_func_array( '\\serialize_block', func_get_args() );
 	}
+	$block_content = '';
+
+	$index = 0;
+	foreach ( $block['innerContent'] as $chunk ) {
+		$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $block['innerBlocks'][ $index ++ ] );
+	}
+
+	if ( ! is_array( $block['attrs'] ) ) {
+		$block['attrs'] = array();
+	}
+
+	return get_comment_delimited_block_content(
+		$block['blockName'],
+		$block['attrs'],
+		$block_content
+	);
 }
 
-if ( ! function_exists( 'get_comment_delimited_block_content' ) ) {
-	function get_comment_delimited_block_content( $block_name, $block_attributes, $block_content ) {
-		if ( is_null( $block_name ) ) {
-			return $block_content;
-		}
-
-		$serialized_block_name = strip_core_block_namespace( $block_name );
-		$serialized_attributes = empty( $block_attributes ) ? '' : serialize_block_attributes( $block_attributes ) . ' ';
-
-		if ( empty( $block_content ) ) {
-			return sprintf( '<!-- wp:%s %s/-->', $serialized_block_name, $serialized_attributes );
-		}
-
-		return sprintf(
-			'<!-- wp:%s %s-->%s<!-- /wp:%s -->',
-			$serialized_block_name,
-			$serialized_attributes,
-			$block_content,
-			$serialized_block_name
-		);
+function get_comment_delimited_block_content( $block_name, $block_attributes, $block_content ) {
+	if ( function_exists( '\\get_comment_delimited_block_content' ) ) {
+		return call_user_func_array( '\\get_comment_delimited_block_content', func_get_args() );
 	}
+	if ( is_null( $block_name ) ) {
+		return $block_content;
+	}
+
+	$serialized_block_name = strip_core_block_namespace( $block_name );
+	$serialized_attributes = empty( $block_attributes ) ? '' : serialize_block_attributes( $block_attributes ) . ' ';
+
+	if ( empty( $block_content ) ) {
+		return sprintf( '<!-- wp:%s %s/-->', $serialized_block_name, $serialized_attributes );
+	}
+
+	return sprintf(
+		'<!-- wp:%s %s-->%s<!-- /wp:%s -->',
+		$serialized_block_name,
+		$serialized_attributes,
+		$block_content,
+		$serialized_block_name
+	);
 }
 
-if ( ! function_exists( 'strip_core_block_namespace' ) ) {
-	function strip_core_block_namespace( $block_name = null ) {
-		if ( is_string( $block_name ) && strncmp( $block_name, 'core/', strlen( 'core/' ) ) === 0 ) {
-			return substr( $block_name, 5 );
-		}
-
-		return $block_name;
+function strip_core_block_namespace( $block_name = null ) {
+	if ( function_exists( '\\strip_core_block_namespace' ) ) {
+		return call_user_func_array( '\\strip_core_block_namespace', func_get_args() );
 	}
+	if ( is_string( $block_name ) && strncmp( $block_name, 'core/', strlen( 'core/' ) ) === 0 ) {
+		return substr( $block_name, 5 );
+	}
+
+	return $block_name;
 }
 
-
-if ( ! function_exists( 'serialize_block_attributes' ) ) {
-	function serialize_block_attributes( $block_attributes ) {
-		$encoded_attributes = json_encode( $block_attributes, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-		$encoded_attributes = preg_replace( '/--/', '\\u002d\\u002d', $encoded_attributes );
-		$encoded_attributes = preg_replace( '/</', '\\u003c', $encoded_attributes );
-		$encoded_attributes = preg_replace( '/>/', '\\u003e', $encoded_attributes );
-		$encoded_attributes = preg_replace( '/&/', '\\u0026', $encoded_attributes );
-		// Regex: /\\"/
-		$encoded_attributes = preg_replace( '/\\\\"/', '\\u0022', $encoded_attributes );
-
-		return $encoded_attributes;
+function serialize_block_attributes( $block_attributes ) {
+	if ( function_exists( '\\serialize_block_attributes' ) ) {
+		return call_user_func_array( '\\serialize_block_attributes', func_get_args() );
 	}
+	$encoded_attributes = json_encode( $block_attributes, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+	$encoded_attributes = preg_replace( '/--/', '\\u002d\\u002d', $encoded_attributes );
+	$encoded_attributes = preg_replace( '/</', '\\u003c', $encoded_attributes );
+	$encoded_attributes = preg_replace( '/>/', '\\u003e', $encoded_attributes );
+	$encoded_attributes = preg_replace( '/&/', '\\u0026', $encoded_attributes );
+	// Regex: /\\"/
+	$encoded_attributes = preg_replace( '/\\\\"/', '\\u0022', $encoded_attributes );
+
+	return $encoded_attributes;
 }

--- a/components/XML/Tests/XMLProcessorTest.php
+++ b/components/XML/Tests/XMLProcessorTest.php
@@ -1486,7 +1486,7 @@ class XMLProcessorTest extends TestCase {
 			 */
 			public function insert_after( $new_xml ) {
 				$this->set_bookmark( 'here' );
-				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+				$this->lexical_updates[] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 					$this->bookmarks['here']->start + $this->bookmarks['here']->length,
 					0,
 					$new_xml

--- a/components/XML/XMLDecoder.php
+++ b/components/XML/XMLDecoder.php
@@ -2,7 +2,7 @@
 
 namespace WordPress\XML;
 
-use WP_HTML_Decoder;
+use WordPress\HTML\WP_HTML_Decoder;
 
 /**
  * XML API: WP_XML_Decoder class

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -6,6 +6,8 @@ use WP_HTML_Span;
 use WP_HTML_Text_Replacement;
 
 use function WordPress\Encoding\utf8_codepoint_at;
+use function WordPress\Polyfill\_doing_it_wrong;
+use function WordPress\Polyfill\__;
 
 /**
  * XML API: XMLProcessor class

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -2,8 +2,8 @@
 
 namespace WordPress\XML;
 
-use WP_HTML_Span;
-use WP_HTML_Text_Replacement;
+use WordPress\HTML\WP_HTML_Span;
+use WordPress\HTML\WP_HTML_Text_Replacement;
 
 use function WordPress\Encoding\utf8_codepoint_at;
 use function WordPress\Polyfill\_doing_it_wrong;
@@ -626,7 +626,7 @@ class XMLProcessor {
 	 *     // sourced from the lazily-parsed XML recognizer.
 	 *     $start  = $attributes['src']->start;
 	 *     $length = $attributes['src']->length;
-	 *     $modifications[] = new WP_HTML_Text_Replacement( $start, $length, $new_value );
+	 *     $modifications[] = new \WordPress\HTML\WP_HTML_Text_Replacement( $start, $length, $new_value );
 	 *
 	 *     // Correspondingly, something like this will appear in this array.
 	 *     $lexical_updates = array(
@@ -3493,7 +3493,7 @@ class XMLProcessor {
 		switch ( $this->parser_state ) {
 			case self::STATE_TEXT_NODE:
 			case self::STATE_COMMENT:
-				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+				$this->lexical_updates[] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 					$this->text_starts_at,
 					$this->text_length,
 					// @TODO: Audit this in details. Is this too naive? Or is it actually safe?
@@ -3503,7 +3503,7 @@ class XMLProcessor {
 				return true;
 
 			case self::STATE_CDATA_NODE:
-				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+				$this->lexical_updates[] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 					$this->text_starts_at,
 					$this->text_length,
 					// @TODO: Audit this in details. Is this too naive? Or is it actually safe?
@@ -3600,7 +3600,7 @@ class XMLProcessor {
 			 *     Result: <content id="new"/>
 			 */
 			$existing_attribute             = $this->attributes[ $name ];
-			$this->lexical_updates[ $name ] = new WP_HTML_Text_Replacement(
+			$this->lexical_updates[ $name ] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 				$existing_attribute->start,
 				$existing_attribute->length,
 				$updated_attribute
@@ -3618,7 +3618,7 @@ class XMLProcessor {
 			 *
 			 *     Result: <content id="new"/>
 			 */
-			$this->lexical_updates[ $name ] = new WP_HTML_Text_Replacement(
+			$this->lexical_updates[ $name ] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 				$this->tag_name_starts_at + $this->tag_name_length,
 				0,
 				' ' . $updated_attribute
@@ -3675,7 +3675,7 @@ class XMLProcessor {
 		 *
 		 *    Result: <content />
 		 */
-		$this->lexical_updates[ $name ] = new WP_HTML_Text_Replacement(
+		$this->lexical_updates[ $name ] = new \WordPress\HTML\WP_HTML_Text_Replacement(
 			$this->attributes[ $name ]->start,
 			$this->attributes[ $name ]->length,
 			''
@@ -4476,5 +4476,5 @@ class XMLProcessor {
 	 *
 	 * @access private
 	 */
-	const CONSTRUCTOR_UNLOCK_CODE = 'Use WP_HTML_Processor::create_fragment() instead of calling the class constructor directly.';
+	const CONSTRUCTOR_UNLOCK_CODE = 'Use \WordPress\HTML\WP_HTML_Processor::create_fragment() instead of calling the class constructor directly.';
 }

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,9 @@
             "WordPress\\Zip\\": "components/Zip/",
             "WordPress\\HttpServer\\": "components/HttpServer/",
             "WordPress\\CORSProxy\\": "components/CORSProxy/",
-            "WordPress\\Git\\": "components/Git/"
+            "WordPress\\Git\\": "components/Git/",
+            "WordPress\\HTML\\": "components/HTML/",
+            "WordPress\\BlockParser\\": "components/BlockParser/"
         }
     },
     "scripts": {

--- a/examples/create-wp-site/import-markdown-directory.php
+++ b/examples/create-wp-site/import-markdown-directory.php
@@ -19,6 +19,8 @@ use WordPress\Zip\ZipFilesystem;
 
 use function WordPress\DataLiberation\URL\is_child_url_of;
 use function WordPress\Filesystem\wp_join_unix_paths;
+use function WordPress\Polyfill\add_action;
+use function WordPress\Polyfill\add_filter;
 
 if ( file_exists( '/wordpress/wp-load.php' ) ) {
 	require_once '/wordpress/wp-load.php';

--- a/plugins/static-files-editor/plugin.php
+++ b/plugins/static-files-editor/plugin.php
@@ -1072,7 +1072,7 @@ class WP_Static_Files_Editor_Plugin {
 				break;
 			case 'html':
 				$converter = new AnnotatedBlockMarkupConsumer(
-					WP_HTML_Processor::create_fragment( $content )
+					\WordPress\HTML\WP_HTML_Processor::create_fragment( $content )
 				);
 				break;
 			case 'md':


### PR DESCRIPTION
This PR is an alternative to https://github.com/WordPress/php-toolkit/pull/133 that doesn't require calling `polyfill_wordpress_apis()`.

`php-toolkit` relies on WordPress APIs, such as `apply_filters()`. Sometimes they're missing, e.g. in PHPUnit runtime, and they're implicitly polyfilled when including `vendor/autoload.php`:

```php
if ( ! class_exists( 'WP_Exception' ) ) {
	class WP_Exception extends Exception {
	}
}
```

This polyfilling technique assumes the library is either:

* Loaded inside a WordPress plugin, where WP_Exception is already available
* Loaded outside of WordPress, where there's no WP_Exception class

However, it does not account an important third scenario that [WooCommerce ran into](https://github.com/woocommerce/woocommerce/actions/runs/16489847925/job/46621900586?pr=59851):

* Loaded in a WordPress runtime, but before `wp-load.php` is included

## Solution

This PR adds a `WordPress\\` namespace to all the polyfills. The `php-toolkit` code then refers to the namespaced code.

### Rationale

At the time of `require "vendor/autoload.php"`, we don't know what the developer is going to do next. Maybe they'll include `wp-load.php`, in which case we must not load the polyfills. Or maybe then won't include `wp-load.php`, in which case we must load the polyfills. Exposing an explicit `polyfill_wordpress_apis()` function lets them decide.

The one downside is: `php-toolkit` will use the polyfills instead of WordPress core code paths even when running as a WordPress plugin. We could counteract that with:

```php
<?php

namespace WordPress\\HTML;

if(class_exists('WP_HTML_Processor')) {
    class WP_HTML_Processor extends \WP_HTML_Processor {}
} else {
    class WP_HTML_Processor { /* ...full polyfill */ }
}
```

## Testing plan

Confirm the CI tests pass – many `php-toolkit` PHPUnit tests rely on WordPress polyfills and won't work if `polyfill_wordpress_apis()` is not called or is incomplete.
