### PR TITLE
Make Requests filterable

### DIFF
--- a/components/HttpClient/Middleware/class-httpmiddleware.php
+++ b/components/HttpClient/Middleware/class-httpmiddleware.php
@@ -4,11 +4,8 @@ namespace WordPress\HttpClient\Middleware;
 
 use WordPress\HttpClient\Client;
 use WordPress\HttpClient\ClientState;
-use WordPress\HttpClient\HttpClientException;
 use WordPress\HttpClient\Request;
 use WordPress\HttpClient\Connection;
-use WordPress\HttpClient\Transport\CurlTransport;
-use WordPress\HttpClient\Transport\SocketTransport;
 use WordPress\HttpClient\Transport\TransportInterface;
 
 class HttpMiddleware implements MiddlewareInterface {
@@ -42,7 +39,7 @@ class HttpMiddleware implements MiddlewareInterface {
 	 */
 	public function enqueue( Request $request ) {
 		$request->state                           = Request::STATE_ENQUEUED;
-		$this->state->requests[]                  = apply_filters( 'wp_http_client_request', $request );
+		$this->state->requests[]                  = $request;
 		$this->state->events[ $request->id ]      = array();
 		$this->state->connections[ $request->id ] = new Connection( $request );
 	}

--- a/components/HttpClient/class-client.php
+++ b/components/HttpClient/class-client.php
@@ -139,8 +139,16 @@ class Client {
 				throw new HttpClientException( sprintf( 'Request %s is not in the created state.', esc_html( $request->id ) ) );
 			}
 
-			$this->middleware->enqueue( $request );
+			$filtered_request = apply_filters( 'wp_http_client_request_before_enqueue', $request );
 
+			$this->middleware->enqueue( $filtered_request ? $filtered_request : $request );
+
+			if ( false === $filtered_request ) {
+				$this->state->set_request_error( $request, new HttpError( sprintf( 'Request %s was rejected by a filter and not enqueued.', esc_html( $request->id ) ) ) );
+				continue;
+			}
+
+			$request = $filtered_request;
 			$parsed = WPURL::parse( $request->url );
 			if ( false === $parsed ) {
 				$this->state->set_request_error( $request, new HttpError( sprintf( 'Invalid URL: %s', $request->url ) ) );

--- a/plugins/data-liberation/plugin.php
+++ b/plugins/data-liberation/plugin.php
@@ -120,7 +120,7 @@ add_action(
  * Git repositories.
  */
 add_filter(
-	'wp_http_client_request',
+	'wp_http_client_request_before_enqueue',
 	function ( Request $request ) {
 		if ( isset( $request->headers['x-cors-proxy-allowed-request-headers'] ) ) {
 			$prefix = $request->headers['x-cors-proxy-allowed-request-headers'] . ',';


### PR DESCRIPTION
Introduces a new filter, `wp_http_client_request_before_enqueue`, to allow modification or rejection of requests before they are enqueued.

The filter may:

* Change the request, in which case the updated request will be enqueued
* Return false to reject the request – the original request will bee enqueued and immediately rejected.

## Remaining work

Only allow updating the original Request object in the filter. Reject filters that return a new Request instance – the object identity matters as Client consumers may use it to track the data flow.