### PR TITLE
Add SlevomatCodingStandard.ControlStructures.DisallowYodaComparison sniff

### DIFF
--- a/composer-ci-matrix-tests.json
+++ b/composer-ci-matrix-tests.json
@@ -25,7 +25,6 @@
     "require-dev": {
         "yoast/phpunit-polyfills": "^4.0.0",
         "phpcompatibility/php-compatibility": "^9.3.5",
-        "slevomat/coding-standard": "^8.21.1",
         "phpunit/phpunit": "8.5.x || ^9.5"
     },
     "autoload": {

--- a/composer-ci-matrix-tests.json
+++ b/composer-ci-matrix-tests.json
@@ -25,6 +25,7 @@
     "require-dev": {
         "yoast/phpunit-polyfills": "^4.0.0",
         "phpcompatibility/php-compatibility": "^9.3.5",
+        "slevomat/coding-standard": "^8.21.1",
         "phpunit/phpunit": "8.5.x || ^9.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "yoast/phpunit-polyfills": "2.0.0",
         "squizlabs/php_codesniffer": "^3.13.4",
         "phpcompatibility/php-compatibility": "^9.3.5",
+        "slevomat/coding-standard": "^8.21.1",
         "wp-coding-standards/wpcs": "^3.2.0",
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74c5ce31b6f065c8e4ce0e422c31a2a6",
+    "content-hash": "96ae901a57220cc49ac12b1903dc7849",
     "packages": [],
     "packages-dev": [
         {
@@ -650,6 +650,54 @@
                 }
             ],
             "time": "2025-09-05T05:39:50+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+            },
+            "time": "2025-08-30T15:50:23+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -2138,6 +2186,72 @@
                 }
             ],
             "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "2b801e950ae1cceb30bb3c0373141f553c99d3c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/2b801e950ae1cceb30bb3c0373141f553c99d3c3",
+                "reference": "2b801e950ae1cceb30bb3c0373141f553c99d3c3",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.1.2",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpdoc-parser": "^2.3.0",
+                "squizlabs/php_codesniffer": "^3.13.2"
+            },
+            "require-dev": {
+                "phing/phing": "3.0.1|3.1.0",
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/phpstan": "2.1.22",
+                "phpstan/phpstan-deprecation-rules": "2.0.3",
+                "phpstan/phpstan-phpunit": "2.0.7",
+                "phpstan/phpstan-strict-rules": "2.0.6",
+                "phpunit/phpunit": "9.6.8|10.5.48|11.4.4|11.5.27|12.3.7"
+            },
+            "default-branch": true,
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.21.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-31T13:32:28+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,8 @@
     <exclude-pattern>*/Tests/*</exclude-pattern>
     <rule ref="PHPCompatibility">
     </rule>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison">
+    </rule>
 	<rule ref="WordPress">
         <exclude name="Generic.Commenting.DocComment.MissingShort"/>
         <exclude name="Generic.PHP.DiscourageGoto.Found"/>


### PR DESCRIPTION
Adds a PHPCBF sniff to auto-fix yoda conditions that WordPress coding standards require