### PR TITLE
Remove stray full stops from end of lines in inline comments

### DIFF
--- a/components/Blueprints/DataReference/class-datareferenceresolver.php
+++ b/components/Blueprints/DataReference/class-datareferenceresolver.php
@@ -81,9 +81,9 @@ class DataReferenceResolver {
 		return $this->resolved_data_references[ $reference->id ];
 	}
 
-	// @TODO: Clean up the semantics of this class. Resolve() and separate resolve_uncached() seem confusing. There's.
-	// a bunch of implicit behaviors related to caching. Ideally we would either have a self-contained resolution.
-	// method, or co-locate the resolution logic with the data reference classes and only use this class for.
+	// @TODO: Clean up the semantics of this class. Resolve() and separate resolve_uncached() seem confusing. There's
+	// a bunch of implicit behaviors related to caching. Ideally we would either have a self-contained resolution
+	// method, or co-locate the resolution logic with the data reference classes and only use this class for
 	// caching.
 	public function resolve_uncached( DataReference $reference ) {
 		$progress_tracker = $this->sub_trackers[ $reference->id ] ?? new Tracker();
@@ -123,7 +123,7 @@ class DataReferenceResolver {
 				$tracked_stream,
 				$filename
 			);
-			// TODO: Consider a clearer name. Some not-so-great ballpark ideas:.
+			// TODO: Consider a clearer name. Some not-so-great ballpark ideas:
 			// BlueprintParentPath, BlueprintRootPath, BlueprintContextPath, BlueprintRelativePath.
 		} elseif ( $reference instanceof ExecutionContextPath ) {
 			$path = $reference->get_path();

--- a/components/Blueprints/Progress/class-progresstrackedreadstream.php
+++ b/components/Blueprints/Progress/class-progresstrackedreadstream.php
@@ -76,7 +76,7 @@ class ProgressTrackedReadStream implements ByteReadStream {
 
 	public function close_reading(): void {
 		$this->stream->close_reading();
-		// Optionally ensure tracker is set to 100% if not already.
+		// Optionally ensure tracker is set to 100% if not already
 		// This depends on whether closing implies completion.
 		// For now, we rely on consume_all or reaching end of data.
 		// If the stream is closed prematurely, the progress will reflect the last read amount.
@@ -102,7 +102,7 @@ class ProgressTrackedReadStream implements ByteReadStream {
 		}
 
 		$progress = ( $this->stream->tell() / $this->stream_length ) * 100;
-		// It's possible to seek() backwards. Let's make sure we never decrease.
+		// It's possible to seek() backwards. Let's make sure we never decrease
 		// the reported progress.
 		if ( $progress > $this->tracker->getProgress() ) {
 			$this->tracker->set( $progress );

--- a/components/Blueprints/SiteResolver/class-newsiteresolver.php
+++ b/components/Blueprints/SiteResolver/class-newsiteresolver.php
@@ -104,9 +104,9 @@ class NewSiteResolver {
 		}
 
 		// 3. Install WordPress if not installed yet.
-		// Technically, this is a "new site" resolver, but it's entirely possible.
-		// the developer-provided WordPress zip already has a sqlite database with the
-		// a WordPress site installed..
+		// Technically, this is a "new site" resolver, but it's entirely possible
+		// the developer-provided WordPress zip already has a sqlite database with
+		// a WordPress site installed.
 		if ( ! self::is_wordpress_installed( $runtime, $progress ) ) {
 			if ( ! $target_fs->exists( '/wp-config.php' ) ) {
 				if ( $target_fs->exists( 'wp-config-sample.php' ) ) {

--- a/components/Blueprints/SiteResolver/class-newsiteresolver.php
+++ b/components/Blueprints/SiteResolver/class-newsiteresolver.php
@@ -105,7 +105,7 @@ class NewSiteResolver {
 
 		// 3. Install WordPress if not installed yet.
 		// Technically, this is a "new site" resolver, but it's entirely possible.
-		// the developer-provided WordPress zip already has a sqlite database with the.
+		// the developer-provided WordPress zip already has a sqlite database with the
 		// a WordPress site installed..
 		if ( ! self::is_wordpress_installed( $runtime, $progress ) ) {
 			if ( ! $target_fs->exists( '/wp-config.php' ) ) {
@@ -128,7 +128,7 @@ class NewSiteResolver {
 					'install',
 					'--path=' . $runtime->get_configuration()->get_target_site_root(),
 
-					// For Docker compatibility. If we got this far, Blueprint runner was already.
+					// For Docker compatibility. If we got this far, Blueprint runner was already
 					// allowed to run as root.
 					'--allow-root',
 					'--url=' . $runtime->get_configuration()->get_target_site_url(),
@@ -222,7 +222,7 @@ PHP
 				preg_match( '/^\d+\.\d+$/', $version_string ) &&
 				$version_string === $api_version['partial_version']
 			) {
-				// When the Blueprint provides a version like 6.6, we must match on the partial.
+				// When the Blueprint provides a version like 6.6, we must match on the partial
 				// version, e.g. "6.6".
 				return $api_version['download'];
 			}

--- a/components/Blueprints/Steps/class-activatepluginstep.php
+++ b/components/Blueprints/Steps/class-activatepluginstep.php
@@ -9,7 +9,7 @@ use WordPress\Blueprints\Runtime;
  * Represents the 'activatePlugin' step.
  */
 class ActivatePluginStep implements StepInterface {
-	// Inline PHP script to avoid reading a static script.php file via.
+	// Inline PHP script to avoid reading a static script.php file via
 	// file_get_contents() inside the built blueprints.phar file.
 	const ACTIVATE_PLUGIN_SCRIPT = <<<'PHP'
 <?php

--- a/components/Blueprints/Steps/class-activatethemestep.php
+++ b/components/Blueprints/Steps/class-activatethemestep.php
@@ -10,7 +10,7 @@ use WordPress\Blueprints\Runtime;
  */
 class ActivateThemeStep implements StepInterface {
 
-	// Inline PHP script to avoid reading a static script.php file via.
+	// Inline PHP script to avoid reading a static script.php file via
 	// file_get_contents() inside the built blueprints.phar file.
 	const ACTIVATE_THEME_SCRIPT = <<<'PHP'
 <?php

--- a/components/Blueprints/Steps/class-defineconstantsstep.php
+++ b/components/Blueprints/Steps/class-defineconstantsstep.php
@@ -28,7 +28,7 @@ class DefineConstantsStep implements StepInterface {
 	 */
 	public function run( Runtime $runtime, Tracker $tracker ) {
 		$tracker->setCaption( 'Defining wp-config constants' );
-		// Inline PHP script to avoid reading a static script.php file via.
+		// Inline PHP script to avoid reading a static script.php file via
 		// file_get_contents() inside the built blueprints.phar file.
 		$runtime->eval_php_code_in_subprocess(
 			<<<'PHP'
@@ -296,7 +296,7 @@ function rewrite_wp_config_to_define_constants( $content, $constants = array() )
 			continue;
 		}
 
-		// We now have a define() call that defines a constant we're looking for.
+		// We now have a define() call that defines a constant we're looking for
 		// Let's rewrite its value to the one
 		$output = array_merge(
 			$output,

--- a/components/Blueprints/Steps/class-importcontentstep.php
+++ b/components/Blueprints/Steps/class-importcontentstep.php
@@ -89,7 +89,7 @@ PHP
 		foreach ( $this->output_lines( $output ) as $line ) {
 			$data = @json_decode( $line, true );
 			if ( ! is_array( $data ) ) {
-				// Non-JSON output is treated as a crash. We use a dedicated file pipe.
+				// Non-JSON output is treated as a crash. We use a dedicated file pipe
 				// for communication and it should never contain a non-JSON line.
 				$import_process->stop();
 				throw new ProcessFailedException( $import_process );

--- a/components/Blueprints/Steps/class-importmediastep.php
+++ b/components/Blueprints/Steps/class-importmediastep.php
@@ -107,9 +107,9 @@ class ImportMediaStep implements StepInterface {
 				if ( ! $resolved instanceof File ) {
 					// TODO: What if the schema specifies a resource type that can only be resolved to a file?
 					// Then the resolver could throw the error instead of requiring each step to check.
-					// But since the resolve interface can return either a File or Directory,.
+					// But since the resolve interface can return either a File or Directory,
 					// would we have to check anyway?
-					// Would there be any value in the runtime having specific methods like resolveFile().
+					// Would there be any value in the runtime having specific methods like resolveFile()
 					// and resolveDirectory() that throw if they cannot resolve the requested type?
 					throw new RuntimeException( "Failed to resolve media file: $human_readable_name" );
 				}

--- a/components/Blueprints/Steps/class-importthemestartercontentstep.php
+++ b/components/Blueprints/Steps/class-importthemestartercontentstep.php
@@ -23,7 +23,7 @@ class ImportThemeStarterContentStep implements StepInterface {
 
 	public function run( Runtime $runtime, Tracker $tracker ) {
 		$tracker->setCaption( 'Importing theme starter content' . ( $this->theme_slug ? ' for ' . $this->theme_slug : '' ) );
-		// Inline PHP script to avoid reading a static script.php file via.
+		// Inline PHP script to avoid reading a static script.php file via
 		// file_get_contents() inside the built blueprints.phar file.
 		$runtime->eval_php_code_in_subprocess(
 			<<<'PHP'

--- a/components/Blueprints/Steps/class-installthemestep.php
+++ b/components/Blueprints/Steps/class-installthemestep.php
@@ -93,7 +93,7 @@ class InstallThemeStep implements StepInterface {
 
 				$tracker->set( 50 );
 
-				// Inline PHP script to avoid reading a static script.php file via.
+				// Inline PHP script to avoid reading a static script.php file via
 				// file_get_contents() inside the built blueprints.phar file.
 				$output = $runtime->eval_php_code_in_subprocess(
 					<<<'PHP'

--- a/components/Blueprints/Steps/class-wpclistep.php
+++ b/components/Blueprints/Steps/class-wpclistep.php
@@ -44,7 +44,7 @@ class WPCLIStep implements StepInterface {
 			' ',
 			array(
 				$this->wp_cli_path ?? $runtime->get_wp_cli_path(),
-				// For Docker compatibility. If we got this far, the Blueprint runner was already.
+				// For Docker compatibility. If we got this far, the Blueprint runner was already
 				// allowed to run as root.
 				'--allow-root',
 				'--path=' . $runtime->get_configuration()->get_target_site_root(),

--- a/components/Blueprints/Steps/scripts/import-content.php
+++ b/components/Blueprints/Steps/scripts/import-content.php
@@ -610,9 +610,9 @@ function run_content_import( $options ) {
 		$import_session   = ImportSession::create(
 			array(
 				'data_source' => 'local_directory',
-				// @TODO: the phrase "file_name" doesn't make sense here. We're sourcing.
-				// data from a directory, not a file. This string is used to tell.
-				// the user in the UI what this they're importing in this import.
+				// @TODO: the phrase "file_name" doesn't make sense here. We're sourcing
+				// data from a directory, not a file. This string is used to tell
+				// the user in the UI what this they're importing in this import
 				// session. Let's rename it to something more descriptive.
 				'file_name' => $options['source'],
 			)

--- a/components/Blueprints/Validator/class-humanfriendlyschemavalidator.php
+++ b/components/Blueprints/Validator/class-humanfriendlyschemavalidator.php
@@ -651,7 +651,7 @@ final class HumanFriendlySchemaValidator {
 			$missing = array_diff( $schema['required'], array_keys( $arr ) );
 			if ( $missing ) {
 				foreach ( $missing as $m ) {
-					// For missing fields, the error pointer should be to the parent object,.
+					// For missing fields, the error pointer should be to the parent object,
 					// as the field itself doesn't exist yet to point to.
 					$children_errors[] = new ValidationError(
 						$this->convert_path_to_string( $path ), // Error is about the object at $path.

--- a/components/Blueprints/Versions/Version1/class-v1tov2transpiler.php
+++ b/components/Blueprints/Versions/Version1/class-v1tov2transpiler.php
@@ -106,9 +106,9 @@ class V1ToV2Transpiler {
 		}
 
 		// Unsupported fields.
-		// @TODO: Actually transpile a few of them:.
+		// @TODO: Actually transpile a few of them:
 		// * features -> runtimeOptions.playground.features.
-		// -> or consider moving this to runtime configuration – as in.
+		// -> or consider moving this to runtime configuration – as in
 		// permissions to access the network, disk, etc.
 		// * landingPage -> runtimeOptions.landingPage.
 		// * login -> runtimeOptions.login.
@@ -516,7 +516,7 @@ PHP
 						$v2steps[] = $v2step;
 						break;
 					case 'wp-cli':
-						// @TODO: Don't naively replace on the entire command. Actually parse it and only replace at the beginning.
+						// @TODO: Don't naively replace on the entire command. Actually parse it and only replace at the beginning
 						// of each argument value.
 						$cmd       = str_replace( '/wordpress/', '', $v1step['command'] );
 						$cmd       = str_replace( 'wordpress/', '', $cmd );
@@ -583,7 +583,7 @@ PHP
 					}
 					return $url;
 				case 'bundled':
-					// BundledReference – must start with.
+					// BundledReference – must start with
 					// ./ or /.
 					$path = $resource['path'];
 					if ( 0 !== strncmp( $path, './', strlen( './' ) ) && 0 !== strncmp( $path, '/', strlen( '/' ) ) ) {

--- a/components/Blueprints/bin/blueprint.php
+++ b/components/Blueprints/bin/blueprint.php
@@ -452,7 +452,7 @@ function cliArgsToRunnerConfiguration( array $positional_args, array $options ):
 			mkdir( $target_site_root, 0755, true );
 		} elseif ( is_dir( $absolute_target_site_root ) ) {
 			$fs = LocalFilesystem::create( $absolute_target_site_root );
-			// Delete all the files and directories in the target site root, but preserve the.
+			// Delete all the files and directories in the target site root, but preserve the
 			// target directory itself. Why? In Playground CLI, `/wordpress` is likely to be a.
 			// mount removing a mount root throws an Exception.
 			foreach ( $fs->ls( '/' ) as $file ) {

--- a/components/Blueprints/class-runner.php
+++ b/components/Blueprints/class-runner.php
@@ -691,7 +691,7 @@ class Runner {
 			if ( $step instanceof ImportContentStep ) {
 				// if($this->configuration->is_running_as_phar()) {
 				// throw new InvalidArgumentException( '@TODO: Importing content is not supported when running as phar.' );
-				// } else {
+				// } else {.
 					$libraries_phar_path = __DIR__ . '/../../dist/php-toolkit.phar';
 				if ( ! file_exists( $libraries_phar_path ) ) {
 					throw new InvalidArgumentException(

--- a/components/Blueprints/class-runner.php
+++ b/components/Blueprints/class-runner.php
@@ -213,7 +213,7 @@ class Runner {
 
 		try {
 			$progress = $this->main_tracker;
-			// Create all top-level progress stages upfront so the tracker knows what %.
+			// Create all top-level progress stages upfront so the tracker knows what %
 			// of the total work is being done with every progress update.
 			$progress->split(
 				array(
@@ -233,7 +233,7 @@ class Runner {
 			$this->load_blueprint();
 			$this->validate_blueprint();
 			$this->assets->set_execution_context( $this->blueprint_execution_context );
-			// Create the execution plan early on to surface any errors before.
+			// Create the execution plan early on to surface any errors before
 			// making the user wait for any downloads or site resolution.
 			$plan = $this->create_execution_plan();
 			$progress['blueprint']->finish();
@@ -308,8 +308,8 @@ class Runner {
 			return;
 		}
 
-		// AbsoluteLocalPath is a necessary special case to correctly support.
-		// Windows absolute paths. There's so much more to them than C:\.
+		// AbsoluteLocalPath is a necessary special case to correctly support
+		// Windows absolute paths. There's so much more to them than C:\
 		//
 		// See https://www.fileside.app/blog/2023-03-17_windows-file-paths/.
 		if ( $reference instanceof AbsoluteLocalPath ) {
@@ -320,9 +320,9 @@ class Runner {
 			$blueprint_string                  = $resolved->getStream()->consume_all();
 			$this->blueprint_execution_context = LocalFilesystem::create( dirname( $reference->get_path() ) );
 		} else {
-			// For the purposes of Blueprint resolution, the execution context is the.
-			// current working directory. This way, a path such as ./blueprint.json.
-			// will mean "a blueprint.json file in the current working directory" and not.
+			// For the purposes of Blueprint resolution, the execution context is the
+			// current working directory. This way, a path such as ./blueprint.json
+			// will mean "a blueprint.json file in the current working directory" and not
 			// "a ./blueprint.json path without a point of reference".
 			$this->assets->set_execution_context( LocalFilesystem::create( getcwd() ) );
 			$resolved = $this->assets->resolve( $reference );
@@ -353,13 +353,13 @@ class Runner {
 					// JSON file.
 					$blueprint_string = $stream->consume_all();
 					if ( $reference instanceof URLReference ) {
-						// @TODO: Only display this if the Blueprint references any bundled files. And in that case,.
+						// @TODO: Only display this if the Blueprint references any bundled files. And in that case,
 						// make it a fatal error.
 						$this->configuration->get_logger()->warning( 'Blueprints loaded from remote URLs have no execution context.' );
 						$this->blueprint_execution_context = InMemoryFilesystem::create();
 					} elseif ( $reference instanceof ExecutionContextPath ) {
-						// It was resolved as an ExecutionContextPath, but it's actually a local.
-						// filesystem path at this point.
+						// It was resolved as an ExecutionContextPath, but it's actually a local
+						// filesystem path at this point
 						// The execution context is the directory containing the blueprint.json file.
 						$this->blueprint_execution_context = LocalFilesystem::create( dirname( $reference->get_path() ) );
 					} elseif ( $reference instanceof InlineFile ) {
@@ -498,9 +498,9 @@ class Runner {
 						throw new BlueprintExecutionException( 'Invalid WordPress version string in wordpressVersion.min: ' . $wp_version['min'] );
 					}
 				}
-				// Latest version is implicitly the default and it's only for resolving.
-				// the WordPress version to install. It's not used for version checks on.
-				// existing sites and VersionConstraint doesn't support it. It doesn't have.
+				// Latest version is implicitly the default and it's only for resolving
+				// the WordPress version to install. It's not used for version checks on
+				// existing sites and VersionConstraint doesn't support it. It doesn't have
 				// enough information anyway – the meaning of "latest" changes over time.
 				if ( isset( $wp_version['max'] ) && 'latest' !== $wp_version['max'] ) {
 					$this->recommended_wp_version = $wp_version['max'];
@@ -525,8 +525,8 @@ class Runner {
 			if ( ! empty( $wp_constraint_errors ) ) {
 				throw new BlueprintExecutionException( 'Invalid WordPress version constraint: ' . implode( '; ', $wp_constraint_errors ) );
 			}
-			// Note: In here's we're only checking if the version constraint is defined.
-			// correctly. The actual version check for WordPress is done in.
+			// Note: In here's we're only checking if the version constraint is defined
+			// correctly. The actual version check for WordPress is done in
 			// NewSiteResolver and ExistingSiteResolver.
 		}
 
@@ -686,12 +686,12 @@ class Runner {
 		}
 
 		foreach ( $plan as $step ) {
-			// @TODO: Make sure this doesn't get included twice in the execution plan,.
+			// @TODO: Make sure this doesn't get included twice in the execution plan,
 			// e.g. if the Blueprint specified this step manually.
 			if ( $step instanceof ImportContentStep ) {
-				// if($this->configuration->is_running_as_phar()) {.
-				// throw new InvalidArgumentException( '@TODO: Importing content is not supported when running as phar.' );.
-				// } else {.
+				// if($this->configuration->is_running_as_phar()) {
+				// throw new InvalidArgumentException( '@TODO: Importing content is not supported when running as phar.' );
+				// } else {
 					$libraries_phar_path = __DIR__ . '/../../dist/php-toolkit.phar';
 				if ( ! file_exists( $libraries_phar_path ) ) {
 					throw new InvalidArgumentException(
@@ -1122,7 +1122,7 @@ PHP
 				// Determine if we should continue or stop execution.
 				$continue_on_error = $this->continue_on_error ?? false;
 				if ( ! $continue_on_error ) {
-					// @TODO: Correlate this message with the original Blueprint,.
+					// @TODO: Correlate this message with the original Blueprint,
 					// as in – was the step created because of "installPlugin" or not?
 					// Which entry of it? etc.
 					throw new BlueprintExecutionException(

--- a/components/Blueprints/class-runtime.php
+++ b/components/Blueprints/class-runtime.php
@@ -236,7 +236,7 @@ class Runtime {
 				// @TODO: Cleaning up the temporary directory is not done here.
 				$temp_dir = $this->create_temporary_directory();
 
-				// Still put the script in a temporary file as the path may be refering.
+				// Still put the script in a temporary file as the path may be refering
 				// to a file inside the currently executed .phar archive.
 				$actual_script_path = wp_join_unix_paths( $temp_dir, 'script.php' );
 				$code               = '<?php function append_output( $output ) { file_put_contents( getenv("OUTPUT_FILE"), $output, FILE_APPEND ); } $_SERVER["HTTP_HOST"] = "localhost"; ?>';

--- a/components/ByteStream/class-memorypipe.php
+++ b/components/ByteStream/class-memorypipe.php
@@ -16,7 +16,7 @@ class MemoryPipe extends BaseByteReadStream implements ByteWriteStream {
 		if ( null !== $bytes ) {
 			$this->buffer          = $bytes;
 			$this->expected_length = strlen( $bytes );
-			// If we have a full buffer, it's already in memory and we don't need.
+			// If we have a full buffer, it's already in memory and we don't need
 			// to clean up old data as we stream it.
 			// If we did clean up old data, we would lose the ability to seek() to.
 			// the beginning of the buffer.

--- a/components/CORSProxy/cors-proxy.php
+++ b/components/CORSProxy/cors-proxy.php
@@ -99,14 +99,14 @@ $relay_http_code_and_initial_headers_if_not_already_sent = function () use ( $ch
 
 function send_response_chunk( $data ) {
 	if ( should_send_as_chunked_response() ) {
-		// We need to manually chunk the response when running in the PHP.
+		// We need to manually chunk the response when running in the PHP
 		// built-in server. It won't handle that for us.
 		printf( "%s\r\n%s\r\n", dechex( strlen( $data ) ), $data );
 	} else {
-		// When running behing an Apache or Nginx or another webserver,.
-		// it will handle the chunking for us. Manually sending the chunk.
-		// header, \r\n separator, body, and \r\n trailer isn't just.
-		// unnecessary, but it would actually include those bytes in the.
+		// When running behing an Apache or Nginx or another webserver,
+		// it will handle the chunking for us. Manually sending the chunk
+		// header, \r\n separator, body, and \r\n trailer isn't just
+		// unnecessary, but it would actually include those bytes in the
 		// response body.
 		echo $data;
 	}
@@ -146,7 +146,7 @@ $strictly_disallowed_headers = array(
 );
 $headers_requiring_opt_in    = array(
 	// Allow Authorization header to be forwarded only if the client.
-	// explicitly opts in to avoid undesirable situations such as:.
+	// explicitly opts in to avoid undesirable situations such as:
 	// - a browser auto-sending basic auth with every proxy request.
 	// - the proxy forwarding the basic auth values to all target servers.
 	'Authorization',
@@ -165,7 +165,7 @@ curl_setopt(
 		$curl_headers,
 		array(
 			"Host: $host",
-			// @TODO: Consider relaying client IP with the following reasoning:.
+			// @TODO: Consider relaying client IP with the following reasoning:
 			// Let's not take full credit for the proxied request.
 			// This is a CORS proxy, not an IP anonymizer.
 			// NOTE: We cannot do this reliably based on X-Forwarded-For unless.
@@ -229,14 +229,14 @@ curl_setopt(
 			);
 			header( 'Location: ' . $new_location, true );
 		} elseif (
-			// Safari fails with "Cannot connect to the server" if we let.
-			// the HTTP/2 line be relayed. This proxy doesn't support HTTP/2,.
+			// Safari fails with "Cannot connect to the server" if we let
+			// the HTTP/2 line be relayed. This proxy doesn't support HTTP/2,
 			// so let's not allow the HTTP line to explicitly pass through.
 			// PHP already provides the HTTP version in the response code anyway.
 			0 !== stripos( $header, 'HTTP/' ) &&
 			// The proxy server does not support relaying auth challenges.
-			// Specifically, we want to avoid browsers prompting for basic auth.
-			// credentials which they will send to the proxy server for the.
+			// Specifically, we want to avoid browsers prompting for basic auth
+			// credentials which they will send to the proxy server for the
 			// remainder of the session.
 			0 !== stripos( $header, 'Set-Cookie:' ) &&
 			0 !== stripos( $header, 'Authorization:' ) &&

--- a/components/DataLiberation/BlockMarkup/class-blockmarkupprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupprocessor.php
@@ -385,7 +385,7 @@ class BlockMarkupProcessor extends WP_HTML_Tag_Processor {
 				return true;
 			}
 
-			// The rest of the comment can only consist of block attributes.
+			// The rest of the comment can only consist of block attributes
 			// and an optional solidus character.
 			$rest = ltrim( substr( $text, $at ) );
 			$at   = strlen( $text );
@@ -402,7 +402,7 @@ class BlockMarkupProcessor extends WP_HTML_Tag_Processor {
 			if ( strlen( $json_maybe ) > 0 ) {
 				$attributes = json_decode( trim( $json_maybe ), true );
 				if ( null === $attributes || ! is_array( $attributes ) ) {
-					// This comment looked like a block comment, but the attributes didn't.
+					// This comment looked like a block comment, but the attributes didn't
 					// parse as a JSON array. This means it wasn't a block after all.
 					$this->last_block_error = new WP_Block_Parser_Error(
 						sprintf( '%s could be parsed as a delimiter but JSON attributes were malformed: %s.', $name, $json_maybe ),
@@ -414,8 +414,8 @@ class BlockMarkupProcessor extends WP_HTML_Tag_Processor {
 			}
 		}
 
-		// We have a block name and a valid attributes array. We may not find a block.
-		// closer, but let's assume is a block and process it as such.
+		// We have a block name and a valid attributes array. We may not find a block
+		// closer, but let's assume is a block and process it as such
 		// @TODO: Confirm that WordPress block parser would have parsed this as a block.
 		$this->block_name       = $name;
 		$this->block_attributes = $attributes;

--- a/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
@@ -69,7 +69,7 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		$this->parsed_url                 = null;
 		$this->inspecting_html_attributes = null;
 		$this->url_in_text_processor      = null;
-		// Do not reset url_in_text_node_updated – it's reset in get_updated_html() which.
+		// Do not reset url_in_text_node_updated – it's reset in get_updated_html() which
 		// is called in parent::next_token().
 
 		return parent::next_token();
@@ -300,7 +300,7 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			$new_raw_url = rtrim( $new_raw_url, '/' );
 		}
 		if ( ! $new_raw_url ) {
-			// @TODO: When does this happen? Let's add the test coverage and.
+			// @TODO: When does this happen? Let's add the test coverage and
 			// doubly verify the logic.
 			return false;
 		}

--- a/components/DataLiberation/DataFormatConsumer/class-markupprocessorconsumer.php
+++ b/components/DataLiberation/DataFormatConsumer/class-markupprocessorconsumer.php
@@ -179,7 +179,7 @@ class MarkupProcessorConsumer implements DataFormatConsumer {
 					$this->block_markup .= '<' . $tag_lowercase . '  class="wp-block-code">';
 					break;
 				case 'CODE':
-					// Guess whether this is:.
+					// Guess whether this is:
 					// * An inline <code> element? Let's convert it into a formatting element.
 					// * A block <code> element? Let's convert it into a block.
 					if ( $this->is_at_inline_code_element() ) {
@@ -237,7 +237,7 @@ class MarkupProcessorConsumer implements DataFormatConsumer {
 				case 'SCRIPT':
 					$this->ignore_text = false;
 					break;
-				// Maintain the same lists as in the tag opener code branch above,.
+				// Maintain the same lists as in the tag opener code branch above,
 				// otherwise we won't pop the correct block.
 
 				// Block elements.

--- a/components/DataLiberation/EntityReader/class-blockswithmetadataentityreader.php
+++ b/components/DataLiberation/EntityReader/class-blockswithmetadataentityreader.php
@@ -61,7 +61,7 @@ class BlocksWithMetadataEntityReader implements EntityReader {
 		$post_fields['post_content']    = $this->block_markup;
 		$post_fields['parsed_metadata'] = $all_metadata;
 
-		// In Markdown, the frontmatter title can be a worse title candidate than.
+		// In Markdown, the frontmatter title can be a worse title candidate than
 		// the first H1 block. In block markup exports, it will be the opposite.
 		//
 		// @TODO: Enable the API consumer to customize the title resolution.

--- a/components/DataLiberation/EntityReader/class-filesystementityreader.php
+++ b/components/DataLiberation/EntityReader/class-filesystementityreader.php
@@ -293,7 +293,7 @@ class FilesystemEntityReader implements EntityReader {
 						$metadata['post_mime_type'] = $filetype;
 						$metadata['post_status']    = 'inherit';
 						$metadata['post_title']     = ImportUtils::slug_to_title( basename( $post_tree_node['local_file_path'] ) );
-						// The importer will use the same Filesystem instance to.
+						// The importer will use the same Filesystem instance to
 						// source the attachment.
 						$metadata['attachment_url'] = 'file://' . $post_tree_node['local_file_path'];
 						$result                     = new BlocksWithMetadata( '', array() );
@@ -365,14 +365,14 @@ class FilesystemEntityReader implements EntityReader {
 				if ( null === $parent_id && $depth > 1 ) {
 					// There's no parent ID even though we're a few levels deep.
 					// This is a scenario where `next_file()` skipped a few levels.
-					// of directories with no relevant content in them:.
+					// of directories with no relevant content in them:
 					//
-					// - /docs/.
-					// - /foo/.
-					// - /bar/.
-					// - /baz.md.
+					// - /docs/
+					// - /foo/
+					// - /bar/
+					// - /baz.md
 					//
-					// In this case, we need to backtrack and create the missing.
+					// In this case, we need to backtrack and create the missing
 					// parent pages for /bar/ and /foo/.
 
 					// Find the topmost missing parent ID.
@@ -397,7 +397,7 @@ class FilesystemEntityReader implements EntityReader {
 				} elseif ( false === $this->pending_directory_index ) {
 					// No directory index candidate found in the current directory.
 					if ( 0 === $depth && isset( $this->parent_ids[- 1] ) && $parent_id === $this->parent_ids[- 1] ) {
-						// We're at the root directory and we have a root parent ID. Let's.
+						// We're at the root directory and we have a root parent ID. Let's
 						// reuse that as the top-level parent.
 						$this->parent_ids[ $depth ] = $this->parent_ids[- 1];
 						// We're no longer looking for a directory index.
@@ -465,7 +465,7 @@ class FilesystemEntityReader implements EntityReader {
 			$event = $this->file_visitor->get_event();
 
 			if ( $event->is_exiting() ) {
-				// Clean up stale IDs to save some memory when processing.
+				// Clean up stale IDs to save some memory when processing
 				// large directory trees.
 				unset( $this->parent_ids[ $event->dir ] );
 				continue;
@@ -478,8 +478,8 @@ class FilesystemEntityReader implements EntityReader {
 				}
 				$this->pending_files = array();
 				foreach ( $abs_paths as $path ) {
-					// Add all the subdirectory into the pending files list – there's.
-					// a chance the directory wouldn't match the filter pattern, but.
+					// Add all the subdirectory into the pending files list – there's
+					// a chance the directory wouldn't match the filter pattern, but
 					// a descendant file might.
 					if ( $this->fs->is_dir( $path ) ) {
 						$this->pending_files[] = $path;
@@ -491,19 +491,19 @@ class FilesystemEntityReader implements EntityReader {
 					}
 				}
 				if ( ! count( $this->pending_files ) ) {
-					// Only consider directories with relevant files in them.
-					// Otherwise we'll create fake pages for media directories.
+					// Only consider directories with relevant files in them
+					// Otherwise we'll create fake pages for media directories
 					// and other directories that don't contain any content.
 					//
-					// One corner case is when there's a few levels of directories.
-					// with a single relevant file at the bottom:.
+					// One corner case is when there's a few levels of directories
+					// with a single relevant file at the bottom:
 					//
-					// - /docs/.
-					// - /foo/.
-					// - /bar/.
-					// - /baz.md.
+					// - /docs/
+					// - /foo/
+					// - /bar/
+					// - /baz.md
 					//
-					// In this case, `next_entity()` will backtrack at baz.md and.
+					// In this case, `next_entity()` will backtrack at baz.md and
 					// create the missing parent pages.
 					continue;
 				}

--- a/components/DataLiberation/EntityReader/class-wxrentityreader.php
+++ b/components/DataLiberation/EntityReader/class-wxrentityreader.php
@@ -278,7 +278,7 @@ class WXREntityReader implements EntityReader {
 			$reader->connect_upstream( $upstream );
 			if ( null !== $cursor ) {
 				if ( ! isset( $cursor['upstream'] ) ) {
-					// No upstream cursor means we've processed the.
+					// No upstream cursor means we've processed the
 					// entire input stream.
 					$xml->input_finished();
 					$xml->next_token();
@@ -307,15 +307,15 @@ class WXREntityReader implements EntityReader {
 			return;
 		}
 
-		// Every XML element is a combination of a long-form namespace and a.
-		// local element name, e.g. a syntax <wp:post_id> could actually refer.
+		// Every XML element is a combination of a long-form namespace and a
+		// local element name, e.g. a syntax <wp:post_id> could actually refer
 		// to a (https://wordpress.org/export/1.0/, post_id) element.
 		//
-		// Namespaces are paramount for parsing XML and cannot be ignored. Elements.
+		// Namespaces are paramount for parsing XML and cannot be ignored. Elements
 		// element must be matched based on both their namespace and local name.
 		//
 		// Unfortunately, different WXR files defined the `wp` namespace in a different way.
-		// Folks use a mixture of HTTP vs HTTPS protocols and version numbers. We must.
+		// Folks use a mixture of HTTP vs HTTPS protocols and version numbers. We must
 		// account for all possible options to parse these documents correctly.
 		$wxr_namespaces       = array(
 			'http://wordpress.org/export/1.0/',
@@ -596,7 +596,7 @@ class WXREntityReader implements EntityReader {
 			if ( $this->read_next_entity() ) {
 				return true;
 			}
-			// If the read failed because of incomplete input data,.
+			// If the read failed because of incomplete input data,
 			// try pulling more bytes from upstream before giving up.
 			if ( $this->is_paused_at_incomplete_input() ) {
 				if ( $this->pull_upstream_bytes() ) {
@@ -710,7 +710,7 @@ class WXREntityReader implements EntityReader {
 					return true;
 				}
 				$this->after_entity();
-				// Only tag openers indicate a new entity. Closers just mean.
+				// Only tag openers indicate a new entity. Closers just mean
 				// the previous entity is finished.
 				if ( $this->xml->is_tag_opener() ) {
 					$this->set_entity_tag( $tag_with_namespace );

--- a/components/DataLiberation/Importer/class-attachmentdownloader.php
+++ b/components/DataLiberation/Importer/class-attachmentdownloader.php
@@ -175,7 +175,7 @@ class AttachmentDownloader {
 				continue;
 			}
 
-			// The request object we get from the client may be a redirect.
+			// The request object we get from the client may be a redirect
 			// Let's keep referring to the original request.
 			$original_url        = $request->original_request()->url;
 			$original_request_id = $request->original_request()->id;

--- a/components/DataLiberation/Importer/class-entityimporter.php
+++ b/components/DataLiberation/Importer/class-entityimporter.php
@@ -729,7 +729,7 @@ class EntityImporter {
 	// $tt_ids = wp_set_post_terms( $post_id, $ids, $tax );
 	// do_action( 'wp_import_set_post_terms', $tt_ids, $ids, $tax, $post_id, $data );
 	// }
-	// }
+	// }.
 
 	/**
 	 * Attempt to create a new menu item from import data

--- a/components/DataLiberation/Importer/class-entityimporter.php
+++ b/components/DataLiberation/Importer/class-entityimporter.php
@@ -708,28 +708,28 @@ class EntityImporter {
 		return $id;
 	}
 
-	// @TOOD handle terms.
+	// @TOOD handle terms
 	// $terms = apply_filters( 'wp_import_post_terms', $terms, $post_id, $data );.
 
-	// if ( ! empty( $terms ) ) {.
-	// $term_ids = array();.
-	// foreach ( $terms as $term ) {.
-	// $taxonomy = $term['taxonomy'];.
+	// if ( ! empty( $terms ) ) {
+	// $term_ids = array();
+	// foreach ( $terms as $term ) {
+	// $taxonomy = $term['taxonomy'];
 	// $key = sha1( $taxonomy . ':' . $term['slug'] );.
 
-	// if ( isset( $this->mapping['term'][ $key ] ) ) {.
-	// $term_ids[ $taxonomy ][] = (int) $this->mapping['term'][ $key ];.
-	// } else {.
-	// $meta[] = array( 'meta_key' => '_wxr_import_term', 'meta_value' => $term );.
-	// $requires_remapping = true;.
-	// }.
+	// if ( isset( $this->mapping['term'][ $key ] ) ) {
+	// $term_ids[ $taxonomy ][] = (int) $this->mapping['term'][ $key ];
+	// } else {
+	// $meta[] = array( 'meta_key' => '_wxr_import_term', 'meta_value' => $term );
+	// $requires_remapping = true;
+	// }
 	// }.
 
-	// foreach ( $term_ids as $tax => $ids ) {.
-	// $tt_ids = wp_set_post_terms( $post_id, $ids, $tax );.
-	// do_action( 'wp_import_set_post_terms', $tt_ids, $ids, $tax, $post_id, $data );.
-	// }.
-	// }.
+	// foreach ( $term_ids as $tax => $ids ) {
+	// $tt_ids = wp_set_post_terms( $post_id, $ids, $tax );
+	// do_action( 'wp_import_set_post_terms', $tt_ids, $ids, $tax, $post_id, $data );
+	// }
+	// }
 
 	/**
 	 * Attempt to create a new menu item from import data
@@ -807,7 +807,7 @@ class EntityImporter {
 			throw new DataLiberationException( 'attachment_processing_error', esc_html__( 'File does not exist', 'wordpress-importer' ) );
 		}
 
-		// try to use _wp_attached file for upload folder placement to ensure the same location as the export site.
+		// Try to use _wp_attached file for upload folder placement to ensure the same location as the export site
 		// e.g. location is 2003/05/image.jpg but the attachment post_date is 2010/09, see media_handle_upload().
 		$post['upload_date'] = $post['post_date'];
 		foreach ( $meta as $meta_item ) {
@@ -877,11 +877,11 @@ class EntityImporter {
 		// @TODO: Check for attachment creation errors.
 		// @TODO: Make it work with Asyncify.
 		// Generate and update attachment metadata.
-		// if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {.
-		// include( ABSPATH . 'wp-admin/includes/image.php' );.
-		// }.
-		// $attach_data = wp_generate_attachment_metadata($attach_id, $filepath);.
-		// wp_update_attachment_metadata($attach_id, $attach_data);.
+		// if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+		// include( ABSPATH . 'wp-admin/includes/image.php' );
+		// }
+		// $attach_data = wp_generate_attachment_metadata($attach_id, $filepath);
+		// wp_update_attachment_metadata($attach_id, $attach_data);
 		return $attach_id;
 	}
 

--- a/components/DataLiberation/Importer/class-importsession.php
+++ b/components/DataLiberation/Importer/class-importsession.php
@@ -146,8 +146,8 @@ class ImportSession {
 				'meta_query'     => array(
 					// @TODO: This somehow makes $post empty.
 					// array(.
-					// 'key' => 'current_stage',.
-					// 'value' => WP_Stream_Importer::STAGE_FINISHED,.
+					// 'key' => 'current_stage',
+					// 'value' => WP_Stream_Importer::STAGE_FINISHED,
 					// 'compare' => '!='.
 					// ).
 				),
@@ -336,7 +336,7 @@ class ImportSession {
 			array( 'post_status' => self::FRONTLOAD_STATUS_IGNORED ),
 			array(
 				'post_type' => 'frontloading_stub',
-				// 'post_status !=' => self::FRONTLOAD_STATUS_SUCCEEDED,.
+				// 'post_status !=' => self::FRONTLOAD_STATUS_SUCCEEDED,
 			)
 		);
 	}

--- a/components/DataLiberation/Importer/class-streamimporter.php
+++ b/components/DataLiberation/Importer/class-streamimporter.php
@@ -306,8 +306,8 @@ class StreamImporter {
 
 	protected static function parse_options( $options ) {
 		if ( ! isset( $options['source_site_url'] ) ) {
-			// @TODO: Throw only if source_site_url is not set by the time we're processing the first encountered URL.
-			// throw new DataLiberationException( 'The "source_site_url" option is required' );.
+			// @TODO: Throw only if source_site_url is not set by the time we're processing the first encountered URL
+			// throw new DataLiberationException( 'The "source_site_url" option is required' );
 		}
 		if ( ! isset( $options['new_site_content_root_url'] ) ) {
 			if ( ! function_exists( 'get_site_url' ) ) {
@@ -390,7 +390,7 @@ class StreamImporter {
 
 				return false;
 			case self::STAGE_TOPOLOGICAL_SORT:
-				// @TODO: Different modes:.
+				// @TODO: Different modes:
 				// 1. skip, reprocess.
 				// 2. sort topologically.
 				$this->next_stage = self::STAGE_FRONTLOAD_ASSETS;
@@ -533,8 +533,8 @@ class StreamImporter {
 								continue;
 							}
 							// @TODO: Consider using sha1 hashes to prevent huge URLs from blowing up the memory.
-							// @TODO: Use a consistent identifier for tracking download progress. Unfortunately,.
-							// $p->get_raw_url() does not line up with the resolved URL later on. The progress.
+							// @TODO: Use a consistent identifier for tracking download progress. Unfortunately,
+							// $p->get_raw_url() does not line up with the resolved URL later on. The progress
 							// events are emited with the full, resolved URL.
 							$this->indexed_assets_urls[ $p->get_parsed_url() . '' ] = true;
 						}
@@ -987,7 +987,7 @@ class StreamImporter {
 		if ( false !== $parsed_url ) {
 			$pathname = $parsed_url->pathname;
 		} else {
-			// Assume $raw_asset_url is a relative path when it cannot be.
+			// Assume $raw_asset_url is a relative path when it cannot be
 			// parsed as an absolute URL.
 			$pathname = $raw_asset_url;
 		}

--- a/components/Filesystem/functions.php
+++ b/components/Filesystem/functions.php
@@ -126,8 +126,8 @@ function pipe_stream( $from_stream, $to_stream, $chunk_size = 65536 ) {
 	}
 
 	if ( 0 === $chunks_written ) {
-		// Make sure the file receives at least one chunk.
-		// so we can be sure it gets created in case the.
+		// Make sure the file receives at least one chunk
+		// so we can be sure it gets created in case the
 		// destination filesystem is lazy.
 		$to_stream->append_bytes( '' );
 		$chunks_written = 1;

--- a/components/Git/Protocol/Parser/class-deltaresolver.php
+++ b/components/Git/Protocol/Parser/class-deltaresolver.php
@@ -65,7 +65,7 @@ class DeltaResolver {
 
 			return true;
 		} catch ( NotEnoughDataException $e ) {
-			// @TODO: Refactor GitProtocolReader to provide a ByteProducer we can pull from instead of.
+			// @TODO: Refactor GitProtocolReader to provide a ByteProducer we can pull from instead of
 			// a fixed MemoryPipe.
 			$this->delta_reader->seek( $position );
 			$this->paused_on_incomplete_input = true;

--- a/components/Git/Protocol/Parser/class-gitprotocoldecoder.php
+++ b/components/Git/Protocol/Parser/class-gitprotocoldecoder.php
@@ -126,8 +126,8 @@ class GitProtocolDecoder {
 			}
 		}
 
-		// Process the demultiplexed packets. Accumulate the body.
-		// of all non-PACK packets for simplicity. They're unlikely.
+		// Process the demultiplexed packets. Accumulate the body
+		// of all non-PACK packets for simplicity. They're unlikely
 		// to be large and it's easier to handle them as fully-loaded.
 		// strings.
 		while ( $this->packet_parser->next_token() ) {

--- a/components/Git/Protocol/Parser/class-packparser.php
+++ b/components/Git/Protocol/Parser/class-packparser.php
@@ -493,11 +493,11 @@ class PackParser {
 			'offset'            => $header_offset,
 		);
 
-		// Deltas also have a reference to the original object.
+		// Deltas also have a reference to the original object
 		// before the object body starts.
 		if ( self::OBJECT_TYPE_OFS_DELTA === $type ) {
-			// Git uses a specific formula: ofs = ((ofs + 1) << 7) + (c & 0x7f).
-			// for each continuation byte. The first byte doesn't do the "ofs+1" part.
+			// Git uses a specific formula: ofs = ((ofs + 1) << 7) + (c & 0x7f)
+			// for each continuation byte. The first byte doesn't do the "ofs+1" part
 			// This code matches Git’s logic.
 			$offset = 0;
 

--- a/components/Git/Protocol/Parser/class-protocoldemultiplexer.php
+++ b/components/Git/Protocol/Parser/class-protocoldemultiplexer.php
@@ -106,11 +106,11 @@ class ProtocolDemultiplexer {
 		$chunk             = $this->upstream->consume( $length );
 		$this->stream_code = $stream_code;
 		if ( 'unknown' === $this->stream_code ) {
-			// $chunk is not actually multiplexed so we need to relay.
+			// $chunk is not actually multiplexed so we need to relay
 			// all the data we've read so far to the consumer.
 			$this->chunk = $length_hex . $chunk;
 		} else {
-			// $chunk is multiplexed and the downstream consumer.
+			// $chunk is multiplexed and the downstream consumer
 			// only expects the wrapped data.
 			$this->chunk = $chunk;
 		}

--- a/components/Git/class-gitendpoint.php
+++ b/components/Git/class-gitendpoint.php
@@ -86,7 +86,7 @@ class GitEndpoint {
 		}
 		$git_response->close_writing();
 
-		// @TODO: Simplify this with a method such as pipe_to() or.
+		// @TODO: Simplify this with a method such as pipe_to() or
 		// a pulling class such as GitHttpResponse.
 		while ( true ) {
 			$available = $git_response->pull( 65536 );
@@ -292,8 +292,8 @@ class GitEndpoint {
 		$objects_to_send = array();
 		$acks            = array();
 		foreach ( $parsed['arguments']['want'] as $want_hash ) {
-			// For all the requested non-shallow commits, find.
-			// most recent parent commit the client we have in.
+			// For all the requested non-shallow commits, find
+			// most recent parent commit the client we have in
 			// common with the client.
 			$common_parent_hash = Commit::NULL_HASH;
 			$commit_hash        = $want_hash;
@@ -301,7 +301,7 @@ class GitEndpoint {
 				$reader            = $this->repository->read_object( $commit_hash );
 				$objects_to_send[] = $commit_hash;
 				if ( 'commit' !== $reader->get_object_type_name() ) {
-					// Just send non-commit objects as they are. It would be lovely to.
+					// Just send non-commit objects as they are. It would be lovely to
 					// delta-compress them in the future.
 					continue 2;
 				}

--- a/components/Git/class-gitfilesystem.php
+++ b/components/Git/class-gitfilesystem.php
@@ -133,7 +133,7 @@ class GitFilesystem implements Filesystem {
 		if ( ! $this->is_dir( $path ) ) {
 			return false;
 		}
-		// There are no empty directories in Git. We're assuming.
+		// There are no empty directories in Git. We're assuming
 		// there are always files in the directory.
 		if ( ! $options['recursive'] ) {
 			return false;

--- a/components/Git/class-gitremote.php
+++ b/components/Git/class-gitremote.php
@@ -404,13 +404,13 @@ class GitRemote {
 						// @TODO: Find an exact solution instead of handwaving.
 						'count'       => 100,
 
-						// Just get as many parents as we have. Don't enforce having.
+						// Just get as many parents as we have. Don't enforce having
 						// exactly 100 hashes available.
 						'on_missing'  => 'return-early',
 					)
 				),
 				// Only fetch the commits. Ignore any associated trees and blobs.
-				// We're answering a question about a common ancestor in the commit.
+				// We're answering a question about a common ancestor in the commit
 				// graph. We don't need all the extra downloads to do that.
 				'filter'    => 'tree:0',
 			)
@@ -429,11 +429,11 @@ class GitRemote {
 		$this->git_upload_pack(
 			array(
 				'want_refs' => array( $remote_commit_hash ),
-				// Don't advertise we have any related commits available. This way the remote.
+				// Don't advertise we have any related commits available. This way the remote
 				// will send all the ancestor commits of $remote_commit_hash.
 				'have_refs' => array(),
 				// Only fetch the commits. Ignore any associated trees and blobs.
-				// We're answering a question about a common ancestor in the commit.
+				// We're answering a question about a common ancestor in the commit
 				// graph. We don't need all the extra downloads to do that.
 				'filter'    => 'tree:0',
 			)

--- a/components/Git/class-gitrepository.php
+++ b/components/Git/class-gitrepository.php
@@ -868,7 +868,7 @@ class GitRepository {
 		// Find the parent of the squashed range.
 		$new_base_oid = $this->read_object( $squash_until_ancestor_oid )->as_commit()->get_first_parent_hash();
 
-		// Reparent the commits from HEAD until $squash_into_commit_oid onto the parent.
+		// Reparent the commits from HEAD until $squash_into_commit_oid onto the parent
 		// of the squashed range.
 		$new_head = $this->reparent_commit_range(
 			$this->get_branch_tip( 'HEAD' ),

--- a/components/HttpClient/ByteStream/class-requestreadstream.php
+++ b/components/HttpClient/ByteStream/class-requestreadstream.php
@@ -172,7 +172,7 @@ class RequestReadStream extends BaseByteReadStream {
 
 					return '';
 				case Client::EVENT_FAILED:
-					// TODO: Think through error handling. Errors are expected when working with.
+					// TODO: Think through error handling. Errors are expected when working with
 					// the network. Should we auto retry? Make it easy for the caller to retry?
 					// Something else?
 					throw new ByteStreamException( 'HTTP request failed: ' . $this->client->get_request()->error );

--- a/components/HttpClient/Middleware/class-httpmiddleware.php
+++ b/components/HttpClient/Middleware/class-httpmiddleware.php
@@ -133,9 +133,9 @@ class HttpMiddleware implements MiddlewareInterface {
 							break;
 						case Client::EVENT_FAILED:
 						case Client::EVENT_FINISHED:
-							// We don't need the response buffer anymore. It's.
-							// safe to clean up the connection object now. The.
-							// HTTP resource have been closed by now via the.
+							// We don't need the response buffer anymore. It's
+							// safe to clean up the connection object now. The
+							// HTTP resource have been closed by now via the
 							// close_connection() method.
 							unset( $this->state->connections[ $request_id ] );
 							break;
@@ -146,8 +146,8 @@ class HttpMiddleware implements MiddlewareInterface {
 			}
 
 			// After we've checked for any available events, see if we've run out of time.
-			// This way, we always return any events that were ready before worrying about the timeout.
-			// If we checked the timeout first, we might miss events that were already waiting for us.
+			// This way, we always return any events that were ready before worrying about the timeout
+			// If we checked the timeout first, we might miss events that were already waiting for us
 			// when the timeout is set to zero.
 			$time_elapsed_ms = ( microtime( true ) - $start_time ) * 1000;
 			if ( $timeout_ms && $time_elapsed_ms >= $timeout_ms ) {

--- a/components/HttpClient/Transport/class-curltransport.php
+++ b/components/HttpClient/Transport/class-curltransport.php
@@ -161,7 +161,7 @@ class CurlTransport implements TransportInterface {
 				CURLOPT_READFUNCTION,
 				function ( $ch, $fp, $length ) use ( $request ) {
 					$stream = $request->upload_body_stream;
-					// Pull at most $length bytes until we either get some bytes.
+					// Pull at most $length bytes until we either get some bytes
 					// or we reach the end of the stream.
 					while ( ! $stream->reached_end_of_data() ) {
 						$got_bytes = $stream->pull( $length );

--- a/components/HttpClient/Transport/class-sockettransport.php
+++ b/components/HttpClient/Transport/class-sockettransport.php
@@ -268,7 +268,7 @@ class SocketTransport implements TransportInterface {
 				);
 				continue;
 			} elseif ( 0 === $enabled_crypto ) {
-				// The SSL handshake isn't finished yet, let's skip it.
+				// The SSL handshake isn't finished yet, let's skip it
 				// for now and try again on the next event loop pass.
 				continue;
 			}
@@ -538,10 +538,10 @@ class SocketTransport implements TransportInterface {
 
 			return array();
 		} elseif ( $ready <= 0 ) {
-			// @TODO allow at most X stream_select attempts per request.
-			// foreach ( $unprocessed_requests as $request ) {.
-			// $this->>set_error($request, new HttpError( 'stream_select timed out' ));.
-			// }.
+			// @TODO allow at most X stream_select attempts per request
+			// foreach ( $unprocessed_requests as $request ) {
+			// $this->>set_error($request, new HttpError( 'stream_select timed out' ));
+			// }
 			return array();
 		}
 

--- a/components/HttpServer/class-incomingrequest.php
+++ b/components/HttpServer/class-incomingrequest.php
@@ -108,8 +108,8 @@ class IncomingRequest extends Request {
 
 	// @TODO: Bake this into the body stream instance.
 	public function close_body_stream() {
-		// Do not close $this->body_stream as it would close.
-		// the tcp connection with the client. We need that.
+		// Do not close $this->body_stream as it would close
+		// the tcp connection with the client. We need that
 		// connection to send the response.
 		foreach ( $this->wrapped_streams as $stream ) {
 			$stream->close_reading();

--- a/components/Markdown/class-markdownconsumer.php
+++ b/components/Markdown/class-markdownconsumer.php
@@ -85,7 +85,7 @@ class MarkdownConsumer implements DataFormatConsumer {
 		$this->frontmatter = array();
 		foreach ( $document->data->export() as $key => $value ) {
 			if ( 'attributes' === $key && empty( $value ) ) {
-				// The Frontmatter extension adds an 'attributes' key to the document data.
+				// The Frontmatter extension adds an 'attributes' key to the document data
 				// even when there is no actual "attributes" key in the frontmatter.
 				//
 				// Let's skip it when the value is empty.
@@ -115,7 +115,7 @@ class MarkdownConsumer implements DataFormatConsumer {
 							$level = 3;
 						}
 						$attrs = array();
-						// 2 is the default level and the editor-produced markup won't contain this attribute, leading to.
+						// 2 is the default level and the editor-produced markup won't contain this attribute, leading to
 						// permanent client-side three-way merges.
 						if ( 2 !== $level ) {
 							$attrs['level'] = $level;
@@ -251,7 +251,7 @@ class MarkdownConsumer implements DataFormatConsumer {
 						$children = $node->children();
 						if ( count( $children ) > 0 && $children[0] instanceof Inline\Text && $children[0]->getLiteral() ) {
 							$html->set_attribute( 'alt', $children[0]->getLiteral() );
-							// Empty the text node so it will not be rendered twice: once in as an alt="",.
+							// Empty the text node so it will not be rendered twice: once in as an alt="",
 							// and once as a new paragraph block.
 							$children[0]->setLiteral( '' );
 						}

--- a/components/Markdown/class-markdownimporter.php
+++ b/components/Markdown/class-markdownimporter.php
@@ -57,11 +57,11 @@ class MarkdownImporter extends StreamImporter {
 			str_starts_with( $raw_url, $this->options['local_markdown_assets_url_prefix'] )
 		) {
 			// @TODO: Source the file from the current input stream if we can.
-			// This would allow stream-importing zipped Markdown and WXR directory.
+			// This would allow stream-importing zipped Markdown and WXR directory
 			// structures.
-			// Maybe for v1 we could just support importing them from ZIP files.
-			// that are already downloaded and available in a local directory just.
-			// to avoid additional data transfer and the hurdle with implementing.
+			// Maybe for v1 we could just support importing them from ZIP files
+			// that are already downloaded and available in a local directory just
+			// to avoid additional data transfer and the hurdle with implementing
 			// multiple range requests.
 			$relative_asset_path = substr( $raw_url, strlen( $this->options['local_markdown_assets_url_prefix'] ) );
 			$relative_asset_path = '/' . ltrim( $relative_asset_path, '/' );

--- a/components/Markdown/class-markdownproducer.php
+++ b/components/Markdown/class-markdownproducer.php
@@ -128,7 +128,7 @@ class MarkdownProducer implements DataFormatProducer {
 				return str_repeat( '#', $level ) . ' ' . $content . "\n\n";
 
 			case 'core/table':
-				// Accumulate all the table contents to compute the markdown.
+				// Accumulate all the table contents to compute the markdown
 				// column widths.
 				$processor   = DataLiberationHTMLProcessor::create_fragment( $inner_html );
 				$rows        = array();
@@ -357,13 +357,13 @@ class MarkdownProducer implements DataFormatProducer {
 			}
 		}
 
-		// The HTML processor gives us all the whitespace verbatim.
-		// as it was encountered in the byte stream.
+		// The HTML processor gives us all the whitespace verbatim
+		// as it was encountered in the byte stream/
 		// Let's normalize it to a single space.
 		$markdown = trim( $markdown, "\n" );
 
-		// The ltrim() here is arbitrary and potentially wrong,.
-		// @TODO: Investigate this further and potentially remove.
+		// The ltrim() here is arbitrary and potentially wrong,
+		// @TODO: Investigate this further and potentially remove
 		// all trimming of space characters.
 		$markdown = ltrim( $markdown, "\n " );
 		$markdown = preg_replace( '/\n+/', "\n", $markdown );

--- a/components/Merge/Merge/class-chunkmerger.php
+++ b/components/Merge/Merge/class-chunkmerger.php
@@ -99,8 +99,8 @@ class ChunkMerger implements Merger {
 
 					$results[] = $deletion['inserted'];
 				} elseif ( '' === trim( $deletion['base'], ' ' ) && '' !== $non_deletion['inserted'] ) {
-					// Sometimes branch A is one space short (e.g. due to a trim()) and branch B.
-					// adds a meaningful span of text. In this case, we want to ignore the deletion.
+					// Sometimes branch A is one space short (e.g. due to a trim()) and branch B
+					// adds a meaningful span of text. In this case, we want to ignore the deletion
 					// and keep branch B's text.
 					$results[] = $non_deletion['base'];
 					$results[] = $non_deletion['inserted'];

--- a/components/Merge/Validate/class-blockmarkupmergevalidator.php
+++ b/components/Merge/Validate/class-blockmarkupmergevalidator.php
@@ -41,7 +41,7 @@ class BlockMarkupMergeValidator implements MergeValidator {
 		// Validate the entire document.
 		self::assert_html_is_structurally_sound( $html );
 
-		// Validate the inner HTML of each block separately in case.
+		// Validate the inner HTML of each block separately in case
 		// there's a structural error spanning the block boundary.
 		$block_markup_processor = new BlockMarkupProcessor( $html );
 		while ( $block_markup_processor->next_token() ) {

--- a/components/Merge/class-diffmatchpatchmergedriver.php
+++ b/components/Merge/class-diffmatchpatchmergedriver.php
@@ -30,11 +30,11 @@ class DiffMatchPatchMergeDriver {
 	public function three_way_merge( $common_parent, $branch_a, $branch_b, $options = array() ) {
 		$diff_a = $this->dmp->diff_main( $common_parent, $branch_a );
 		$this->dmp->diff_cleanupSemantic( $diff_a );
-		// $this->dmp->diff_cleanupEfficiency($diff_a);.
+		// $this->dmp->diff_cleanupEfficiency($diff_a);
 
 		$diff_b = $this->dmp->diff_main( $common_parent, $branch_b );
-		// $this->dmp->diff_cleanupSemantic($diff_b);.
-		// $this->dmp->diff_cleanupEfficiency($diff_b);.
+		// $this->dmp->diff_cleanupSemantic($diff_b);
+		// $this->dmp->diff_cleanupEfficiency($diff_b);
 
 		$patch_a                      = $this->dmp->patch_make( $common_parent, $diff_a );
 		list( $merged_a, $applied_a ) = $this->dmp->patch_apply( $patch_a, $common_parent );
@@ -67,7 +67,7 @@ class DiffMatchPatchMergeDriver {
 
 	private function apply_patch( $text, $patch ) {
 		list( $merged, $changes_applied ) = $this->dmp->patch_apply( $patch, $text );
-		// @TODO: Reason about $changes_applied. Sometimes it contains.
+		// @TODO: Reason about $changes_applied. Sometimes it contains
 		// false entries when the $merged value looks great.
 		return $merged;
 	}
@@ -86,12 +86,12 @@ class DiffMatchPatchMergeDriver {
 		// Convert the diffs to format that makes rebasing easier.
 		$diff_a = self::dmp_diff_to_annotated_diff( $base_diff );
 		$diff_b = self::dmp_diff_to_annotated_diff( $diff_to_rebase );
-		// print_r([.
-		// 'diff_a' => $diff_a,.
-		// 'diff_b' => $diff_b,.
-		// 'delta_a' => $this->diff_as_delta($base_diff),.
-		// 'delta_b' => $this->diff_as_delta($diff_to_rebase),.
-		// ]);.
+		// print_r([
+		// 'diff_a' => $diff_a,
+		// 'diff_b' => $diff_b,
+		// 'delta_a' => $this->diff_as_delta($base_diff),
+		// 'delta_b' => $this->diff_as_delta($diff_to_rebase),
+		// ]);
 
 		// Do the rebase.
 		$i_a = 0;
@@ -158,11 +158,11 @@ class DiffMatchPatchMergeDriver {
 												'change_b' => $change_b,
 											)
 										);
-										// if($change_b['start'] === $change_a['start']) {.
-										// Diff b already accounts for the shift from this change, let's add it to.
+										// if($change_b['start'] === $change_a['start']) {
+										// Diff b already accounts for the shift from this change, let's add it to
 										// the accumulator to make sure we won't count it twice.
 										$accumulated_shift += $change_b['length'];
-										// }.
+										// }
 										continue 3;
 									} else {
 										// Otherwise we can merge the two deletions.
@@ -186,7 +186,7 @@ class DiffMatchPatchMergeDriver {
 							}
 						}
 
-						// Shift by the number of characters that are being deleted, but.
+						// Shift by the number of characters that are being deleted, but
 						// only up to the point where deletion A starts.
 						$accumulated_shift -= min(
 							$change_a['length'],
@@ -234,12 +234,12 @@ class DiffMatchPatchMergeDriver {
 			);
 		}
 
-		// print_r([.
-		// 'diff' => $base_diff,.
-		// 'diff_a' => $this->diff_as_delta($base_diff),.
-		// 'diff_b' => $this->diff_as_delta($diff_to_rebase),.
-		// 'diff_r' => $this->diff_as_delta($dmp_diff),.
-		// ]);.
+		// print_r([
+		// 'diff' => $base_diff,
+		// 'diff_a' => $this->diff_as_delta($base_diff),
+		// 'diff_b' => $this->diff_as_delta($diff_to_rebase),
+		// 'diff_r' => $this->diff_as_delta($dmp_diff),
+		// ]);
 		return $dmp_diff;
 	}
 

--- a/components/Merge/class-diffmatchpatchmergedriver.php
+++ b/components/Merge/class-diffmatchpatchmergedriver.php
@@ -91,7 +91,7 @@ class DiffMatchPatchMergeDriver {
 		// 'diff_b' => $diff_b,
 		// 'delta_a' => $this->diff_as_delta($base_diff),
 		// 'delta_b' => $this->diff_as_delta($diff_to_rebase),
-		// ]);
+		// ]);.
 
 		// Do the rebase.
 		$i_a = 0;
@@ -239,7 +239,7 @@ class DiffMatchPatchMergeDriver {
 		// 'diff_a' => $this->diff_as_delta($base_diff),
 		// 'diff_b' => $this->diff_as_delta($diff_to_rebase),
 		// 'diff_r' => $this->diff_as_delta($dmp_diff),
-		// ]);
+		// ]);.
 		return $dmp_diff;
 	}
 

--- a/components/Merge/functions.php
+++ b/components/Merge/functions.php
@@ -44,7 +44,7 @@ function mb_wordwrap( string $text, int $width, string $break = "\n", bool $cut 
 		$word = $words[ $i ];
 		if ( false !== strpos( $word, "\n" ) ) {
 			$offset = strpos( $word, "\n" );
-			// Slice until the newline character while keeping the number of.
+			// Slice until the newline character while keeping the number of
 			// characters the same.
 			$before = substr( $word, 0, $offset ) . ' ';
 			$after  = substr( $word, $offset + 1 );
@@ -147,11 +147,11 @@ function format_chunk_side( array $chunk, $width ): string {
 		$cursor = $line_end + 1;
 
 		if ( $padding_length > 0 ) {
-			// Tab characters have variable length in terminal which breaks the side-by-side formatting.
-			// We cannot easily preserve them and display nice diff columns. At the same time, removing.
-			// them in favor of spaces may confuse the viewer – "why are spaces replaced with spaces here?".
+			// Tab characters have variable length in terminal which breaks the side-by-side formatting
+			// We cannot easily preserve them and display nice diff columns. At the same time, removing
+			// them in favor of spaces may confuse the viewer – "why are spaces replaced with spaces here?"
 			//
-			// @TODO: Investigate how other diff tools solve that problem and find a useful and established.
+			// @TODO: Investigate how other diff tools solve that problem and find a useful and established
 			// pattern. Perhaps display UTF-8 arrows instead of tabs and dots instead of spaces?
 			$wrapped[ $k ] = str_replace( "\t", ' ', $wrapped[ $k ] );
 			$wrapped[ $k ] = trim( $wrapped[ $k ] ) . str_repeat( ' ', $padding_length );

--- a/components/XML/class-xmlprocessor.php
+++ b/components/XML/class-xmlprocessor.php
@@ -1241,7 +1241,7 @@ class XMLProcessor {
 				$attribute->namespace                          = $namespace_reference;
 			}
 
-			// Store attributes with their namespaces and discard the temporary.
+			// Store attributes with their namespaces and discard the temporary
 			// qualified attributes array.
 			$this->attributes           = $namespaced_attributes;
 			$this->qualified_attributes = array();
@@ -1989,7 +1989,7 @@ class XMLProcessor {
 				'm' === $xml[ $at + 3 ] &&
 				'l' === $xml[ $at + 4 ]
 			) {
-				// Setting the parser state early for the get_attribute_by_qualified_name() calls later in this.
+				// Setting the parser state early for the get_attribute_by_qualified_name() calls later in this
 				// branch.
 				$this->parser_state = self::STATE_XML_DECLARATION;
 
@@ -2073,8 +2073,8 @@ class XMLProcessor {
 				$this->bytes_already_parsed = $at + 2;
 				$this->parser_state         = self::STATE_XML_DECLARATION;
 
-				// Processing instructions don't have namespaces. We can just.
-				// copy the qualified attributes to the attributes array without.
+				// Processing instructions don't have namespaces. We can just
+				// copy the qualified attributes to the attributes array without
 				// resolving anything.
 				$this->attributes           = $this->qualified_attributes;
 				$this->qualified_attributes = array();
@@ -2140,7 +2140,7 @@ class XMLProcessor {
 			++$at;
 		}
 
-		// There's no more tag openers and we're not expecting more data –.
+		// There's no more tag openers and we're not expecting more data –
 		// this mist be a trailing text node.
 		if ( ! $this->expecting_more_input ) {
 			$this->parser_state         = self::STATE_TEXT_NODE;
@@ -2376,8 +2376,8 @@ class XMLProcessor {
 	}
 
 	private function is_valid_name_codepoint( $codepoint, $is_first_character = false ) {
-		// Test against the NameStartChar pattern:.
-		// NameStartChar ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF].
+		// Test against the NameStartChar pattern:
+		// NameStartChar ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
 		// See `https://www.w3.org/TR/xml/#NT-Name`.
 		if (
 			// :.
@@ -2419,8 +2419,8 @@ class XMLProcessor {
 			return false;
 		}
 
-		// Test against the NameChar pattern:.
-		// NameChar ::= NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040].
+		// Test against the NameChar pattern:
+		// NameChar ::= NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
 		// See `https://www.w3.org/TR/xml/#NT-Name`.
 		return (
 			// "-".
@@ -3700,7 +3700,7 @@ class XMLProcessor {
 			}
 		}
 
-		// XML requires a root element. If we've reached the end of data in the prolog stage,.
+		// XML requires a root element. If we've reached the end of data in the prolog stage,
 		// before finding a root element, then the document is incomplete.
 		if ( self::STATE_COMPLETE === $this->parser_state ) {
 			$this->mark_incomplete_input();

--- a/components/Zip/class-zipdecoder.php
+++ b/components/Zip/class-zipdecoder.php
@@ -33,8 +33,8 @@ class ZipDecoder {
 	}
 
 	public function next_object(): bool {
-		// If we're calling next_object() when an object is ready,.
-		// it means we want to scan for the next object. Let's clear.
+		// If we're calling next_object() when an object is ready,
+		// it means we want to scan for the next object. Let's clear
 		// the state and start scanning again.
 		if ( self::STATE_OBJECT_READY === $this->state ) {
 			$this->after_record();

--- a/components/Zip/class-zipfilesystem.php
+++ b/components/Zip/class-zipfilesystem.php
@@ -163,7 +163,7 @@ class ZipFilesystem implements Filesystem {
 			$central_directory[ $object->path ] = $object;
 		}
 
-		// Transform the central directory into a tree structure with.
+		// Transform the central directory into a tree structure with
 		// directories and files.
 		foreach ( $central_directory as $entry ) {
 			/**


### PR DESCRIPTION
I've made a script to autofix all PHPCS complaints related to "all comments must end with a full stop" since the sniff complains but does not autofix. It seems like I haven't considered multiline comments :-) This PR removes a bunch of end-of-line full stops from places where they don't make any sense.