### PR TITLE
BlockMarkupUrlProcessor: Iterate over the attributes using names, not indices

### DIFF
--- a/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
@@ -22,7 +22,14 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	private $base_url_object;
 	private $url_in_text_processor;
 	private $url_in_text_node_updated;
-	private $inspected_url_attribute_idx = - 1;
+	private $attributes_to_inspect;
+
+	/**
+	 * The name of the URL attribute whose value is currently being inspected.
+	 *
+	 * @var string|null
+	 */
+	private $currently_inspected_url_attribute_name;
 
 	public function __construct( $html, ?string $base_url_string = null ) {
 		parent::__construct( $html );
@@ -50,10 +57,11 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	public function next_token(): bool {
 		$this->get_updated_html();
 
-		$this->raw_url                     = null;
-		$this->parsed_url                  = null;
-		$this->inspected_url_attribute_idx = - 1;
-		$this->url_in_text_processor       = null;
+		$this->raw_url                                = null;
+		$this->parsed_url                             = null;
+		$this->attributes_to_inspect                  = null;
+		$this->currently_inspected_url_attribute_name = null;
+		$this->url_in_text_processor                  = null;
 		// Do not reset url_in_text_node_updated – it's reset in get_updated_html() which.
 		// is called in parent::next_token().
 
@@ -116,20 +124,22 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 
 	private function next_url_attribute() {
 		$tag = $this->get_tag();
-		if (
-			! array_key_exists( $tag, self::URL_ATTRIBUTES ) &&
-			'INPUT' !== $tag // type=image => src,.
-		) {
+
+		if ( ! array_key_exists( $tag, self::URL_ATTRIBUTES ) ) {
 			return false;
 		}
 
-		while ( ++$this->inspected_url_attribute_idx < count( self::URL_ATTRIBUTES[ $tag ] ) ) {
-			$attr = self::URL_ATTRIBUTES[ $tag ][ $this->inspected_url_attribute_idx ];
-			if ( false === $attr ) {
-				return false;
+		if ( null === $this->attributes_to_inspect ) {
+			$this->attributes_to_inspect = self::URL_ATTRIBUTES[ $tag ];
+		}
+
+		while ( count( $this->attributes_to_inspect ) > 0 ) {
+			$attr      = array_shift( $this->attributes_to_inspect );
+			$url_maybe = $this->get_attribute( $attr );
+			if ( ! is_string( $url_maybe ) ) {
+				continue;
 			}
 
-			$url_maybe = $this->get_attribute( $attr );
 			/*
 			 * Use base URL to resolve known URI attributes as we are certain we're
 			 * dealing with URI values.
@@ -137,18 +147,16 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			 * be correctly recognized as a URL.
 			 * Without a base URL, this Processor would incorrectly skip it.
 			 */
+			$parsed_url = WPURL::parse( $url_maybe, $this->base_url_string );
 
-			if ( is_string( $url_maybe ) ) {
-				$parsed_url = WPURL::parse( $url_maybe, $this->base_url_string );
-
-				if ( false === $parsed_url ) {
-					return false;
-				}
-				$this->raw_url    = $url_maybe;
-				$this->parsed_url = $parsed_url;
-
-				return true;
+			if ( false === $parsed_url ) {
+				continue;
 			}
+			$this->raw_url                                = $url_maybe;
+			$this->parsed_url                             = $parsed_url;
+			$this->currently_inspected_url_attribute_name = $attr;
+
+			return true;
 		}
 
 		return false;
@@ -324,19 +332,7 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			return false;
 		}
 
-		$tag = $this->get_tag();
-		if ( ! array_key_exists( $tag, self::URL_ATTRIBUTES ) ) {
-			return false;
-		}
-
-		if (
-			$this->inspected_url_attribute_idx < 0 ||
-			$this->inspected_url_attribute_idx >= count( self::URL_ATTRIBUTES[ $tag ] )
-		) {
-			return false;
-		}
-
-		return self::URL_ATTRIBUTES[ $tag ][ $this->inspected_url_attribute_idx ];
+		return $this->currently_inspected_url_attribute_name ?? false;
 	}
 
 

--- a/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
@@ -24,18 +24,20 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	private $url_in_text_node_updated;
 
 	/**
-	 * The list of HTML attributes whose values haven't been yet processed.
+	 * The list of names of URL-related HTML attributes that may be available on
+	 * the current token. They will be inspected by next_url_attribute().
+	 * 
+	 * Possible values:
+	 * 
+	 * - null: We haven't inspected any attribute yet.
+	 * - array: The first element is the currently inspected attribute
+	 *          and the rest of the list are elements yet to be inspected on
+	 *          the upcoming next_url_attribute() call.
+	 * - empty array: We've already inspected all the URL-related attributes.
 	 *
 	 * @var array<string>|null
 	 */
 	private $inspecting_html_attributes;
-
-	/**
-	 * The name of the URL attribute whose value is currently being inspected.
-	 *
-	 * @var string|null
-	 */
-	private $currently_inspected_url_html_attribute;
 
 	public function __construct( $html, ?string $base_url_string = null ) {
 		parent::__construct( $html );
@@ -66,7 +68,6 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		$this->raw_url                                = null;
 		$this->parsed_url                             = null;
 		$this->inspecting_html_attributes             = null;
-		$this->currently_inspected_url_html_attribute = null;
 		$this->url_in_text_processor                  = null;
 		// Do not reset url_in_text_node_updated – it's reset in get_updated_html() which.
 		// is called in parent::next_token().
@@ -136,13 +137,25 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		}
 
 		if ( null === $this->inspecting_html_attributes ) {
+			/**
+			 * Initialize the list on the first call to next_url_attribute()
+			 * for the current token. The last element is the attribute we'll
+			 * inspect in the while() loop below.
+			 */
 			$this->inspecting_html_attributes = self::URL_ATTRIBUTES[ $tag ];
+		} else {
+			/**
+			 * Forget the attribute we've inspected on the previous call to
+			 * next_url_attribute().
+			 */
+			array_pop( $this->inspecting_html_attributes );
 		}
 
 		while ( count( $this->inspecting_html_attributes ) > 0 ) {
-			$attr      = array_shift( $this->inspecting_html_attributes );
+			$attr      = $this->inspecting_html_attributes[ count( $this->inspecting_html_attributes ) - 1 ];
 			$url_maybe = $this->get_attribute( $attr );
 			if ( ! is_string( $url_maybe ) ) {
+				array_pop( $this->inspecting_html_attributes );
 				continue;
 			}
 
@@ -156,11 +169,11 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			$parsed_url = WPURL::parse( $url_maybe, $this->base_url_string );
 
 			if ( false === $parsed_url ) {
+				array_pop( $this->inspecting_html_attributes );
 				continue;
 			}
 			$this->raw_url                                = $url_maybe;
 			$this->parsed_url                             = $parsed_url;
-			$this->currently_inspected_url_html_attribute = $attr;
 
 			return true;
 		}
@@ -338,7 +351,15 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			return false;
 		}
 
-		return $this->currently_inspected_url_html_attribute ?? false;
+		if ( null === $this->inspecting_html_attributes ) {
+			return false;
+		}
+
+		if ( empty( $this->inspecting_html_attributes ) ) {
+			return false;
+		}
+
+		return $this->inspecting_html_attributes[ count( $this->inspecting_html_attributes ) - 1 ];
 	}
 
 

--- a/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
@@ -22,14 +22,20 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	private $base_url_object;
 	private $url_in_text_processor;
 	private $url_in_text_node_updated;
-	private $attributes_to_inspect;
+
+	/**
+	 * The list of HTML attributes whose values haven't been yet processed.
+	 *
+	 * @var array<string>|null
+	 */
+	private $inspecting_html_attributes;
 
 	/**
 	 * The name of the URL attribute whose value is currently being inspected.
 	 *
 	 * @var string|null
 	 */
-	private $currently_inspected_url_attribute_name;
+	private $currently_inspected_url_html_attribute;
 
 	public function __construct( $html, ?string $base_url_string = null ) {
 		parent::__construct( $html );
@@ -59,8 +65,8 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 
 		$this->raw_url                                = null;
 		$this->parsed_url                             = null;
-		$this->attributes_to_inspect                  = null;
-		$this->currently_inspected_url_attribute_name = null;
+		$this->inspecting_html_attributes             = null;
+		$this->currently_inspected_url_html_attribute = null;
 		$this->url_in_text_processor                  = null;
 		// Do not reset url_in_text_node_updated – it's reset in get_updated_html() which.
 		// is called in parent::next_token().
@@ -129,12 +135,12 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			return false;
 		}
 
-		if ( null === $this->attributes_to_inspect ) {
-			$this->attributes_to_inspect = self::URL_ATTRIBUTES[ $tag ];
+		if ( null === $this->inspecting_html_attributes ) {
+			$this->inspecting_html_attributes = self::URL_ATTRIBUTES[ $tag ];
 		}
 
-		while ( count( $this->attributes_to_inspect ) > 0 ) {
-			$attr      = array_shift( $this->attributes_to_inspect );
+		while ( count( $this->inspecting_html_attributes ) > 0 ) {
+			$attr      = array_shift( $this->inspecting_html_attributes );
 			$url_maybe = $this->get_attribute( $attr );
 			if ( ! is_string( $url_maybe ) ) {
 				continue;
@@ -154,7 +160,7 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			}
 			$this->raw_url                                = $url_maybe;
 			$this->parsed_url                             = $parsed_url;
-			$this->currently_inspected_url_attribute_name = $attr;
+			$this->currently_inspected_url_html_attribute = $attr;
 
 			return true;
 		}
@@ -332,7 +338,7 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			return false;
 		}
 
-		return $this->currently_inspected_url_attribute_name ?? false;
+		return $this->currently_inspected_url_html_attribute ?? false;
 	}
 
 

--- a/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
@@ -26,9 +26,9 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	/**
 	 * The list of names of URL-related HTML attributes that may be available on
 	 * the current token. They will be inspected by next_url_attribute().
-	 * 
+	 *
 	 * Possible values:
-	 * 
+	 *
 	 * - null: We haven't inspected any attribute yet.
 	 * - array: The first element is the currently inspected attribute
 	 *          and the rest of the list are elements yet to be inspected on
@@ -65,10 +65,10 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	public function next_token(): bool {
 		$this->get_updated_html();
 
-		$this->raw_url                                = null;
-		$this->parsed_url                             = null;
-		$this->inspecting_html_attributes             = null;
-		$this->url_in_text_processor                  = null;
+		$this->raw_url                    = null;
+		$this->parsed_url                 = null;
+		$this->inspecting_html_attributes = null;
+		$this->url_in_text_processor      = null;
 		// Do not reset url_in_text_node_updated – it's reset in get_updated_html() which.
 		// is called in parent::next_token().
 
@@ -172,8 +172,8 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 				array_pop( $this->inspecting_html_attributes );
 				continue;
 			}
-			$this->raw_url                                = $url_maybe;
-			$this->parsed_url                             = $parsed_url;
+			$this->raw_url    = $url_maybe;
+			$this->parsed_url = $parsed_url;
 
 			return true;
 		}

--- a/components/DataLiberation/Tests/BlockMarkupUrlProcessorTest.php
+++ b/components/DataLiberation/Tests/BlockMarkupUrlProcessorTest.php
@@ -125,10 +125,10 @@ class BlockMarkupUrlProcessorTest extends TestCase {
 		$markup = '<img longdesc="https://first-url.org" src="https://mysite.com/wp-content/image.png">';
 		$p      = new BlockMarkupUrlProcessor( $markup );
 		$this->assertTrue( $p->next_url(), 'Failed to find the URL in the markup.' );
-		$this->assertEquals( 'https://first-url.org', $p->get_raw_url(), 'Found a URL in the markup, but it wasn\'t the expected one.' );
+		$this->assertEquals( 'https://mysite.com/wp-content/image.png', $p->get_raw_url(), 'Found a URL in the markup, but it wasn\'t the expected one.' );
 
 		$this->assertTrue( $p->next_url(), 'Failed to find the URL in the markup.' );
-		$this->assertEquals( 'https://mysite.com/wp-content/image.png', $p->get_raw_url(),
+		$this->assertEquals( 'https://first-url.org', $p->get_raw_url(),
 			'Found a URL in the markup, but it wasn\'t the expected one.' );
 	}
 
@@ -136,10 +136,10 @@ class BlockMarkupUrlProcessorTest extends TestCase {
 		$markup = '<img longdesc="https://first-url.org" src="https://mysite.com/wp-content/image.png"><a href="https://third-url.org">';
 		$p      = new BlockMarkupUrlProcessor( $markup );
 		$this->assertTrue( $p->next_url(), 'Failed to find the URL in the markup.' );
-		$this->assertEquals( 'https://first-url.org', $p->get_raw_url(), 'Found a URL in the markup, but it wasn\'t the expected one.' );
+		$this->assertEquals( 'https://mysite.com/wp-content/image.png', $p->get_raw_url(), 'Found a URL in the markup, but it wasn\'t the expected one.' );
 
 		$this->assertTrue( $p->next_url(), 'Failed to find the URL in the markup.' );
-		$this->assertEquals( 'https://mysite.com/wp-content/image.png', $p->get_raw_url(),
+		$this->assertEquals( 'https://first-url.org', $p->get_raw_url(),
 			'Found a URL in the markup, but it wasn\'t the expected one.' );
 
 		$this->assertTrue( $p->next_url(), 'Failed to find the URL in the markup.' );

--- a/components/DataLiberation/Tests/BlockMarkupUrlProcessorTest.php
+++ b/components/DataLiberation/Tests/BlockMarkupUrlProcessorTest.php
@@ -74,6 +74,11 @@ class BlockMarkupUrlProcessorTest extends TestCase {
 				'<a href=""></a><a href="https://developer.w.org"></a>',
 				null,
 			),
+			'Skips over a class name in the <a> tag' => array(
+				'https://developer.w.org',
+				'<a class="http://example.com" href="https://developer.w.org"></a>',
+				null,
+			),
 		);
 	}
 


### PR DESCRIPTION
@dmsnell [noted](https://github.com/WordPress/wordpress-importer/pull/202#discussion_r2334173254):

> the passing around of the index with the `-1` sentinel value is hard for me to follow. did you consider setting something like `$this->currently_examined_attribute_name = null;`?

This PR switches from to using indices to using a list of names.

> or is the issue reentrancy in all of these functions?

Block markup parser is not re-entrant. We should never need to process block markup that blows up the memory so I didn't bother implementing re-entrancy there.

# Testing instructions

CI