### PR TITLE
Fix flaky tests and errors discovered by them

### DIFF
--- a/.github/workflows/phpunit-tests-run.yml
+++ b/.github/workflows/phpunit-tests-run.yml
@@ -68,4 +68,4 @@ jobs:
       - name: Run PHPUnit tests
         # Explicitly use the composer-installed version of phpunit
         # because there have been conflicts with other versions during CI.
-        run: vendor/bin/phpunit --testdox
+        run: vendor/bin/phpunit -c phpunit.xml

--- a/components/ByteStream/ReadStream/BaseByteReadStream.php
+++ b/components/ByteStream/ReadStream/BaseByteReadStream.php
@@ -174,8 +174,7 @@ abstract class BaseByteReadStream implements ByteReadStream {
 
 	public function close_reading(): void {
 		$this->is_read_closed = true;
-		// @TODO: Closing the underlying stream here breaks the tests. Why?
-		// $this->internal_close_reading();
+		$this->internal_close_reading();
 	}
 
 	protected function internal_close_reading(): void {

--- a/components/ByteStream/ReadStream/LimitedByteReadStream.php
+++ b/components/ByteStream/ReadStream/LimitedByteReadStream.php
@@ -40,8 +40,4 @@ class LimitedByteReadStream extends BaseByteReadStream {
 	protected function seek_outside_of_buffer( int $target_offset ): void {
 		$this->upstream->seek( $this->initial_offset + $target_offset );
 	}
-
-	protected function internal_close_reading(): void {
-		$this->upstream->close_reading();
-	}
 }

--- a/components/HttpClient/ByteStream/RequestReadStream.php
+++ b/components/HttpClient/ByteStream/RequestReadStream.php
@@ -205,6 +205,7 @@ class RequestReadStream extends BaseByteReadStream {
 		return (
 			Request::STATE_FINISHED === $this->request->latest_redirect()->state &&
 			! $this->client->has_pending_event( $this->request, Client::EVENT_BODY_CHUNK_AVAILABLE ) &&
+			! $this->client->has_pending_event( $this->request, Client::EVENT_FINISHED ) &&
 			strlen( $this->buffer ) === $this->offset_in_current_buffer
 		);
 	}

--- a/components/HttpClient/ByteStream/SeekableRequestReadStream.php
+++ b/components/HttpClient/ByteStream/SeekableRequestReadStream.php
@@ -105,10 +105,9 @@ class SeekableRequestReadStream implements ByteReadStream {
 	public function consume_all(): string {
 		while ( ! $this->remote->reached_end_of_data() ) {
 			$pulled = $this->remote->pull( BaseByteReadStream::CHUNK_SIZE );
-			if ( 0 === $pulled ) {
-				break;
+			if ( $pulled > 0 ) {
+				$this->cache->append_bytes( $this->remote->consume( $pulled ) );
 			}
-			$this->cache->append_bytes( $this->remote->consume( $pulled ) );
 		}
 		$this->cache->close_writing();
 

--- a/components/HttpClient/ClientState.php
+++ b/components/HttpClient/ClientState.php
@@ -178,6 +178,7 @@ class ClientState {
 		$connection = $this->connections[ $request->id ];
 		if (
 			$request->state === Request::STATE_RECEIVING_BODY ||
+			$request->state === Request::STATE_RECEIVED ||
 			$request->state === Request::STATE_FINISHED
 		) {
 			return $connection->consume_buffer();

--- a/components/HttpClient/Connection.php
+++ b/components/HttpClient/Connection.php
@@ -25,6 +25,9 @@ class Connection {
 	}
 
 	public function time_elapsed_ms() {
-		return (microtime( true ) - $this->started_at) * 1000;
+		if ( null === $this->started_at ) {
+			return 0;
+		}
+		return ( microtime( true ) - $this->started_at ) * 1000;
 	}
 }

--- a/components/HttpClient/Middleware/CacheMiddleware.php
+++ b/components/HttpClient/Middleware/CacheMiddleware.php
@@ -61,13 +61,15 @@ final class CacheMiddleware implements MiddlewareInterface {
 
 	public function await_next_event( $requests_ids ): bool {
 		/* serve cached replay first */
-		foreach ( $this->replay as $id => $context ) {
-			if ( $context['done'] ) {
-				fclose( $context['file'] );
-				unset( $this->replay[ $id ] );
-				continue;
-			}
+		$id = array_keys( $this->replay )[0] ?? null;
+		if ( null !== $id ) {
 			$this->fromCache( $id );
+
+			// When done, close the file handle and clean up the replay entry.
+			if ( $this->replay[ $id ]['done'] ) {
+				fclose( $this->replay[ $id ]['file'] );
+				unset( $this->replay[ $id ] );
+			}
 			return true;
 		}
 		
@@ -413,9 +415,18 @@ final class CacheMiddleware implements MiddlewareInterface {
 		if ( $fp = @fopen( $metaFile, 'c' ) ) {
 			flock( $fp, LOCK_EX );
 		}
+
 		// Delete cache files if they exist
 		@unlink( $bodyFile );
+		if ( 'Windows' === PHP_OS_FAMILY && PHP_VERSION_ID < 70300 && isset( $fp ) && $fp ) {
+			// On Windows, PHP 7.2 or earlier can't "unlink()" files with handles in use.
+			// In that case, we need to first release the lock, and then unlink the file.
+			flock( $fp, LOCK_UN );
+			fclose( $fp );
+			unset( $fp );
+		}
 		@unlink( $metaFile );
+
 		// Also remove any temp files for this entry
 		foreach ( glob( $bodyFile . '.tmp*' ) as $tmp ) {
 			@unlink( $tmp );

--- a/components/HttpClient/Middleware/HttpMiddleware.php
+++ b/components/HttpClient/Middleware/HttpMiddleware.php
@@ -112,11 +112,9 @@ class HttpMiddleware implements MiddlewareInterface {
 		$this->state->request             = null;
 		$this->state->response_body_chunk = null;
 
+		// Give the requests an opportunity to time out; 10% more, but at least 300ms.
+		$timeout_ms = $this->state->request_timeout_ms + max( 300, $this->state->request_timeout_ms * 0.1 );
 		$start_time = microtime( true );
-		$timeout_ms = isset( $query['timeout_ms'] )
-			? $query['timeout_ms']
-			// Give the requests an opportunity to time out
-			: $this->state->request_timeout_ms * 1.1;
 
 		do {
 			foreach ( $requests_ids as $request_id ) {

--- a/components/HttpClient/Tests/SeekableRequestReadStreamTest.php
+++ b/components/HttpClient/Tests/SeekableRequestReadStreamTest.php
@@ -3,6 +3,7 @@
 namespace WordPress\HttpClient\Tests;
 
 use PHPUnit\Framework\TestCase;
+use WordPress\ByteStream\ByteStreamException;
 use WordPress\HttpClient\ByteStream\SeekableRequestReadStream;
 use WordPress\HttpClient\Request;
 
@@ -85,9 +86,12 @@ class SeekableRequestReadStreamTest extends TestCase {
 	public function testCloseReading() {
 		$this->withServer(function($url) {
 			$stream = $this->createStream($url);
-			$stream->pull( 10 );
+			// At the moment, cancelling "RequestReadStream" is not implemented.
+			// Therefore, we won't pull any data and will expect an exception.
+			// $stream->pull( 10 );
+			$this->expectException( ByteStreamException::class );
+			$this->expectExceptionMessage( 'Cancelling the request is not implemented yet' );
 			$stream->close_reading();
-			$this->expectNotToPerformAssertions(); // No exception means pass
 		});
 	}
 }

--- a/components/HttpClient/Tests/SocketTransportTest.php
+++ b/components/HttpClient/Tests/SocketTransportTest.php
@@ -131,7 +131,7 @@ class SocketTransportTest extends ClientTestBase {
             $client->enqueue( $request );
 
             $error_occurred = false;
-            while ( $client->await_next_event( [ 'requests' => [ $request ], 'timeout_ms' => 2000 ] ) ) {
+            while ( $client->await_next_event( [ 'requests' => [ $request ] ] ) ) {
                 switch ( $client->get_event() ) {
                     case Client::EVENT_FAILED:
                         $error_occurred = true;
@@ -145,21 +145,15 @@ class SocketTransportTest extends ClientTestBase {
     }
 
 	public function errorProvider() {
-		$cases = [
+		return [
 			'Broken Connection' => [ 'broken-connection', ['Connection closed while reading response headers.', 'Request timed out'] ],
 			'Invalid Response' => [ 'invalid-response', 'Malformed HTTP headers received from the server.' ],
 			'Unsupported Encoding' => [ 'unsupported-encoding', 'Unsupported transfer encoding received from the server: unsupported' ],
 			'Incomplete Status Line' => [ 'incomplete-status-line', 'Malformed HTTP headers received from the server.' ],
 			'Early EOF Headers' => [ 'early-eof-headers', ['Connection closed while reading response headers.', 'Request timed out' ]],
+			'Timeout' => [ 'timeout', 'Request timed out' ],
+			'Timeout Read Body' => [ 'timeout-read-body', 'Request timed out' ],
 		];
-
-		// @TODO: Support these tests on PHP < 8.0
-		if(PHP_VERSION_ID >= 80000) {
-			$cases['Timeout'] = [ 'timeout', 'Request timed out' ]; // Client-side timeout
-			// @TODO: Fix this test. It's flaky between OSes and PHP versions.
-			// $cases['Timeout Read Body'] = [ 'timeout-read-body', 'Request timed out' ]; // Timeout during body read
-		}
-		return $cases;
 	}
 
     protected function getClientSpecificErrorMessages(): array {

--- a/components/HttpClient/Transport/SocketTransport.php
+++ b/components/HttpClient/Transport/SocketTransport.php
@@ -249,7 +249,9 @@ class SocketTransport implements TransportInterface {
 	protected function enable_crypto( array $requests ) {
 		foreach ( $this->stream_select( $requests, static::STREAM_SELECT_WRITE ) as $request ) {
 			@stream_set_timeout( $this->state->connections[ $request->id ]->http_socket, 1 );
-			$enabled_crypto = stream_socket_enable_crypto(
+
+			// Use @ to suppress warnings. They're collected by error_get_last().
+			$enabled_crypto = @stream_socket_enable_crypto(
 				$this->state->connections[ $request->id ]->http_socket,
 				true,
 				STREAM_CRYPTO_METHOD_TLS_CLIENT

--- a/components/HttpClient/Transport/SocketTransport.php
+++ b/components/HttpClient/Transport/SocketTransport.php
@@ -55,7 +55,7 @@ class SocketTransport implements TransportInterface {
 		]) as $request ) {
 			$time_elapsed_ms = $this->state->connections[ $request->id ]->time_elapsed_ms();
 			if ( $time_elapsed_ms > $this->state->request_timeout_ms ) {
-				$this->set_error( $request, new HttpError( sprintf( 'Request timed out after %s seconds.', $time_elapsed_ms ) ) );
+				$this->set_error( $request, new HttpError( sprintf( 'Request timed out after %d ms.', (int) $time_elapsed_ms ) ) );
 			}
 		}
 
@@ -156,7 +156,7 @@ class SocketTransport implements TransportInterface {
 				'tcp://' . $host . ':' . $port,
 				$errno,
 				$errstr,
-				$this->state->request_timeout_ms,
+				$this->state->request_timeout_ms / 1000,
 				STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT,
 				$context
 			);

--- a/composer.lock
+++ b/composer.lock
@@ -4,186 +4,33 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "695ade0c60bb0dbd48e82f4ca4eb4b1d",
-    "packages": [
-        {
-            "name": "psr/log",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
-            },
-            "time": "2021-05-03T11:20:27+00:00"
-        },
-        {
-            "name": "wordpress/data-liberation",
-            "version": "dev-main",
-            "dist": {
-                "type": "path",
-                "url": "components/DataLiberation",
-                "reference": "5f6aee276982fc798ca9681a283fca508c1e4032"
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "vendor-patched/"
-                ],
-                "files": [
-                    "URL/functions.php"
-                ],
-                "psr-4": {
-                    "WordPress\\DataLiberation\\": "",
-                    "Rowbot\\": "vendor-patched/",
-                    "Brick\\": "vendor-patched/"
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "authors": [
-                {
-                    "name": "Adam Zielinski",
-                    "email": "adam@adamziel.com"
-                },
-                {
-                    "name": "WordPress Team",
-                    "email": "wordpress@wordpress.org"
-                }
-            ],
-            "description": "Data Liberation component for WordPress.",
-            "transport-options": {
-                "symlink": true,
-                "relative": true
-            }
-        },
-        {
-            "name": "yetanotherape/diff-match-patch",
-            "version": "v1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/yetanotherape/diff-match-patch.git",
-                "reference": "a0c37bc694c27ddccbd4989f72908ce524261bd1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/yetanotherape/diff-match-patch/zipball/a0c37bc694c27ddccbd4989f72908ce524261bd1",
-                "reference": "a0c37bc694c27ddccbd4989f72908ce524261bd1",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "9.*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "DiffMatchPatch\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Daniil Skrobov",
-                    "email": "yetanotherape@gmail.com"
-                },
-                {
-                    "name": "Neil Fraser",
-                    "email": "fraser@google.com",
-                    "homepage": "http://neil.fraser.name/"
-                }
-            ],
-            "description": "Port of the google-diff-match-patch (https://github.com/google/diff-match-patch) lib to PHP",
-            "homepage": "https://github.com/yetanotherape/diff-match-patch",
-            "keywords": [
-                "Fuzzy search",
-                "Match",
-                "diff",
-                "patch"
-            ],
-            "support": {
-                "issues": "https://github.com/yetanotherape/diff-match-patch/issues",
-                "source": "https://github.com/yetanotherape/diff-match-patch/tree/v1.1.1"
-            },
-            "time": "2025-02-16T18:49:39+00:00"
-        }
-    ],
+    "content-hash": "e1a8e75d27e1a13c0c8f38f3acc91f99",
+    "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
+                "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
+                "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "yoast/phpunit-polyfills": "^1.0"
             },
@@ -203,9 +50,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
@@ -213,7 +60,6 @@
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -234,9 +80,28 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -244,12 +109,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f427191c2690b0518194683d900f892ecd72c8a0"
+                "reference": "0daa7cfba7b009aa3c95ae585322fb596a4ca2ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f427191c2690b0518194683d900f892ecd72c8a0",
-                "reference": "f427191c2690b0518194683d900f892ecd72c8a0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0daa7cfba7b009aa3c95ae585322fb596a4ca2ae",
+                "reference": "0daa7cfba7b009aa3c95ae585322fb596a4ca2ae",
                 "shasum": ""
             },
             "require": {
@@ -306,7 +171,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-24T06:55:45+00:00"
+            "time": "2025-08-12T06:30:42+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -314,12 +179,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -359,7 +224,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -367,20 +232,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T12:36:36+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
                 "shasum": ""
             },
             "require": {
@@ -393,13 +258,14 @@
                 "ircmaxell/php-yacc": "^0.0.7",
                 "phpunit/phpunit": "^9.0"
             },
+            "default-branch": true,
             "bin": [
                 "bin/php-parse"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -423,9 +289,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-08-13T20:13:15+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -433,12 +299,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+                "reference": "65f90285728eae4eae313b8b6ba11b2f5436038e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
-                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/65f90285728eae4eae313b8b6ba11b2f5436038e",
+                "reference": "65f90285728eae4eae313b8b6ba11b2f5436038e",
                 "shasum": ""
             },
             "require": {
@@ -485,7 +351,7 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+                "source": "https://github.com/phar-io/manifest/tree/master"
             },
             "funding": [
                 {
@@ -493,7 +359,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:33:53+00:00"
+            "time": "2025-07-05T08:48:25+00:00"
         },
         {
             "name": "phar-io/version",
@@ -552,18 +418,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "9013cd039fe5740953f9fdeebd19d901b80e26f2"
+                "reference": "07f2dc91fcbd35c6b129f1a48032af23b183e176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9013cd039fe5740953f9fdeebd19d901b80e26f2",
-                "reference": "9013cd039fe5740953f9fdeebd19d901b80e26f2",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/07f2dc91fcbd35c6b129f1a48032af23b183e176",
+                "reference": "07f2dc91fcbd35c6b129f1a48032af23b183e176",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.12",
-                "squizlabs/php_codesniffer": "^3.10.0"
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "replace": {
                 "wimg/php-compatibility": "*"
@@ -573,8 +439,8 @@
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.3",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.1.0",
-                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.5.32 || ^11.3.3",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0 || ^3.0"
             },
             "suggest": {
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
@@ -608,7 +474,7 @@
                 }
             ],
             "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
-            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "homepage": "https://techblog.wimgodden.be/tag/codesniffer/",
             "keywords": [
                 "compatibility",
                 "phpcs",
@@ -638,7 +504,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-01-20T20:06:48+00:00"
+            "time": "2025-08-18T06:51:15+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
@@ -646,23 +512,23 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "76fb7328eb76df97d535cb7c52f6169b78c9f1a6"
+                "reference": "0c759085130ebf1cd7e79334fddf203a4e2d1aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/76fb7328eb76df97d535cb7c52f6169b78c9f1a6",
-                "reference": "76fb7328eb76df97d535cb7c52f6169b78c9f1a6",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/0c759085130ebf1cd7e79334fddf203a4e2d1aae",
+                "reference": "0c759085130ebf1cd7e79334fddf203a4e2d1aae",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.13.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
                 "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
@@ -702,6 +568,7 @@
                 "phpcodesniffer-standard",
                 "phpcs",
                 "phpcs3",
+                "phpcs4",
                 "standards",
                 "static analysis",
                 "tokens",
@@ -731,7 +598,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-05-19T13:48:13+00:00"
+            "time": "2025-08-18T15:06:24+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -739,12 +606,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "fea728f03454f7a119d607e318c8e4c058d20294"
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fea728f03454f7a119d607e318c8e4c058d20294",
-                "reference": "fea728f03454f7a119d607e318c8e4c058d20294",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
                 "shasum": ""
             },
             "require": {
@@ -789,7 +656,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-18T21:24:56+00:00"
+            "time": "2025-07-17T17:15:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1116,12 +983,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e3874aa4afb83cb6afa3689f22a300a9d7882e0f"
+                "reference": "87d05338fd7df8665184dacaa17250c75aef77d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e3874aa4afb83cb6afa3689f22a300a9d7882e0f",
-                "reference": "e3874aa4afb83cb6afa3689f22a300a9d7882e0f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/87d05338fd7df8665184dacaa17250c75aef77d5",
+                "reference": "87d05338fd7df8665184dacaa17250c75aef77d5",
                 "shasum": ""
             },
             "require": {
@@ -1132,7 +999,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.1",
+                "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
@@ -1143,11 +1010,11 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.8",
+                "sebastian/comparator": "^4.0.9",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.6",
-                "sebastian/global-state": "^5.0.7",
+                "sebastian/global-state": "^5.0.8",
                 "sebastian/object-enumerator": "^4.0.4",
                 "sebastian/resource-operations": "^3.0.4",
                 "sebastian/type": "^3.2.1",
@@ -1219,7 +1086,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-14T13:32:26+00:00"
+            "time": "2025-08-17T06:07:43+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1394,12 +1261,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "b247957a1c8dc81a671770f74b479c0a78a818f1"
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/b247957a1c8dc81a671770f74b479c0a78a818f1",
-                "reference": "b247957a1c8dc81a671770f74b479c0a78a818f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
                 "shasum": ""
             },
             "require": {
@@ -1452,15 +1319,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:46:14+00:00"
+            "time": "2025-08-10T06:51:50+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1731,12 +1610,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
@@ -1779,15 +1658,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -1964,12 +1855,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
@@ -2011,15 +1902,27 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2191,12 +2094,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "038b4a1e2d86d247e435aafeea9c550e99c7cbb4"
+                "reference": "38a40fdae10862df09ca2d803f12d1366aab3c2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/038b4a1e2d86d247e435aafeea9c550e99c7cbb4",
-                "reference": "038b4a1e2d86d247e435aafeea9c550e99c7cbb4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/38a40fdae10862df09ca2d803f12d1366aab3c2c",
+                "reference": "38a40fdae10862df09ca2d803f12d1366aab3c2c",
                 "shasum": ""
             },
             "require": {
@@ -2268,7 +2171,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-05-19T16:07:24+00:00"
+            "time": "2025-08-18T15:57:20+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2444,6 +2347,6 @@
         "ext-json": "*",
         "ext-mbstring": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
#### 1. Fix `WordPress\ByteStream\ByteStreamException: Cannot seek to a negative offset`
This error seemed to occur in some scenarios when the `RequestReadStream` finished reading data without correctly reaching the end of data, leaving a `FINISHED` event unprocessed. This caused no data length to be set for requests without the `Content-Length` header, because this logic is in the `FINISHED` even handler.

I fixed it to make sure the remote stream is always consumed until the end of data.

Locally on macOS, it happens rarely. To reproduce it, I used the command below:
```bash
while php ./vendor/bin/phpunit -c phpunit.xml --filter testReadRemoteZip components/Zip/Tests/ZipFilesystemTest.php; do :; done
```
After up to a few dozen iterations, the error appears.

#### 2. Fix `stream_socket_enable_crypto(): SSL operation failed with code 1.`
The full error message is:
```bash
stream_socket_enable_crypto(): SSL operation failed with code 1. OpenSSL Error messages:
error:0A0000C6:SSL routines::packet length too long
error:0A000139:SSL routines::record layer failure
```

This is a warning [emitted by `stream_socket_enable_crypto()`](https://github.com/WordPress/php-toolkit/blob/9b032ae571e68264efc0ce09a144185d755d0869/components/HttpClient/Transport/SocketTransport.php#L252) that is then converted by PHPUnit to a `PHPUnit\Framework\Error\Warning` error.

Again, it only happens sometimes, and it is a mystery to me why. Here's a way to reproduce it on `macOS`:
```bash
while php ./vendor/bin/phpunit -c phpunit.xml --filter test_ssl_handshake_failure components/HttpClient/Tests/SocketTransportTest.php; do :; done
```
After up to a few dozen iterations, the error appears.

#### 3. Fix `HttpMiddleware` timeout sometimes cutting off `SocketTransport` timeout
It seems that `WordPress\HttpClient\Transport\SocketTransport` sometimes times out a bit later than the implementation of `WordPress\HttpClient\Middleware\HttpMiddleware` was expecting, which was causing some flaky tests. Adding a minimum of 300ms extra time in `HttpMiddleware` seems to solve the issue.

Here's a way to reproduce it on `macOS`:
```bash
while php ./vendor/bin/phpunit -c phpunit.xml --filter test_errors components/HttpClient/Tests/SocketTransportTest.php; do :; done
```
After up to a few dozen iterations, the error appears. It also helps to comment out [all other data provider cases](https://github.com/WordPress/php-toolkit/blob/9b032ae571e68264efc0ce09a144185d755d0869/components/HttpClient/Tests/SocketTransportTest.php#L148-L154) and decrease the [client timeout](https://github.com/WordPress/php-toolkit/blob/9b032ae571e68264efc0ce09a144185d755d0869/components/HttpClient/Tests/SocketTransportTest.php#L129), which makes it more flaky (10% extra time of a smaller number means a smaller margin).

#### 4. `SocketTransportTest::test_redirect_chain`
The error message in the tests was the following:
```
1) WordPress\HttpClient\Tests\SocketTransportTest::test_redirect_chain
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Redirect 2'
+''
```

It appears that sometimes, when a request was transitioning through the `STATE_RECEIVED` state, the buffered body could be lost in `ClientState:: consume_buffered_response_body()`. Adding the state to a condition in that method seems to have resolved the issue. I wonder if any more states need to be added there, or if now the list is complete.

#### 5. Fix cache invalidation on Windows with PHP <= 7.2

The `WordPress\HttpClient\Tests\CacheMiddlewareIntegrationTest` was failing on Windows with PHP 7.2 with the following errors:

```
1) WordPress\HttpClient\Tests\CacheMiddlewareIntegrationTest::test_post_invalidates_cache
Failed asserting that an array is empty.

D:\a\php-toolkit\php-toolkit\components\HttpClient\Tests\CacheMiddlewareIntegrationTest.php:271
D:\a\php-toolkit\php-toolkit\components\HttpClient\Tests\WithServerTrait.php:31
D:\a\php-toolkit\php-toolkit\components\HttpClient\Tests\CacheMiddlewareIntegrationTest.php:272
phpvfscomposer://D:\a\php-toolkit\php-toolkit\vendor\phpunit\phpunit\phpunit:97

2) WordPress\HttpClient\Tests\CacheMiddlewareTest::test_non_cacheable_methods_invalidate_cache
Failed asserting that an array is empty.

D:\a\php-toolkit\php-toolkit\components\HttpClient\Tests\CacheMiddlewareTest.php:69
phpvfscomposer://D:\a\php-toolkit\php-toolkit\vendor\phpunit\phpunit\phpunit:97
```

As it turns out, before PHP 7.3 it was not possible to `unlink()` a file with handles in use. I added a condition to address that.

#### 6. Tests failing when calling `$this->internal_close_reading();` in `BaseByteReadStream`
When debugging the test failures, I noticed the following snippet in `BaseByteReadStream`:
```php
public function close_reading(): void {
	$this->is_read_closed = true;
	// @TODO: Closing the underlying stream here breaks the tests. Why?
	// $this->internal_close_reading();
	$this->internal_close_reading();
}
```

I uncommented the line and encountered two failures:

1. In `ZipFilesystemTest::testReadFile` I got `TypeError: fseek(): Argument #1 ($stream) must be of type resource, null given`. This happened because `LimitedByteReadStream.php` was calling `$this->upstream->close_reading();`. Looking at other similar stream classes, it seemed to me that this should in fact not be called, as the class doesn't initialize the upstream. In other cases, we also don't call `close_reading()` on the upstream. I hope that's the correct fix.
2. In `SeekableRequestReadStreamTest::testCloseReading`, I was sometimes getting `ByteStreamException: Cancelling the request is not implemented yet`. I think this is expected, so I made the test expect the error and made the exception to always appear.