### PR TITLE
Code style consistency for ByteReadStream

### DIFF
--- a/components/Blueprints/Progress/class-progresstrackedreadstream.php
+++ b/components/Blueprints/Progress/class-progresstrackedreadstream.php
@@ -35,7 +35,7 @@ class ProgressTrackedReadStream implements ByteReadStream {
 		return $this->stream->tell();
 	}
 
-	public function seek( int $offset ) {
+	public function seek( int $offset ): void {
 		$this->stream->seek( $offset );
 		$this->updateProgress();
 	}
@@ -49,18 +49,18 @@ class ProgressTrackedReadStream implements ByteReadStream {
 		return $is_end_of_data;
 	}
 
-	public function pull( $n, $mode = self::PULL_NO_MORE_THAN ): int {
+	public function pull( ?int $n, string $mode = self::PULL_NO_MORE_THAN ): int {
 		$bytes_pulled = $this->stream->pull( $n, $mode );
 		$this->updateProgress();
 
 		return $bytes_pulled;
 	}
 
-	public function peek( $n ): string {
+	public function peek( int $n ): string {
 		return $this->stream->peek( $n );
 	}
 
-	public function consume( $n ): string {
+	public function consume( int $n ): string {
 		$data = $this->stream->consume( $n );
 		$this->updateProgress();
 

--- a/components/ByteStream/ReadStream/class-basebytereadstream.php
+++ b/components/ByteStream/ReadStream/class-basebytereadstream.php
@@ -70,7 +70,7 @@ abstract class BaseByteReadStream implements ByteReadStream {
 		return $this->expected_length;
 	}
 
-	public function pull( $n = self::CHUNK_SIZE_BYTES, $mode = self::PULL_NO_MORE_THAN ): int {
+	public function pull( ?int $n = self::CHUNK_SIZE_BYTES, string $mode = self::PULL_NO_MORE_THAN ): int {
 		switch ( $mode ) {
 			case self::PULL_NO_MORE_THAN:
 			case self::PULL_EXACTLY:
@@ -154,11 +154,11 @@ abstract class BaseByteReadStream implements ByteReadStream {
 
 	abstract protected function internal_pull( $n ): string;
 
-	public function peek( $n ): string {
+	public function peek( int $n ): string {
 		return substr( $this->buffer, $this->offset_in_current_buffer, $n );
 	}
 
-	public function consume( $n ): string {
+	public function consume( int $n ): string {
 		if ( strlen( $this->buffer ) < $this->offset_in_current_buffer + $n ) {
 			throw new NotEnoughDataException( 'Cannot consume more bytes than available in the buffer.' );
 		}

--- a/components/ByteStream/ReadStream/class-inflatereadstream.php
+++ b/components/ByteStream/ReadStream/class-inflatereadstream.php
@@ -83,12 +83,12 @@ class InflateReadStream extends BaseByteReadStream {
 		return null === $this->inflate_context && $this->upstream->reached_end_of_data();
 	}
 
-	public function seek( $target_offset ): void {
-		if ( null !== $this->length() && $target_offset > $this->length() ) {
+	public function seek( $offset ): void {
+		if ( null !== $this->length() && $offset > $this->length() ) {
 			throw new ByteStreamException( 'Cannot seek past the available data. Call append_bytes() first.' );
 		}
 
-		if ( $target_offset < $this->tell() ) {
+		if ( $offset < $this->tell() ) {
 			$this->upstream->seek( $this->delegate_offset_0 ?? 0 );
 			$this->buffer                   = '';
 			$this->bytes_already_forgotten  = 0;
@@ -97,8 +97,8 @@ class InflateReadStream extends BaseByteReadStream {
 			$this->inflate_init();
 		}
 
-		while ( $this->tell() < $target_offset ) {
-			$remaining_bytes = $target_offset - $this->tell();
+		while ( $this->tell() < $offset ) {
+			$remaining_bytes = $offset - $this->tell();
 			$next_chunk_size = min( 50 * 1024, $remaining_bytes );
 			$pulled          = $this->pull( $next_chunk_size );
 			// Keep skipping bytes until we've consumed enough.

--- a/components/ByteStream/ReadStream/interface-bytereadstream.php
+++ b/components/ByteStream/ReadStream/interface-bytereadstream.php
@@ -52,7 +52,7 @@ interface ByteReadStream {
 	 *
 	 * @return int how many bytes were pulled
 	 */
-	public function pull( int $n, string $mode = self::PULL_NO_MORE_THAN ): int;
+	public function pull( ?int $n, string $mode = self::PULL_NO_MORE_THAN ): int;
 
 	/**
 	 * Get the next $n bytes without advancing the pointer.
@@ -64,7 +64,7 @@ interface ByteReadStream {
 	/**
 	 * Returns $n bytes and advances the pointer.
 	 *
-	 * @param $n
+	 * @param  int $n
 	 *
 	 * @return string
 	 */

--- a/components/ByteStream/ReadStream/interface-bytereadstream.php
+++ b/components/ByteStream/ReadStream/interface-bytereadstream.php
@@ -36,7 +36,7 @@ interface ByteReadStream {
 	 * @return void
 	 * @throws ByteStreamException If the offset is invalid.
 	 */
-	public function seek( int $offset );
+	public function seek( int $offset ): void;
 
 	/**
 	 * Check if the end of the data stream has been reached.
@@ -52,14 +52,14 @@ interface ByteReadStream {
 	 *
 	 * @return int how many bytes were pulled
 	 */
-	public function pull( $n, $mode = self::PULL_NO_MORE_THAN ): int;
+	public function pull( int $n, string $mode = self::PULL_NO_MORE_THAN ): int;
 
 	/**
 	 * Get the next $n bytes without advancing the pointer.
 	 *
 	 * @return string The bytes read.
 	 */
-	public function peek( $n ): string;
+	public function peek( int $n ): string;
 
 	/**
 	 * Returns $n bytes and advances the pointer.
@@ -68,7 +68,7 @@ interface ByteReadStream {
 	 *
 	 * @return string
 	 */
-	public function consume( $n ): string;
+	public function consume( int $n ): string;
 
 	/**
 	 * Returns all remaining bytes in the stream.

--- a/components/HttpClient/ByteStream/class-seekablerequestreadstream.php
+++ b/components/HttpClient/ByteStream/class-seekablerequestreadstream.php
@@ -84,7 +84,7 @@ class SeekableRequestReadStream implements ByteReadStream {
 		return $this->cache->tell();
 	}
 
-	public function seek( int $offset ) {
+	public function seek( int $offset ): void {
 		$this->pipe_until( $offset );
 		$this->cache->seek( $offset );
 	}
@@ -93,19 +93,19 @@ class SeekableRequestReadStream implements ByteReadStream {
 		return $this->remote->reached_end_of_data() && $this->cache->reached_end_of_data();
 	}
 
-	public function pull( $n, $mode = self::PULL_NO_MORE_THAN ): int {
+	public function pull( ?int $n, string $mode = self::PULL_NO_MORE_THAN ): int {
 		$this->pipe_until( $this->tell() + $n );
 
 		return $this->cache->pull( $n, $mode );
 	}
 
-	public function peek( $n ): string {
+	public function peek( int $n ): string {
 		$this->pipe_until( $this->tell() + $n );
 
 		return $this->cache->peek( $n );
 	}
 
-	public function consume( $n ): string {
+	public function consume( int $n ): string {
 		return $this->cache->consume( $n );
 	}
 


### PR DESCRIPTION
This PR:

* Renames `class-bytereadstream.php` to `interface-bytereadstream.php` for consistency – that file holds an interface after all
* Adds a few missing type hints to the interface

cc @brandonpayton 