### PR TITLE
XMLProcessor and ByteStream improvements for wordpress-importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# Repository Archived
-
-The development continues in https://github.com/WordPress/php-toolkit
-
----
-
 ## PHP Toolkit
 
 Standalone PHP libraries for use in WordPress plugins and standalone PHP projects:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Repository Archived
+
+The development continues in https://github.com/WordPress/php-toolkit
+
+--
+
 ## PHP Toolkit
 
 Standalone PHP libraries for use in WordPress plugins and standalone PHP projects:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The development continues in https://github.com/WordPress/php-toolkit
 
---
+---
 
 ## PHP Toolkit
 

--- a/components/Blueprints/DataReference/DataReferenceResolver.php
+++ b/components/Blueprints/DataReference/DataReferenceResolver.php
@@ -111,7 +111,7 @@ class DataReferenceResolver {
 					 *
 					 * @TODO: Support ZIPs >= 100MB.
 					 */
-					'buffer_size'      => 100 * 1024 * 1024,
+					'max_lookbehind_bytes'      => 100 * 1024 * 1024,
 					'progress_tracker' => $progress_tracker,
 					'eagerly_enqueue'  => true,
 				)

--- a/components/Blueprints/Steps/SetSiteLanguageStep.php
+++ b/components/Blueprints/Steps/SetSiteLanguageStep.php
@@ -171,7 +171,7 @@ class SetSiteLanguageStep implements StepInterface {
 				// @see Runtime for more details on these options
 				'progress_tracker' => $progress[ $k ],
 				'eagerly_enqueue'  => true,
-				'buffer_size'      => 100 * 1024 * 1024,
+				'max_lookbehind_bytes'      => 100 * 1024 * 1024,
 			] );
 		}
 

--- a/components/ByteStream/MemoryPipe.php
+++ b/components/ByteStream/MemoryPipe.php
@@ -20,7 +20,7 @@ class MemoryPipe extends BaseByteReadStream implements ByteWriteStream {
 			// to clean up old data as we stream it.
 			// If we did clean up old data, we would lose the ability to seek() to
 			// the beginning of the buffer.
-			$this->buffer_size = PHP_INT_MAX;
+			$this->max_lookbehind_bytes = PHP_INT_MAX;
 		} elseif ( null !== $expected_length ) {
 			$this->expected_length = $expected_length;
 		}

--- a/components/ByteStream/ReadStream/BaseByteReadStream.php
+++ b/components/ByteStream/ReadStream/BaseByteReadStream.php
@@ -7,7 +7,7 @@ use WordPress\ByteStream\NotEnoughDataException;
 
 abstract class BaseByteReadStream implements ByteReadStream {
 
-	const CHUNK_SIZE = 64 * 1024;
+	const CHUNK_SIZE_BYTES = 64 * 1024; // 64kb
 
 	protected $buffer_size = 2048;
 
@@ -21,7 +21,7 @@ abstract class BaseByteReadStream implements ByteReadStream {
 		return $this->expected_length;
 	}
 
-	public function pull( $n = self::CHUNK_SIZE, $mode = self::PULL_NO_MORE_THAN ): int {
+	public function pull( $n = self::CHUNK_SIZE_BYTES, $mode = self::PULL_NO_MORE_THAN ): int {
 		switch ( $mode ) {
 			case self::PULL_NO_MORE_THAN:
 			case self::PULL_EXACTLY:
@@ -83,7 +83,7 @@ abstract class BaseByteReadStream implements ByteReadStream {
 	}
 
 	protected function pull_no_more_than( $n ): int {
-		$this->buffer .= $this->internal_pull( self::CHUNK_SIZE );
+		$this->buffer .= $this->internal_pull( self::CHUNK_SIZE_BYTES );
 
 		return min( $n, $this->count_consumable_bytes() );
 	}
@@ -94,7 +94,7 @@ abstract class BaseByteReadStream implements ByteReadStream {
 			if ( $this->reached_end_of_data() ) {
 				return $body;
 			}
-			$consumable = $this->pull( self::CHUNK_SIZE );
+			$consumable = $this->pull( self::CHUNK_SIZE_BYTES );
 			$body       .= $this->consume( $consumable );
 		}
 	}

--- a/components/ByteStream/ReadStream/BaseByteReadStream.php
+++ b/components/ByteStream/ReadStream/BaseByteReadStream.php
@@ -9,12 +9,49 @@ abstract class BaseByteReadStream implements ByteReadStream {
 
 	const CHUNK_SIZE_BYTES = 64 * 1024; // 64kb
 
-	protected $buffer_size = 2048;
+	/**
+	 * The maximum number of consumed bytes to keep in memory.
+	 *
+	 * For example:
+	 * 
+	 *     The quick brown fox jumps over the lazy dog.
+	 *     ^-------------------^
+	 *         consumed bytes
+	 * 
+	 * Say the maximum lookbehind bytes is 4. Then the byte stream will forget about
+	 * all consumed bytes except the last 4:
+	 * 
+	 *     fox jumps over the lazy dog.
+	 *     ^--^
+	 *       consumed but retained for seek()-ing backwards.
+	 */
+	protected $max_lookbehind_bytes = 2048;
 
+	/**
+	 * The remaining unconsumed bytes.
+	 */
 	protected $buffer = '';
+
+	/**
+	 * How many bytes have already been consumed in the current **buffer**.
+	 */
 	protected $offset_in_current_buffer = 0;
+
+	/**
+	 * How many bytes have already been forgotten in the current **stream**.
+	 */
 	protected $bytes_already_forgotten = 0;
+
+	/**
+	 * Whether the stream has been closed for reading.
+	 */
 	protected $is_read_closed = false;
+
+	/**
+	 * How many bytes are expected in the stream. Optional.
+	 *
+	 * When it's null, the stream is unbounded and length() will also return null.
+	 */
 	protected $expected_length = null;
 
 	public function length(): ?int {
@@ -115,8 +152,8 @@ abstract class BaseByteReadStream implements ByteReadStream {
 		}
 		$bytes                          = substr( $this->buffer, $this->offset_in_current_buffer, $n );
 		$this->offset_in_current_buffer += $n;
-		if ( $this->offset_in_current_buffer > $this->buffer_size ) {
-			$overflow                       = $this->offset_in_current_buffer - $this->buffer_size;
+		if ( $this->offset_in_current_buffer > $this->max_lookbehind_bytes ) {
+			$overflow                       = $this->offset_in_current_buffer - $this->max_lookbehind_bytes;
 			$this->offset_in_current_buffer -= $overflow;
 			$this->bytes_already_forgotten  += $overflow;
 			$this->buffer                   = substr( $this->buffer, $overflow );

--- a/components/ByteStream/ReadStream/BaseByteReadStream.php
+++ b/components/ByteStream/ReadStream/BaseByteReadStream.php
@@ -94,7 +94,7 @@ abstract class BaseByteReadStream implements ByteReadStream {
 			if ( $this->reached_end_of_data() ) {
 				return $body;
 			}
-			$consumable = $this->pull( 64 * 1024 );
+			$consumable = $this->pull( self::CHUNK_SIZE );
 			$body       .= $this->consume( $consumable );
 		}
 	}

--- a/components/ByteStream/Tests/FileReadWriteStreamTest.php
+++ b/components/ByteStream/Tests/FileReadWriteStreamTest.php
@@ -106,7 +106,7 @@ class FileReadWriteStreamTest extends TestCase {
 		$stream->seek( 0 );
 		$stream->pull( 3000, FileReadWriteStream::PULL_EXACTLY );
 		$stream->consume( 3000 );
-		// After consuming, buffer should be trimmed to buffer_size (2048)
+		// After consuming, buffer should be trimmed to max_lookbehind_bytes (2048)
 		$reflection = new ReflectionClass( $stream );
 		$bufferProp = $reflection->getProperty( 'buffer' );
 		$bufferProp->setAccessible( true );

--- a/components/HttpClient/ByteStream/RequestReadStream.php
+++ b/components/HttpClient/ByteStream/RequestReadStream.php
@@ -45,8 +45,8 @@ class RequestReadStream extends BaseByteReadStream {
 		}
 		$this->client  = $options['client'] ?? new Client();
 		$this->request = $request;
-		if ( isset( $options['buffer_size'] ) ) {
-			$this->buffer_size = $options['buffer_size'];
+		if ( isset( $options['max_lookbehind_bytes'] ) ) {
+			$this->max_lookbehind_bytes = $options['max_lookbehind_bytes'];
 		}
 		if ( isset( $options['progress_tracker'] ) ) {
 			$this->progress_tracker = $options['progress_tracker'];

--- a/components/HttpClient/ByteStream/SeekableRequestReadStream.php
+++ b/components/HttpClient/ByteStream/SeekableRequestReadStream.php
@@ -33,7 +33,7 @@ class SeekableRequestReadStream implements ByteReadStream {
 
 	private function pipe_until( int $offset ): void {
 		while ( $this->cache->length() === null || $this->cache->length() < $offset ) {
-			$pulled = $this->remote->pull( BaseByteReadStream::CHUNK_SIZE );
+			$pulled = $this->remote->pull( BaseByteReadStream::CHUNK_SIZE_BYTES );
 			if ( 0 === $pulled ) {
 				break;
 			}
@@ -104,7 +104,7 @@ class SeekableRequestReadStream implements ByteReadStream {
 
 	public function consume_all(): string {
 		while ( ! $this->remote->reached_end_of_data() ) {
-			$pulled = $this->remote->pull( BaseByteReadStream::CHUNK_SIZE );
+			$pulled = $this->remote->pull( BaseByteReadStream::CHUNK_SIZE_BYTES );
 			if ( $pulled > 0 ) {
 				$this->cache->append_bytes( $this->remote->consume( $pulled ) );
 			}

--- a/components/XML/Tests/XMLProcessorTest.php
+++ b/components/XML/Tests/XMLProcessorTest.php
@@ -545,33 +545,6 @@ class XMLProcessorTest extends TestCase {
 		$this->assertSame( '<wp:content wonky="true" xmlns:wp="w.org"><photo hidden></wp:content>', $processor->get_updated_xml() );
 	}
 
-	public function test_declare_element_as_pcdata() {
-		$text      = '
-			This text contains syntax that may seem
-			like XML nodes:
-
-			<input />
-			</seemingly invalid element --/>
-			<!-- is this a comment? -->
-			<?xml version="1.0" ?>
-
-			&amp;&lt;&gt;&quot;&apos;
-
-			But! It is all treated as text.
-		';
-		$processor = XMLProcessor::create_from_string(
-			"<root xmlns:wp=\"w.org\"><my-pcdata>$text</my-pcdata></root>"
-		);
-		$processor->declare_element_as_pcdata( 'my-pcdata' );
-		$processor->next_tag( 'my-pcdata' );
-
-		$this->assertEquals(
-			$text,
-			$processor->get_modifiable_text(),
-			'get_modifiable_text() did not return the expected text'
-		);
-	}
-
 	/**
 	 * Ensures that bookmarks start and length correctly describe a given token in XML.
 	 *

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -41,19 +41,6 @@ use function WordPress\Encoding\utf8_codepoint_at;
  *        * <!NOTATION, see https://www.w3.org/TR/xml/#sec-entity-decl
  *        * Conditional sections, see https://www.w3.org/TR/xml/#sec-condition-sect
  *
- * @TODO Explore declaring elements as PCdata directly in the XML document,
- *       for example as follows:
- *
- *       <!ELEMENT p (#PCDATA|emph)* >
- *
- *       or
- *
- *       <!DOCTYPE test [
- *           <!ELEMENT test (#PCDATA) >
- *           <!ENTITY % xx '&#37;zz;'>
- *           <!ENTITY % zz '&#60;!ENTITY tricky "error-prone" >' >
- *           %xx;
- *       ]>
  *
  * @TODO: Support XML 1.1.
  *
@@ -186,19 +173,6 @@ use function WordPress\Encoding\utf8_codepoint_at;
  *     $processor = XMLProcessor::create_from_string( '<style>// this is everything</style><content>' );
  *     true === $processor->next_tag( 'content' );
  *
- * #### Special elements
- *
- * All XML elements are handled in the same way, except when you mark
- * them as PCData elements. These are special because their contents
- * are treated as text, even if it looks like XML tags.
- *
- * Example:
- *
- *    $processor = XMLProcessor::create_from_string( '<root><post-content>Text inside</input></post-content></root>' );
- *    $processor->declare_element_as_pcdata('post-content');
- *    $processor->next_tag('post-content');
- *    $processor->next_token();
- *    echo $processor->get_modifiable_text(); // Text inside</input>
  *
  * ### Modifying XML attributes for a found tag
  *
@@ -1266,14 +1240,6 @@ class XMLProcessor {
 		}
 
 		/*
-		 * If we are in a PCData element, everything until the closer
-		 * is considered text.
-		 */
-		if ( ! $this->is_pcdata_element() ) {
-			return true;
-		}
-
-		/*
 		 * Preserve the opening tag pointers, as these will be overwritten
 		 * when finding the closing tag. They will be reset after finding
 		 * the closing to tag to point to the opening of the special atomic
@@ -1283,16 +1249,6 @@ class XMLProcessor {
 		$tag_name_length    = $this->tag_name_length;
 		$tag_ends_at        = $this->token_starts_at + $this->token_length;
 		$attributes         = $this->qualified_attributes;
-
-		$found_closer = $this->skip_pcdata( $this->get_tag_local_name() );
-
-		// Closer not found, the document is incomplete.
-		if ( false === $found_closer ) {
-			$this->mark_incomplete_input( 'Closing tag missing.' );
-			$this->bytes_already_parsed = $was_at;
-
-			return false;
-		}
 
 		/*
 		 * The values here look like they reference the opening tag but they reference
@@ -1531,55 +1487,6 @@ class XMLProcessor {
 	}
 
 	/**
-	 * Skips contents of PCDATA element.
-	 *
-	 * @param  string  $tag_name  The tag name which will close the PCDATA region.
-	 *
-	 * @return false|int Byte offset of the closing tag, or false if not found.
-	 * @since WP_VERSION
-	 *
-	 * @see https://www.w3.org/TR/xml/#sec-mixed-content
-	 *
-	 */
-	private function skip_pcdata( $tag_name ) {
-		$xml        = $this->xml;
-		$doc_length = strlen( $xml );
-		$tag_length = strlen( $tag_name );
-
-		$at = $this->bytes_already_parsed;
-		while ( false !== $at && $at < $doc_length ) {
-			$at                       = strpos( $this->xml, '</' . $tag_name, $at );
-			$this->tag_name_starts_at = $at;
-
-			// Fail if there is no possible tag closer.
-			if ( false === $at ) {
-				return false;
-			}
-
-			$at                        += 2 + $tag_length;
-			$at                        += strspn( $this->xml, " \t\f\r\n", $at );
-			$this->bytes_already_parsed = $at;
-
-			/*
-			 * Ensure that the tag name terminates to avoid matching on
-			 * substrings of a longer tag name. For example, the sequence
-			 * "</contentrug" should not match for "</content" even
-			 * though "content" is found within the text.
-			 */
-			if ( $at >= strlen( $xml ) ) {
-				return false;
-			}
-			if ( '>' === $xml[ $at ] ) {
-				$this->bytes_already_parsed = $at + 1;
-
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Returns the last error, if any.
 	 *
 	 * Various situations lead to parsing failure but this class will
@@ -1605,94 +1512,6 @@ class XMLProcessor {
 	public function get_last_error(): ?string {
 		return $this->last_error;
 	}
-
-	/**
-	 * Tag names declared as PCDATA elements.
-	 *
-	 * PCDATA elements are elements in which everything is treated as
-	 * text, even syntax that may look like other elements, closers,
-	 * processing instructions, etc.
-	 *
-	 * Example:
-	 *
-	 *     <root>
-	 *         <my-pcdata>
-	 *             This text contains syntax that seems
-	 *             like XML nodes:
-	 *
-	 *             <input />
-	 *             </seemingly invalid element --/>
-	 *             <!-- is this a comment? -->
-	 *             <?xml version="1.0" ?>
-	 *
-	 *             &amp;&lt;&gt;&quot;&apos;
-	 *
-	 *             But! It's all treated as text.
-	 *         </my-pcdata>
-	 *    </root>
-	 *
-	 * @var array
-	 */
-	private $pcdata_elements = array();
-
-	/**
-	 * Declares an element as PCDATA.
-	 *
-	 * PCDATA elements are elements in which everything is treated as
-	 * text, even syntax that may look like other elements, closers,
-	 * processing instructions, etc.
-	 *
-	 * For example:
-	 *
-	 *      $processor = new XMLProcessor(
-	 *      <<<XML
-	 *          <root>
-	 *              <my-pcdata>
-	 *                  This text uses syntax that may seem
-	 *                  like XML nodes:
-	 *
-	 *                  <input />
-	 *                  </seemingly invalid element --/>
-	 *                  <!-- is this a comment? -->
-	 *                  <?xml version="1.0" ?>
-	 *
-	 *                  &amp;&lt;&gt;&quot;&apos;
-	 *
-	 *                  But! It's all treated as text.
-	 *              </my-pcdata>
-	 *         </root>
-	 *      XML
-	 *      );
-	 *
-	 *      $processor->declare_element_as_pcdata('my-pcdata');
-	 *      $processor->next_tag('my-pcdata');
-	 *      $processor->next_token();
-	 *
-	 *      // Returns everything inside the <my-pcdata>
-	 *      // element as text:
-	 *      $processor->get_modifiable_text();
-	 *
-	 * @param  string  $element_name  The name of the element to declare as PCDATA.
-	 *
-	 * @TODO: Reconsider whether this method is needed.
-	 *
-	 * @return void
-	 */
-	public function declare_element_as_pcdata( $element_name ) {
-		$this->pcdata_elements[ $element_name ] = true;
-	}
-
-	/**
-	 * Indicates if the currently matched tag is a PCDATA element.
-	 *
-	 * @return bool Whether the currently matched tag is a PCDATA element.
-	 * @since WP_VERSION
-	 *
-	 */
-	public function is_pcdata_element() {
-		return array_key_exists( $this->get_tag_local_name(), $this->pcdata_elements );
-	}
-
 
 	/**
 	 * Finds the next element matching the $query.
@@ -3451,8 +3270,6 @@ class XMLProcessor {
 	 * changing the XML structure of the document around it. This includes
 	 * the contents of `#text` and `#cdata-section` nodes in the XML as well
 	 * as the inner contents of XML comments, Processing Instructions, and others.
-	 * They also contain of PCdata tags any other section in an XML document which
-	 * cannot contain XML markup (DATA).
 	 *
 	 * If a token has no modifiable text then an empty string is returned to
 	 * avoid needless crashing or type errors. An empty string does not mean
@@ -3480,11 +3297,10 @@ class XMLProcessor {
 		 */
 		$text = str_replace( array( "\r\n", "\r" ), "\n", $text );
 
-		// Comment data, CDATA sections, and PCData tags contents are not decoded any further.
+		// Comment data and CDATA sections contents are not decoded any further.
 		if (
 			self::STATE_CDATA_NODE === $this->parser_state ||
-			self::STATE_COMMENT === $this->parser_state ||
-			$this->is_pcdata_element()
+			self::STATE_COMMENT === $this->parser_state
 		) {
 			return $text;
 		}
@@ -3518,8 +3334,6 @@ class XMLProcessor {
 	 * changing the XML structure of the document around it. This includes
 	 * the contents of `#text` and `#cdata-section` nodes in the XML as well
 	 * as the inner contents of XML comments, Processing Instructions, and others.
-	 * They also contain of PCdata tags any other section in an XML document which
-	 * cannot contain XML markup (DATA).
 	 *
 	 * If a token has no modifiable text then false is returned to avoid needless
 	 * crashing or type errors.

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -342,6 +342,31 @@ use function WordPress\Encoding\utf8_codepoint_at;
  *
  * The XMLProcessor assumes that the input XML document is encoded with a
  * UTF-8 encoding and will refuse to process documents that declare other encodings.
+ * 
+ * ### Namespaces
+ *
+ * Namespaces are first-class citizens in the XMLProcessor. Methods such as `set_attribute()` and `remove_attribute()`
+ * require the full namespace URI, not just the local name. The XML specification treats the local
+ * name as a mere syntax sugar. The actual matching is always done on the fully qualified namespace name.
+ *
+ * Example:
+ *
+ *     $processor = XMLProcessor::from_string( '<root xmlns:wp="http://wordpress.org/export/1.2/"><wp:image src="cat.jpg" /></root>' );
+ *     $processor->next_tag( 'image' );
+ *     $local_name = $processor->get_tag_local_name(); // 'image'
+ *     $ns = $processor->get_tag_namespace(); // 'http://wordpress.org/export/1.2/'
+ *     echo $processor->get_tag_namespace_and_local_name(); // '{http://wordpress.org/export/1.2/}image'
+ *
+ * #### Internal representation of names
+ *
+ * Internally, the XMLProcessor stores names using the following format:
+ * 
+ *     {namespace}local_name
+ * 
+ * It's safe, because the "{" and "}" bytes cannot be used in tag names or attribute names:
+ * 
+ *     [4]   	NameStartChar  ::=   	":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
+ *     [4a]   	NameChar	   ::=   	NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
  *
  * @since WP_VERSION
  */

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -21,7 +21,7 @@ use function WordPress\Encoding\utf8_codepoint_at;
  * * Well-formed
  * * UTF-8 encoded
  * * Not standalone (so can use external entities)
- * * No DTD, DOCTYPE, ATTLIST, ENTITY, or conditional sections
+ * * No DTD, DOCTYPE, ATTLIST, ENTITY, or conditional sections (will fail on them)
  *
  * ### Possible future direction for this module
  *
@@ -34,7 +34,7 @@ use function WordPress\Encoding\utf8_codepoint_at;
  * @TODO: Track specific error states, expose informative messages, line
  *        numbers, indexes, and other debugging info.
  *
- * @TODO: Skip over the following syntax elements:
+ * @TODO: Skip over the following syntax elements instead of failing:
  *        * <!DOCTYPE, see https://www.w3.org/TR/xml/#sec-prolog-dtd
  *        * <!ATTLIST, see https://www.w3.org/TR/xml/#attdecls
  *        * <!ENTITY, see https://www.w3.org/TR/xml/#sec-entity-decl

--- a/components/XML/XMLProcessor.php
+++ b/components/XML/XMLProcessor.php
@@ -25,10 +25,9 @@ use function WordPress\Encoding\utf8_codepoint_at;
  *
  * ### Possible future direction for this module
  *
- * The final goal is to support both 1.0 and 1.1 depending on the
- * initial processing instruction (<?xml version="1.0" ?>). We're
- * starting with 1.0, however, because most that's what most WXR
- * files declare.
+ * XMLProcessor only aims to support XML 1.0, which is mostly well-defined and
+ * supported across the web. There are no plans to extend the parsing logic to XML 1.1,
+ * which is a more complex specification and not so widely supported.
  *
  * @TODO: Include the cursor string in internal bookmarks and use it for seeking.
  *


### PR DESCRIPTION
Address @dmsnell's feedback from https://github.com/WordPress/wordpress-importer/pull/190:

> this looks nice. I believe that the curly brackets are illegal in tag names, right? so this is a way we can encoding the namespace of tag? I think you explained this to me before but I wanted to leave a note here about it.

([link](https://github.com/WordPress/wordpress-importer/pull/190#discussion_r2298983774))

curly brackets are indeed illegal in tag names. I've added an "Internal representation of names" section to the comment block to clarify this and refer the relevant XML spec fragment.

> units would be helpful, and the comment seems to directly contradict the code.

([link](https://github.com/WordPress/wordpress-importer/pull/190#discussion_r2298986766))

I've increased the CHUNK_SIZE to 64kb and renamed it to CHUNK_SIZE_BYTES

> the only way to embed CDATA in an element is inside a CDATA section with <![CDATA[…]]>.

([link](https://github.com/WordPress/wordpress-importer/pull/190#discussion_r2299261462))

I've removed the entire `declare_element_as_pcdata` semantics.

> $buffer_size is given as 2048 but this appears to be pulling self::CHUNK_SIZE, which does not match. should they match?

([link](https://github.com/WordPress/wordpress-importer/pull/190#discussion_r2298990175))

I've renamed that variable to `$max_lookbehind_bytes` and documented it to clarify the meaning

## Testing

CI tests should continue to pass.

cc @dmsnell 