### PR TITLE
Fix line ending setup in `.gitattributes` to correctly detect text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,7 @@
 #
 # Let's make sure we use LF (\n) as the line ending in all test files
 # for consistent outcomes across different operating systems.
-**/Tests/**/* text eol=lf
+**/Tests/**/* text=auto eol=lf
 /examples export-ignore
 /plugins export-ignore
 /.github export-ignore


### PR DESCRIPTION
Before this change, `.bin` and `.zip` files always seemed to report unstaged changes.