### PR TITLE
Make WP-CLI.phar data reference configurable

### DIFF
--- a/components/Blueprints/Runner.php
+++ b/components/Blueprints/Runner.php
@@ -233,7 +233,7 @@ class Runner {
 
 			$progress['targetResolution']->setCaption( 'Resolving target site' );
 			$targetSiteFs   = LocalFilesystem::create( $this->configuration->getTargetSiteRoot() );
-			$wpCliReference = DataReference::create( 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar' );
+			$wpCliReference = $this->configuration->getWpCliReference();
 
 			$execution_context = $this->blueprintExecutionContext->get_meta();
 			if(

--- a/components/Blueprints/RunnerConfiguration.php
+++ b/components/Blueprints/RunnerConfiguration.php
@@ -56,8 +56,15 @@ class RunnerConfiguration {
 	 */
 	private $sqliteIntegrationPlugin;
 
+	/**
+	 * @var DataReference|null
+	 * Reference to the WP-CLI phar file, if configured.
+	 */
+	private $wpCliReference;
+
 	public function __construct() {
 		$this->sqliteIntegrationPlugin = DataReference::create( 'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip' );
+		$this->wpCliReference          = DataReference::create( 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar' );
 		$this->logger                  = new NoopLogger();
 		$this->permissions             = [
 			self::PERMISSION_LOCAL_FILESYSTEM_ACCESS => false,
@@ -201,6 +208,28 @@ class RunnerConfiguration {
 	 */
 	public function getSqliteIntegrationPlugin(): ?DataReference {
 		return $this->sqliteIntegrationPlugin;
+	}
+
+	/**
+	 * Set a custom DataReference for the WP-CLI phar file.
+	 *
+	 * @param  DataReference  $ref
+	 *
+	 * @return self
+	 */
+	public function setWpCliReference( DataReference $ref ): self {
+		$this->wpCliReference = $ref;
+
+		return $this;
+	}
+
+	/**
+	 * Get the DataReference for the WP-CLI phar file.
+	 *
+	 * @return DataReference
+	 */
+	public function getWpCliReference(): DataReference {
+		return $this->wpCliReference;
 	}
 
 	/**


### PR DESCRIPTION
This PR allows configuring the hardcoded WP-CLI download URL. This change is meant for WordPress Playground that serves its own, minified, WP-CLI build.

## Testing instructions

Confirm the CI is still green