### PR TITLE
Rename code_point to codepoint. Truncate encoded bytes in utf8_encoder.

### DIFF
--- a/components/Encoding/utf8_decoder.php
+++ b/components/Encoding/utf8_decoder.php
@@ -169,7 +169,7 @@ function utf8_decoder_apply_byte( string $byte, int $state, int &$codepoint = 0 
 }
 
 /**
- * Extract a slice of a text by code point, where invalid byte seuqences count
+ * Extract a slice of a text by code point, where invalid byte sequences count
  * as a single code point, U+FFFD (the Unicode replacement character `�`).
  *
  * This function does not permit passing negative indices and will return

--- a/components/Encoding/utf8_decoder.php
+++ b/components/Encoding/utf8_decoder.php
@@ -82,18 +82,18 @@ function utf8_is_valid_byte_stream( string $bytes, int $starting_byte = 0, ?int 
  * @since {WP_VERSION}
  *
  */
-function utf8_code_point_count( string $bytes, ?int &$first_error_byte_at = null ): int {
+function utf8_codepoint_count( string $bytes, ?int &$first_error_byte_at = null ): int {
 	$state         = UTF8_DECODER_ACCEPT;
 	$last_start_at = 0;
 	$count         = 0;
-	$code_point    = 0;
+	$codepoint     = 0;
 
 	for ( $at = 0, $end = strlen( $bytes ); $at < $end && UTF8_DECODER_REJECT !== $state; $at ++ ) {
 		if ( UTF8_DECODER_ACCEPT === $state ) {
 			$last_start_at = $at;
 		}
 
-		$state = utf8_decoder_apply_byte( $bytes[ $at ], $state, $code_point );
+		$state = utf8_decoder_apply_byte( $bytes[ $at ], $state, $codepoint );
 
 		if ( UTF8_DECODER_ACCEPT === $state ) {
 			++ $count;
@@ -124,13 +124,13 @@ function utf8_code_point_count( string $bytes, ?int &$first_error_byte_at = null
  *                             <li>`UTF8_DECODER_ACCEPT`: Decoder is ready for a new code point.<br>
  *                             <li>`UTF8_DECODER_REJECT`: An error has occurred.<br>
  *                             Any other positive value: Decoder is waiting for additional bytes.
- * @param  int|null  $code_point  Optional. If provided, will accumulate the decoded code point as
+ * @param  int|null  $codepoint  Optional. If provided, will accumulate the decoded code point as
  *                             each byte is processed. If not provided or unable to decode, will
  *                             not be set, or will be set to invalid and unusable data.
  *
  * @return int Next decoder state after processing the current byte.
  */
-function utf8_decoder_apply_byte( string $byte, int $state, int &$code_point = 0 ): int {
+function utf8_decoder_apply_byte( string $byte, int $state, int &$codepoint = 0 ): int {
 	/**
 	 * State classification and transition table for UTF-8 validation.
 	 *
@@ -161,9 +161,9 @@ function utf8_decoder_apply_byte( string $byte, int $state, int &$code_point = 0
 
 	$byte       = ord( $byte );
 	$type       = ord( $state_table[ $byte ] );
-	$code_point = ( UTF8_DECODER_ACCEPT === $state )
+	$codepoint = ( UTF8_DECODER_ACCEPT === $state )
 		? ( ( 0xFF >> $type ) & $byte )
-		: ( ( $byte & 0x3F ) | ( $code_point << 6 ) );
+		: ( ( $byte & 0x3F ) | ( $codepoint << 6 ) );
 
 	return ord( $state_table[ 256 + ( $state * 16 ) + $type ] );
 }
@@ -187,27 +187,27 @@ function utf8_substr( string $text, int $from = 0, ?int $length = null ): string
 	}
 
 	$position_in_input  = 0;
-	$code_point_at      = 0;
+	$codepoint_at       = 0;
 	$end_byte           = strlen( $text );
 	$buffer             = '';
-	$seen_code_points   = 0;
-	$sliced_code_points = 0;
+	$seen_codepoints    = 0;
+	$sliced_codepoints  = 0;
 	$decoder_state      = UTF8_DECODER_ACCEPT;
 
 	// Get to the start of the string.
-	while ( $position_in_input < $end_byte && $seen_code_points < $length ) {
+	while ( $position_in_input < $end_byte && $seen_codepoints < $length ) {
 		$decoder_state = utf8_decoder_apply_byte( $text[ $position_in_input ], $decoder_state );
 
 		if ( UTF8_DECODER_ACCEPT === $decoder_state ) {
 			++ $position_in_input;
 
-			if ( $seen_code_points >= $from ) {
-				++ $sliced_code_points;
-				$buffer .= substr( $text, $code_point_at, $position_in_input - $code_point_at );
+			if ( $seen_codepoints >= $from ) {
+				++ $sliced_codepoints;
+				$buffer .= substr( $text, $codepoint_at, $position_in_input - $codepoint_at );
 			}
 
-			++ $seen_code_points;
-			$code_point_at = $position_in_input;
+			++ $seen_codepoints;
+			$codepoint_at = $position_in_input;
 		} elseif ( UTF8_DECODER_REJECT === $decoder_state ) {
 			$buffer .= "\u{FFFD}";
 
@@ -216,8 +216,8 @@ function utf8_substr( string $text, int $from = 0, ?int $length = null ): string
 				$decoder_state = utf8_decoder_apply_byte( $text[ ++ $position_in_input ], UTF8_DECODER_ACCEPT );
 			}
 
-			++ $seen_code_points;
-			$code_point_at = $position_in_input;
+			++ $seen_codepoints;
+			$codepoint_at  = $position_in_input;
 			$decoder_state = UTF8_DECODER_ACCEPT;
 		} else {
 			++ $position_in_input;
@@ -247,7 +247,7 @@ function utf8_codepoint_at( string $text, int $byte_offset = 0, &$matched_bytes 
 	}
 
 	$position_in_input = $byte_offset;
-	$code_point_at     = $byte_offset;
+	$codepoint_at      = $byte_offset;
 	$end_byte          = strlen( $text );
 	$codepoint         = null;
 	$decoder_state     = UTF8_DECODER_ACCEPT;
@@ -258,7 +258,7 @@ function utf8_codepoint_at( string $text, int $byte_offset = 0, &$matched_bytes 
 
 		if ( UTF8_DECODER_ACCEPT === $decoder_state ) {
 			++ $position_in_input;
-			$codepoint = utf8_ord( substr( $text, $code_point_at, $position_in_input - $code_point_at ) );
+			$codepoint = utf8_ord( substr( $text, $codepoint_at, $position_in_input - $codepoint_at ) );
 			break;
 		} elseif ( UTF8_DECODER_REJECT === $decoder_state ) {
 			$codepoint = utf8_ord( "\u{FFFD}" );

--- a/components/Encoding/utf8_encoder.php
+++ b/components/Encoding/utf8_encoder.php
@@ -18,52 +18,52 @@ namespace WordPress\Encoding;
  *
  * Example:
  *
- *     '🅰' === WP_HTML_Decoder::code_point_to_utf8_bytes( 0x1f170 );
+ *     '🅰' === WP_HTML_Decoder::codepoint_to_utf8_bytes( 0x1f170 );
  *
  *     // Half of a surrogate pair is an invalid code point.
- *     '�' === WP_HTML_Decoder::code_point_to_utf8_bytes( 0xd83c );
+ *     '�' === WP_HTML_Decoder::codepoint_to_utf8_bytes( 0xd83c );
  *
  * @since 6.6.0
  *
  * @see https://www.rfc-editor.org/rfc/rfc3629 For the UTF-8 standard.
  *
- * @param int $code_point Which code point to convert.
+ * @param int $codepoint Which code point to convert.
  * @return string Converted code point, or `�` if invalid.
  */
-function code_point_to_utf8_bytes( $code_point ) {
+function codepoint_to_utf8_bytes( $codepoint ) {
 	// Pre-check to ensure a valid code point.
 	if (
-		$code_point <= 0 ||
-		( $code_point >= 0xD800 && $code_point <= 0xDFFF ) ||
-		$code_point > 0x10FFFF
+		$codepoint <= 0 ||
+		( $codepoint >= 0xD800 && $codepoint <= 0xDFFF ) ||
+		$codepoint > 0x10FFFF
 	) {
 		return '�';
 	}
 
-	if ( $code_point <= 0x7F ) {
-		return chr( $code_point );
+	if ( $codepoint <= 0x7F ) {
+		return chr( $codepoint );
 	}
 
-	if ( $code_point <= 0x7FF ) {
-		$byte1 = chr( ( $code_point >> 6 ) | 0xC0 );
-		$byte2 = chr( $code_point & 0x3F | 0x80 );
+	if ( $codepoint <= 0x7FF ) {
+		$byte1 = chr( ( 0xC0 | ( ( $codepoint >> 6 ) & 0x1F ) ) );
+		$byte2 = chr( $codepoint & 0x3F | 0x80 );
 
 		return "{$byte1}{$byte2}";
 	}
 
-	if ( $code_point <= 0xFFFF ) {
-		$byte1 = chr( ( $code_point >> 12 ) | 0xE0 );
-		$byte2 = chr( ( $code_point >> 6 ) & 0x3F | 0x80 );
-		$byte3 = chr( $code_point & 0x3F | 0x80 );
+	if ( $codepoint <= 0xFFFF ) {
+		$byte1 = chr( ( $codepoint >> 12 ) | 0xE0 );
+		$byte2 = chr( ( $codepoint >> 6 ) & 0x3F | 0x80 );
+		$byte3 = chr( $codepoint & 0x3F | 0x80 );
 
 		return "{$byte1}{$byte2}{$byte3}";
 	}
 
 	// Any values above U+10FFFF are eliminated above in the pre-check.
-	$byte1 = chr( ( $code_point >> 18 ) | 0xF0 );
-	$byte2 = chr( ( $code_point >> 12 ) & 0x3F | 0x80 );
-	$byte3 = chr( ( $code_point >> 6 ) & 0x3F | 0x80 );
-	$byte4 = chr( $code_point & 0x3F | 0x80 );
+	$byte1 = chr( ( $codepoint >> 18 ) | 0xF0 );
+	$byte2 = chr( ( $codepoint >> 12 ) & 0x3F | 0x80 );
+	$byte3 = chr( ( $codepoint >> 6 ) & 0x3F | 0x80 );
+	$byte4 = chr( $codepoint & 0x3F | 0x80 );
 
 	return "{$byte1}{$byte2}{$byte3}{$byte4}";
 }

--- a/components/HTML/class-wp-html-decoder.php
+++ b/components/HTML/class-wp-html-decoder.php
@@ -283,7 +283,7 @@ class WP_HTML_Decoder {
 			}
 
 			$digits     = substr( $text, $digits_at + $zero_count, $digit_count );
-			$code_point = intval( $digits, $numeric_base );
+			$codepoint = intval( $digits, $numeric_base );
 
 			/*
 			 * Noncharacters, 0x0D, and non-ASCII-whitespace control characters.
@@ -316,7 +316,7 @@ class WP_HTML_Decoder {
 			 * > the first column, and set the character reference code to
 			 * > the number in the second column of that row.
 			 */
-			if ( $code_point >= 0x80 && $code_point <= 0x9F ) {
+			if ( $codepoint >= 0x80 && $codepoint <= 0x9F ) {
 				$windows_1252_mapping = array(
 					0x20AC, // 0x80 -> EURO SIGN (€).
 					0x81,   // 0x81 -> (no change).
@@ -352,12 +352,12 @@ class WP_HTML_Decoder {
 					0x0178, // 0x9F -> LATIN CAPITAL LETTER Y WITH DIAERESIS (Ÿ).
 				);
 
-				$code_point = $windows_1252_mapping[ $code_point - 0x80 ];
+				$codepoint = $windows_1252_mapping[ $codepoint - 0x80 ];
 			}
 
 			$match_byte_length = $end_of_span - $at;
 
-			return self::code_point_to_utf8_bytes( $code_point );
+			return self::codepoint_to_utf8_bytes( $codepoint );
 		}
 
 		/** Tracks inner parsing within the named character reference. */
@@ -422,12 +422,12 @@ class WP_HTML_Decoder {
 	 *
 	 * Example:
 	 *
-	 *     '🅰' === WP_HTML_Decoder::code_point_to_utf8_bytes( 0x1f170 );
+	 *     '🅰' === WP_HTML_Decoder::codepoint_to_utf8_bytes( 0x1f170 );
 	 *
 	 *     // Half of a surrogate pair is an invalid code point.
-	 *     '�' === WP_HTML_Decoder::code_point_to_utf8_bytes( 0xd83c );
+	 *     '�' === WP_HTML_Decoder::codepoint_to_utf8_bytes( 0xd83c );
 	 *
-	 * @param  int  $code_point  Which code point to convert.
+	 * @param  int  $codepoint  Which code point to convert.
 	 *
 	 * @return string Converted code point, or `�` if invalid.
 	 * @since 6.6.0
@@ -435,40 +435,40 @@ class WP_HTML_Decoder {
 	 * @see https://www.rfc-editor.org/rfc/rfc3629 For the UTF-8 standard.
 	 *
 	 */
-	public static function code_point_to_utf8_bytes( $code_point ): string {
+	public static function codepoint_to_utf8_bytes( $codepoint ): string {
 		// Pre-check to ensure a valid code point.
 		if (
-			$code_point <= 0 ||
-			( $code_point >= 0xD800 && $code_point <= 0xDFFF ) ||
-			$code_point > 0x10FFFF
+			$codepoint <= 0 ||
+			( $codepoint >= 0xD800 && $codepoint <= 0xDFFF ) ||
+			$codepoint > 0x10FFFF
 		) {
 			return '�';
 		}
 
-		if ( $code_point <= 0x7F ) {
-			return chr( $code_point );
+		if ( $codepoint <= 0x7F ) {
+			return chr( $codepoint );
 		}
 
-		if ( $code_point <= 0x7FF ) {
-			$byte1 = chr( ( $code_point >> 6 ) | 0xC0 );
-			$byte2 = chr( $code_point & 0x3F | 0x80 );
+		if ( $codepoint <= 0x7FF ) {
+			$byte1 = chr( ( $codepoint >> 6 ) | 0xC0 );
+			$byte2 = chr( $codepoint & 0x3F | 0x80 );
 
 			return "{$byte1}{$byte2}";
 		}
 
-		if ( $code_point <= 0xFFFF ) {
-			$byte1 = chr( ( $code_point >> 12 ) | 0xE0 );
-			$byte2 = chr( ( $code_point >> 6 ) & 0x3F | 0x80 );
-			$byte3 = chr( $code_point & 0x3F | 0x80 );
+		if ( $codepoint <= 0xFFFF ) {
+			$byte1 = chr( ( $codepoint >> 12 ) | 0xE0 );
+			$byte2 = chr( ( $codepoint >> 6 ) & 0x3F | 0x80 );
+			$byte3 = chr( $codepoint & 0x3F | 0x80 );
 
 			return "{$byte1}{$byte2}{$byte3}";
 		}
 
 		// Any values above U+10FFFF are eliminated above in the pre-check.
-		$byte1 = chr( ( $code_point >> 18 ) | 0xF0 );
-		$byte2 = chr( ( $code_point >> 12 ) & 0x3F | 0x80 );
-		$byte3 = chr( ( $code_point >> 6 ) & 0x3F | 0x80 );
-		$byte4 = chr( $code_point & 0x3F | 0x80 );
+		$byte1 = chr( ( $codepoint >> 18 ) | 0xF0 );
+		$byte2 = chr( ( $codepoint >> 12 ) & 0x3F | 0x80 );
+		$byte3 = chr( ( $codepoint >> 6 ) & 0x3F | 0x80 );
+		$byte4 = chr( $codepoint & 0x3F | 0x80 );
 
 		return "{$byte1}{$byte2}{$byte3}{$byte4}";
 	}

--- a/components/XML/XMLDecoder.php
+++ b/components/XML/XMLDecoder.php
@@ -2,7 +2,7 @@
 
 namespace WordPress\XML;
 
-use function WordPress\Encoding\code_point_to_utf8_bytes;
+use function WordPress\Encoding\codepoint_to_utf8_bytes;
 
 /**
  * XML API: WP_XML_Decoder class
@@ -143,9 +143,9 @@ class XMLDecoder {
 				continue;
 			}
 
-			$code_point          = intval( substr( $text, $digits_at, $digit_count ), $base );
-			$character_reference = code_point_to_utf8_bytes( $code_point );
-			if ( '�' === $character_reference && 0xFFFD !== $code_point ) {
+			$codepoint          = intval( substr( $text, $digits_at, $digit_count ), $base );
+			$character_reference = codepoint_to_utf8_bytes( $codepoint );
+			if ( '�' === $character_reference && 0xFFFD !== $codepoint ) {
 				/*
 				 * Stop processing if we got an invalid character AND the reference does not
 				 * specifically refer code point FFFD (�).

--- a/components/XML/XMLUnsupportedException.php
+++ b/components/XML/XMLUnsupportedException.php
@@ -13,7 +13,7 @@ use Exception;
  *
  * This class is designed for internal use by the XML processor.
  *
- * The XML API aims to operate in compliance with the XML5
+ * The XML API aims to operate in compliance with the XML 1.0
  * specification, but does not implement the full specification.
  * In cases where it lacks support it should not cause breakage
  * or unexpected behavior. In the cases where it recognizes that


### PR DESCRIPTION
Backports @zaerl feedback from https://github.com/WordPress/wordpress-importer/pull/190:

* Fixes typos in comments
* Renames `code_point` to `codepoint`
* Truncates encoded 2-byte UTF-8 sequences via `& 0x1F`