### PR TITLE
Move public suffix list check to WPURL::is_known_public_domain

### DIFF
--- a/components/DataLiberation/URL/class-urlintextprocessor.php
+++ b/components/DataLiberation/URL/class-urlintextprocessor.php
@@ -106,14 +106,7 @@ class URLInTextProcessor {
 	 * If set to false, the matching will be more lenient, allowing for potential false positives.
 	 */
 	private $strict = false;
-	private static $public_suffix_list;
-
-
 	public function __construct( $text, $base_url = null ) {
-		if ( ! self::$public_suffix_list ) {
-			// @TODO: Parse wildcards and exceptions from the public suffix list.
-			self::$public_suffix_list = require_once __DIR__ . '/public-suffix-list.php';
-		}
 		$this->text          = $text;
 		$this->base_url      = $base_url;
 		$this->base_protocol = $base_url ? parse_url( $base_url, PHP_URL_SCHEME ) : null;
@@ -238,8 +231,8 @@ class URLInTextProcessor {
 					continue;
 				}
 
-				$tld = strtolower( substr( $parsed_url->hostname, $last_dot_position + 1 ) );
-				if ( empty( self::$public_suffix_list[ $tld ] ) && 'internal' !== $tld ) {
+				$tld = substr( $parsed_url->hostname, $last_dot_position + 1 );
+				if ( ! WPURL::is_known_public_domain( $tld ) ) {
 					// This TLD is not in the public suffix list. It's not a valid domain name.
 					continue;
 				}

--- a/components/DataLiberation/URL/class-wpurl.php
+++ b/components/DataLiberation/URL/class-wpurl.php
@@ -99,6 +99,7 @@ class WPURL {
 			$public_suffix_list = require_once __DIR__ . '/public-suffix-list.php';
 		}
 
+		// @TODO: Parse wildcards and exceptions from the public suffix list.
 		$tld = strtolower( $tld );
 		return ! empty( $public_suffix_list[ $tld ] ) || 'internal' === $tld;
 	}

--- a/components/DataLiberation/URL/class-wpurl.php
+++ b/components/DataLiberation/URL/class-wpurl.php
@@ -82,4 +82,24 @@ class WPURL {
 
 		return $base_url->toString();
 	}
+
+	/**
+	 * Checks if a TLD is in the known public domain suffix list.
+	 * This reduces false positives like `index.html` or `plugins.php`.
+	 *
+	 * @see https://publicsuffix.org/
+	 *
+	 * @param string $tld The top-level domain to check.
+	 * @return bool True if the TLD is a known public domain, false otherwise.
+	 */
+	public static function is_known_public_domain( $tld ) {
+		static $public_suffix_list = null;
+
+		if ( null === $public_suffix_list ) {
+			$public_suffix_list = require_once __DIR__ . '/public-suffix-list.php';
+		}
+
+		$tld = strtolower( $tld );
+		return ! empty( $public_suffix_list[ $tld ] ) || 'internal' === $tld;
+	}
 }


### PR DESCRIPTION
Abstract the public suffix list check inside the WPURL class. This will help us swap it for a database lookup in the future – @dmsnell noted in https://github.com/WordPress/wordpress-importer/pull/202 the PSL list changes and shipping a hardcoded one with the plugin may not be enough to keep up in the long term.

 ## Testing instructions

CI