### PR TITLE
[XML] Remove dependency on HTML API

### DIFF
--- a/components/Encoding/composer.json
+++ b/components/Encoding/composer.json
@@ -17,7 +17,8 @@
 	},
 	"autoload": {
 		"files": [
-			"utf8_decoder.php"
+			"utf8_decoder.php",
+			"utf8_encoder.php"
 		],
 		"exclude-from-classmap": [
 			"/Tests/"

--- a/components/Encoding/utf8_encoder.php
+++ b/components/Encoding/utf8_encoder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace WordPress\Encoding;
+
+/**
+ * UTF-8 encoding pipeline by Dennis Snell (@dmsnell).
+ *
+ * It enables parsing XML documents with incomplete UTF-8 byte sequences
+ * without crashing or depending on the mbstring extension.
+ */
+
+/**
+ * Encode a code point number into the UTF-8 encoding.
+ *
+ * This encoder implements the UTF-8 encoding algorithm for converting
+ * a code point into a byte sequence. If it receives an invalid code
+ * point it will return the Unicode Replacement Character U+FFFD `�`.
+ *
+ * Example:
+ *
+ *     '🅰' === WP_HTML_Decoder::code_point_to_utf8_bytes( 0x1f170 );
+ *
+ *     // Half of a surrogate pair is an invalid code point.
+ *     '�' === WP_HTML_Decoder::code_point_to_utf8_bytes( 0xd83c );
+ *
+ * @since 6.6.0
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc3629 For the UTF-8 standard.
+ *
+ * @param int $code_point Which code point to convert.
+ * @return string Converted code point, or `�` if invalid.
+ */
+function code_point_to_utf8_bytes( $code_point ) {
+	// Pre-check to ensure a valid code point.
+	if (
+		$code_point <= 0 ||
+		( $code_point >= 0xD800 && $code_point <= 0xDFFF ) ||
+		$code_point > 0x10FFFF
+	) {
+		return '�';
+	}
+
+	if ( $code_point <= 0x7F ) {
+		return chr( $code_point );
+	}
+
+	if ( $code_point <= 0x7FF ) {
+		$byte1 = chr( ( $code_point >> 6 ) | 0xC0 );
+		$byte2 = chr( $code_point & 0x3F | 0x80 );
+
+		return "{$byte1}{$byte2}";
+	}
+
+	if ( $code_point <= 0xFFFF ) {
+		$byte1 = chr( ( $code_point >> 12 ) | 0xE0 );
+		$byte2 = chr( ( $code_point >> 6 ) & 0x3F | 0x80 );
+		$byte3 = chr( $code_point & 0x3F | 0x80 );
+
+		return "{$byte1}{$byte2}{$byte3}";
+	}
+
+	// Any values above U+10FFFF are eliminated above in the pre-check.
+	$byte1 = chr( ( $code_point >> 18 ) | 0xF0 );
+	$byte2 = chr( ( $code_point >> 12 ) & 0x3F | 0x80 );
+	$byte3 = chr( ( $code_point >> 6 ) & 0x3F | 0x80 );
+	$byte4 = chr( $code_point & 0x3F | 0x80 );
+
+	return "{$byte1}{$byte2}{$byte3}{$byte4}";
+}

--- a/components/XML/XMLDecoder.php
+++ b/components/XML/XMLDecoder.php
@@ -2,7 +2,7 @@
 
 namespace WordPress\XML;
 
-use WP_HTML_Decoder;
+use function WordPress\Encoding\code_point_to_utf8_bytes;
 
 /**
  * XML API: WP_XML_Decoder class
@@ -144,7 +144,7 @@ class XMLDecoder {
 			}
 
 			$code_point          = intval( substr( $text, $digits_at, $digit_count ), $base );
-			$character_reference = WP_HTML_Decoder::code_point_to_utf8_bytes( $code_point );
+			$character_reference = code_point_to_utf8_bytes( $code_point );
 			if ( '�' === $character_reference && 0xFFFD !== $code_point ) {
 				/*
 				 * Stop processing if we got an invalid character AND the reference does not

--- a/composer-ci-matrix-tests.json
+++ b/composer-ci-matrix-tests.json
@@ -44,6 +44,7 @@
         "files": [
             "components/DataLiberation/URL/functions.php",
             "components/Encoding/utf8_decoder.php",
+            "components/Encoding/utf8_encoder.php",
             "components/Filesystem/functions.php",
             "components/Zip/functions.php",
             "components/Polyfill/wordpress.php",

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "files": [
             "components/DataLiberation/URL/functions.php",
             "components/Encoding/utf8_decoder.php",
+            "components/Encoding/utf8_encoder.php",
             "components/Filesystem/functions.php",
             "components/Zip/functions.php",
             "components/Polyfill/wordpress.php",


### PR DESCRIPTION
XMLDecoder calls WP_HTML_Decoder::code_point_to_utf8_bytes. This dependency assumes the HTML Decoder is available, which it may not be in the older WordPress versions. This PR extracts the UTF-8 encoder into a standalone function to make the XML API independent of the HTML API.

 ## Testing instructions

CI