### PR TITLE
PHPCS: EnforceYodaComparisonSniff

### DIFF
--- a/components/ToolkitCodingStandards/WordPressToolkitCodingStandards/Sniffs/PHP/EnforceYodaComparisonSniff.php
+++ b/components/ToolkitCodingStandards/WordPressToolkitCodingStandards/Sniffs/PHP/EnforceYodaComparisonSniff.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace WordPressToolkitCodingStandards\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+use SlevomatCodingStandard\Helpers\YodaHelper;
+use function array_keys;
+use function count;
+use const T_EQUAL;
+use const T_IS_EQUAL;
+use const T_IS_IDENTICAL;
+use const T_IS_NOT_EQUAL;
+use const T_IS_NOT_IDENTICAL;
+
+/**
+ * Bigger value must be on the left side:
+ *
+ * ($variable, Foo::$class, Foo::bar(), foo())
+ *  > (Foo::BAR, BAR)
+ *  > (true, false, null, 1, 1.0, arrays, 'foo')
+ */
+class EnforceYodaComparisonSniff implements Sniff
+{
+
+    public const CODE_DISALLOWED_YODA_COMPARISON = 'DisallowedYodaComparison';
+
+    /**
+     * @return array<int, (int|string)>
+     */
+    public function register(): array
+    {
+        return [
+            T_IS_IDENTICAL,
+            T_IS_NOT_IDENTICAL,
+            T_IS_EQUAL,
+            T_IS_NOT_EQUAL,
+        ];
+    }
+
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @param int $comparisonTokenPointer
+     */
+    public function process(File $phpcsFile, $comparisonTokenPointer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $leftSideTokens = YodaHelper::getRightSideTokens($tokens, $comparisonTokenPointer);
+        $rightSideTokens = YodaHelper::getLeftSideTokens($tokens, $comparisonTokenPointer);
+        $leftDynamism = YodaHelper::getDynamismForTokens($tokens, $leftSideTokens);
+        $rightDynamism = YodaHelper::getDynamismForTokens($tokens, $rightSideTokens);
+
+        if ($leftDynamism === null || $rightDynamism === null) {
+            return;
+        }
+
+        if ($leftDynamism >= $rightDynamism) {
+            return;
+        }
+
+        if ($leftDynamism >= 900 && $rightDynamism >= 900) {
+            return;
+        }
+
+        $errorParameters = [
+            'Yoda comparisons are required.',
+            $comparisonTokenPointer,
+            self::CODE_DISALLOWED_YODA_COMPARISON,
+        ];
+
+        $lastRightSideTokenPointer = array_keys($rightSideTokens)[count($rightSideTokens) - 1];
+
+        $nextPointer = TokenHelper::findNextEffective($phpcsFile, $lastRightSideTokenPointer + 1);
+        if ($tokens[$nextPointer]['code'] === T_EQUAL) {
+            $phpcsFile->addError(...$errorParameters);
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(...$errorParameters);
+        if (!$fix) {
+            return;
+        }
+
+        YodaHelper::fix($phpcsFile, $leftSideTokens, $rightSideTokens);
+    }
+}
+
+

--- a/components/ToolkitCodingStandards/WordPressToolkitCodingStandards/ruleset.xml
+++ b/components/ToolkitCodingStandards/WordPressToolkitCodingStandards/ruleset.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ruleset name="WordPressToolkitCodingStandards">
+    <description>Local custom sniffs for WordPress toolkit.</description>
+    <rule ref="WordPressToolkitCodingStandards.PHP.EnforceYodaComparison"/>
+</ruleset>
+
+

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
             "components/Merge/",
             "components/Merge/vendor-patched",
             "components/ByteStream/",
+            "components/ToolkitCodingStandards/",
             "components/XML/",
             "components/Zip/"
         ],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,13 +1,13 @@
 <ruleset name="WordPressStandard">
     <description>PHP 7.2 compatibility.</description>
+    <autoload>vendor/autoload.php</autoload>
     <config name="testVersion" value="7.2"/>
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>*/vendor-patched/*</exclude-pattern>
     <exclude-pattern>*/Tests/*</exclude-pattern>
     <rule ref="PHPCompatibility">
     </rule>
-    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison">
-    </rule>
+    <rule ref="components/ToolkitCodingStandards/WordPressToolkitCodingStandards/ruleset.xml"/>
 	<rule ref="WordPress">
         <exclude name="Generic.Commenting.DocComment.MissingShort"/>
         <exclude name="Generic.PHP.DiscourageGoto.Found"/>


### PR DESCRIPTION
Based on SlevomatCodingStandard.ControlStructures.DisallowYodaComparison but it's doing the opposite – it enforces Yoda conditions via phpcbf.

Related to #157 