### PR TITLE
Extract WPURL::replace_base_url() from BlockMarkupUrlProcessor

### DIFF
--- a/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
@@ -262,20 +262,22 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			return false;
 		}
 
-		if (
-			'#text' === $this->get_token_type() &&
-			! WPURL::can_parse( $this->get_raw_url() )
-		) {
-			// In text nodes, only convert absolute URLs.
-			return false;
-		}
-
 		$result = WPURL::replace_base_url(
 			$this->get_parsed_url(),
 			array(
 				'old_base_url' => $base_url,
 				'new_base_url' => $to_url,
 				'raw_url'      => $this->get_raw_url(),
+				'is_relative'  => (
+					/**
+					 * In text nodes, the only detected URLs are absolute. The tricky part
+					 * is they may start without a protocol, e.g. `wordpress.org`. Therefore,
+					 * we need to tell WPURL::replace_base_url what's our intention regarding
+					 * the URL's relativity. It cannot just infer it from the URL itself.
+					 */
+					'#text' !== $this->get_token_type() &&
+					! WPURL::can_parse( $this->get_raw_url() )
+				),
 			)
 		);
 
@@ -283,7 +285,7 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			return false;
 		}
 
-		$this->set_url( (string) $result, $result->getConvertedUrl() );
+		$this->set_url( $result . '', $result->new_url );
 
 		return true;
 	}

--- a/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
@@ -5,6 +5,7 @@ namespace WordPress\DataLiberation\BlockMarkup;
 use Rowbot\URL\URL;
 use WordPress\DataLiberation\URL\URLInTextProcessor;
 use WordPress\DataLiberation\URL\WPURL;
+use WordPress\DataLiberation\URL\ConvertedUrl;
 
 use function WordPress\DataLiberation\URL\urldecode_n;
 
@@ -256,85 +257,35 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 	 *        by this WPURL_In_Text_Processor class so maybe the two do go hand in hand?
 	 */
 	public function replace_base_url( URL $to_url, ?URL $base_url = null ) {
-		$updated_url = clone $this->get_parsed_url();
-
-		$updated_url->hostname = $to_url->hostname;
-		$updated_url->protocol = $to_url->protocol;
-		$updated_url->port     = $to_url->port;
-
-		// Update the pathname if needed.
-		$from_url      = $this->get_parsed_url();
-		$from_pathname = $from_url->pathname;
-		$to_pathname   = $to_url->pathname;
-
 		$base_url = $base_url ?? $this->base_url_object;
-		if ( $base_url->pathname !== $to_pathname ) {
-			$base_pathname_with_trailing_slash = rtrim( $base_url->pathname, '/' ) . '/';
-			$decoded_matched_pathname          = urldecode_n(
-				$from_pathname,
-				strlen( $base_pathname_with_trailing_slash )
-			);
-			$to_pathname_with_trailing_slash   = rtrim( $to_pathname, '/' ) . '/';
-			$remaining_pathname                =
-				substr(
-					$decoded_matched_pathname,
-					strlen( $base_pathname_with_trailing_slash )
-				);
-
-			$updated_url->pathname = $to_pathname_with_trailing_slash . $remaining_pathname;
-		}
-
-		/*
-		 * Stylistic choice – if the updated URL has no trailing slash,
-		 * do not add it to the new URL. The WHATWG URL parser will
-		 * add one automatically if the path is empty, so we have to
-		 * explicitly remove it.
-		 */
-		$new_raw_url = $updated_url->toString();
-		if (
-			'/' !== $from_url->pathname[ strlen( $from_url->pathname ) - 1 ] &&
-			'/' !== $from_url->pathname &&
-			'' === $from_url->search &&
-			'' === $from_url->hash
-		) {
-			$new_raw_url = rtrim( $new_raw_url, '/' );
-		}
-		if ( ! $new_raw_url ) {
-			// @TODO: When does this happen? Let's add the test coverage and
-			// doubly verify the logic.
+		if ( ! $base_url ) {
 			return false;
 		}
 
-		if ( ! $this->is_url_relative() ) {
-			$this->set_url( $new_raw_url, $updated_url );
-
-			return true;
+		if (
+			'#text' === $this->get_token_type() &&
+			! WPURL::can_parse( $this->get_raw_url() )
+		) {
+			// In text nodes, only convert absolute URLs.
+			return false;
 		}
 
-		$new_relative_url = $updated_url->pathname;
-		if ( '' !== $updated_url->search ) {
-			$new_relative_url .= $updated_url->search;
-		}
-		if ( '' !== $updated_url->hash ) {
-			$new_relative_url .= $updated_url->hash;
+        $result = WPURL::replace_base_url(
+			$this->get_parsed_url(),
+            array(
+                'old_base_url' => $base_url,
+                'new_base_url' => $to_url,
+                'raw_url'      => $this->get_raw_url(),
+            )
+        );
+
+        if ( false === $result ) {
+			return false;
 		}
 
-		$this->set_url( $new_relative_url, $updated_url );
+        $this->set_url( (string) $result, $result->getConvertedUrl() );
 
 		return true;
-	}
-
-	/**
-	 * Returns true if the currently matched URL is relative.
-	 *
-	 * @return bool Whether the currently matched URL is relative.
-	 */
-	public function is_url_relative() {
-		return (
-			! WPURL::can_parse( $this->get_raw_url() ) &&
-			// only absolute URLs are detected in text nodes.
-			'#text' !== $this->get_token_type()
-		);
 	}
 
 	/**

--- a/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
@@ -270,20 +270,20 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 			return false;
 		}
 
-        $result = WPURL::replace_base_url(
+		$result = WPURL::replace_base_url(
 			$this->get_parsed_url(),
-            array(
-                'old_base_url' => $base_url,
-                'new_base_url' => $to_url,
-                'raw_url'      => $this->get_raw_url(),
-            )
-        );
+			array(
+				'old_base_url' => $base_url,
+				'new_base_url' => $to_url,
+				'raw_url'      => $this->get_raw_url(),
+			)
+		);
 
-        if ( false === $result ) {
+		if ( false === $result ) {
 			return false;
 		}
 
-        $this->set_url( (string) $result, $result->getConvertedUrl() );
+		$this->set_url( (string) $result, $result->getConvertedUrl() );
 
 		return true;
 	}

--- a/components/DataLiberation/URL/class-convertedurl.php
+++ b/components/DataLiberation/URL/class-convertedurl.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace WordPress\DataLiberation\URL;
+
+use Rowbot\URL\URL;
+
+/**
+ * Value object returned by WPURL::replace_base_url().
+ *
+ * - Cast to string to get the updated URL as a string.
+ * - When the original URL was relative, casting returns a relative string against
+ *   the new base.
+ */
+class ConvertedUrl {
+
+	/** @var URL */
+	private $url;
+
+	/** @var string */
+	private $string;
+
+	/** @var string|null */
+	private $relative_string;
+
+	/** @var bool */
+	private $was_relative;
+
+	public function __construct( URL $url, string $string, ?string $relative_string, bool $was_relative ) {
+		$this->url             = $url;
+		$this->string          = $string;
+		$this->relative_string = $relative_string;
+		$this->was_relative    = $was_relative;
+	}
+
+	/**
+	 * Returns the updated URL string. If the original was relative, returns a relative string.
+	 */
+	public function __toString(): string {
+		if ( $this->was_relative ) {
+			return $this->getRelativeString();
+		}
+		return $this->getString();
+	}
+
+	/**
+	 * The parsed updated URL object.
+	 */
+	public function getConvertedUrl(): URL {
+		return $this->url;
+	}
+
+	/**
+	 * Whether the input URL was originally relative.
+	 */
+	public function wasRelative(): bool {
+		return $this->was_relative;
+	}
+
+	/**
+	 * Returns the absolute updated URL string.
+	 */
+	public function getString(): string {
+		return $this->string;
+	}
+
+	/**
+	 * Returns the relative string if available, otherwise constructs it from the URL.
+	 */
+	public function getRelativeString(): ?string {
+		if ( null !== $this->relative_string ) {
+			return $this->relative_string;
+		}
+
+		$relative = $this->url->pathname;
+		if ( '' !== $this->url->search ) {
+			$relative .= $this->url->search;
+		}
+		if ( '' !== $this->url->hash ) {
+			$relative .= $this->url->hash;
+		}
+
+		return $relative;
+	}
+}

--- a/components/DataLiberation/URL/class-convertedurl.php
+++ b/components/DataLiberation/URL/class-convertedurl.php
@@ -14,71 +14,24 @@ use Rowbot\URL\URL;
 class ConvertedUrl {
 
 	/** @var URL */
-	private $url;
+	public $new_url;
 
 	/** @var string */
-	private $string;
+	public $new_raw_url;
 
 	/** @var string|null */
-	private $relative_string;
+	public $new_raw_relative_url;
 
 	/** @var bool */
-	private $was_relative;
-
-	public function __construct( URL $url, string $string, ?string $relative_string, bool $was_relative ) {
-		$this->url             = $url;
-		$this->string          = $string;
-		$this->relative_string = $relative_string;
-		$this->was_relative    = $was_relative;
-	}
+	public $was_relative = false;
 
 	/**
 	 * Returns the updated URL string. If the original was relative, returns a relative string.
 	 */
 	public function __toString(): string {
 		if ( $this->was_relative ) {
-			return $this->getRelativeString();
+			return $this->new_raw_relative_url;
 		}
-		return $this->getString();
-	}
-
-	/**
-	 * The parsed updated URL object.
-	 */
-	public function getConvertedUrl(): URL {
-		return $this->url;
-	}
-
-	/**
-	 * Whether the input URL was originally relative.
-	 */
-	public function wasRelative(): bool {
-		return $this->was_relative;
-	}
-
-	/**
-	 * Returns the absolute updated URL string.
-	 */
-	public function getString(): string {
-		return $this->string;
-	}
-
-	/**
-	 * Returns the relative string if available, otherwise constructs it from the URL.
-	 */
-	public function getRelativeString(): ?string {
-		if ( null !== $this->relative_string ) {
-			return $this->relative_string;
-		}
-
-		$relative = $this->url->pathname;
-		if ( '' !== $this->url->search ) {
-			$relative .= $this->url->search;
-		}
-		if ( '' !== $this->url->hash ) {
-			$relative .= $this->url->hash;
-		}
-
-		return $relative;
+		return $this->new_raw_url;
 	}
 }

--- a/components/DataLiberation/URL/class-wpurl.php
+++ b/components/DataLiberation/URL/class-wpurl.php
@@ -156,26 +156,29 @@ class WPURL {
 			return false;
 		}
 
-		$was_relative = null;
+		$converted_url              = new ConvertedUrl();
+		$converted_url->new_url     = $updated_url;
+		$converted_url->new_raw_url = $new_raw_url;
+
 		if ( array_key_exists( 'raw_url', $options ) && is_string( $options['raw_url'] ) ) {
-			$was_relative = ! self::can_parse( $options['raw_url'] );
-		}
-		if ( null === $was_relative ) {
-			$was_relative = false;
+			if ( ! array_key_exists( 'is_relative', $options ) ) {
+				$options['is_relative'] = self::can_parse( $options['raw_url'] );
+			}
+			if ( $options['is_relative'] ) {
+				$relative_url = $updated_url->pathname;
+				if ( '' !== $updated_url->search ) {
+					$relative_url .= $updated_url->search;
+				}
+				if ( '' !== $updated_url->hash ) {
+					$relative_url .= $updated_url->hash;
+				}
+
+				$converted_url->was_relative         = true;
+				$converted_url->new_raw_relative_url = $relative_url;
+			}
 		}
 
-		$relative_url = null;
-		if ( $was_relative ) {
-			$relative_url = $updated_url->pathname;
-			if ( '' !== $updated_url->search ) {
-				$relative_url .= $updated_url->search;
-			}
-			if ( '' !== $updated_url->hash ) {
-				$relative_url .= $updated_url->hash;
-			}
-		}
-
-		return new ConvertedUrl( $updated_url, $new_raw_url, $relative_url, (bool) $was_relative );
+		return $converted_url;
 	}
 
 	/**

--- a/components/DataLiberation/URL/class-wpurl.php
+++ b/components/DataLiberation/URL/class-wpurl.php
@@ -26,6 +26,159 @@ class WPURL {
 	}
 
 	/**
+	 * Replaces the "base" of a URL — scheme, host (and port), and the portion of the path that
+	 * belongs to the old base — with a new base while keeping the remainder of the URL intact.
+	 *
+	 * This is intended for content migrations, where URLs embedded in block markup, HTML attributes,
+	 * or inline text must be moved from one site root to another without losing the rest of the path,
+	 * query, or fragment. It handles simple domain swaps, ports, and deep path bases. When the old
+	 * base includes path segments, only that matched prefix is substituted and the unmatched tail is
+	 * carried over to the target base.
+	 *
+	 * For example:
+	 * * URL:      https://example.com/a/b/c/d/e/f/g/h/i/j/page/
+	 * * Old base: https://example.com/a/b/c/d/e/f/
+	 * * New base: https://example.org/docs/
+	 * * Result:   https://example.org/docs/g/h/i/j/page/
+	 *
+	 * ## Trailing slash handling
+	 *
+	 * Trailing slash style is preserved from the original URL. If it has no trailing slash, the
+	 * result will also omit the trailing slash and vice versa.
+	 *
+	 * For example, here the final result has no trailing slash:
+	 * * URL:      https://example.com/uploads/file.txt
+	 * * Old base: https://example.com/uploads/
+	 * * New base: https://example.org/docs/
+	 * * Result:   https://example.org/docs/file.txt
+	 *
+	 * And here it does:
+	 * * URL:      https://example.com/uploads/2018/
+	 * * Old base: https://example.com/uploads/
+	 * * New base: https://example.org/docs/
+	 * * Result:   https://example.org/docs/2018/
+	 *
+	 * ## URL-encoded path segments
+	 *
+	 * URL-encoded path segments are respected and not inadvertently decoded or re-encoded. Only the
+	 * matched base prefix is considered for alignment, so inputs that contain percent-encoded content
+	 * keep that content exactly as-is in the output. This prevents data corruption in tricky cases such
+	 * as "/~jappleseed/1997.10.1/%2561-reasons-to-migrate-data/" where the "%2561" must remain
+	 * double-escaped after the move.
+	 *
+	 * ## Relative URLs
+	 *
+	 * This method can preserve the relative nature of the original URL. Say you are processing a markup
+	 * that contains `<a href="/uploads/file.txt">`. The original URL string is "/uploads/file.txt",
+	 * and the URL actually resolves to "https://example.com/uploads/file.txt". If you want to replace
+	 * the base URL from "https://example.com/uploads/" to "https://newsite.com/files/" but keep the
+	 * URL relative, you can pass the raw URL string via the "raw_url" option.
+	 *
+	 * For example:
+	 * * URL:      https://example.com/uploads/file.txt
+	 * * Raw URL:  /uploads/file.txt
+	 * * Old base: https://example.com/uploads/
+	 * * New base: https://example.org/files/
+	 * * Result:   /files/file.txt
+	 *
+	 * The method also supports relative inputs commonly found in markup. If you pass the raw URL
+	 * string via the "raw_url" option, the method can infer whether the author originally wrote a
+	 * relative URL like "docs/page.html" or an absolute one. You may also explicitly
+	 * assert relativity with "is_relative" to avoid inference.
+	 *
+	 * @param string|URL $url The URL to replace the base of.
+	 * @param array      $options Associative options: old_base_url, new_base_url; optional raw_url.
+	 * @return ConvertedUrl|false Returns a ConvertedUrl value object on success, or false when parsing
+	 *                           or replacement cannot be performed.
+	 */
+	public static function replace_base_url( $url, $options ) {
+		if ( ! is_array( $options ) ) {
+			return false;
+		}
+
+		foreach ( array( 'old_base_url', 'new_base_url' ) as $required ) {
+			if ( ! array_key_exists( $required, $options ) || null === $options[ $required ] ) {
+				return false;
+			}
+		}
+
+		$old_base_url = self::parse( $options['old_base_url'] );
+		$new_base_url = self::parse( $options['new_base_url'] );
+		$url          = self::parse( $url, $old_base_url ? $old_base_url->toString() : null );
+
+		if ( false === $old_base_url || false === $new_base_url || false === $url ) {
+			return false;
+		}
+
+		$updated_url = clone $url;
+
+		$updated_url->hostname = $new_base_url->hostname;
+		$updated_url->protocol = $new_base_url->protocol;
+		$updated_url->port     = $new_base_url->port;
+
+		$from_pathname = $url->pathname;
+		$to_pathname   = $new_base_url->pathname;
+		$base_pathname = $old_base_url->pathname;
+
+		if ( $base_pathname !== $to_pathname ) {
+			$base_pathname_with_trailing_slash = rtrim( $base_pathname, '/' ) . '/';
+			$decoded_matched_pathname          = urldecode_n(
+				$from_pathname,
+				strlen( $base_pathname_with_trailing_slash )
+			);
+			$to_pathname_with_trailing_slash   = rtrim( $to_pathname, '/' ) . '/';
+			$remaining_pathname                = substr(
+				$decoded_matched_pathname,
+				strlen( $base_pathname_with_trailing_slash )
+			);
+
+			$updated_url->pathname = $to_pathname_with_trailing_slash . $remaining_pathname;
+		}
+
+		/*
+		 * Stylistic choice – if the updated URL has no trailing slash,
+		 * do not add it to the new URL. The WHATWG URL parser will
+		 * add one automatically if the path is empty, so we have to
+		 * explicitly remove it.
+		 */
+		$new_raw_url                = $updated_url->toString();
+		$should_trim_trailing_slash = (
+			'' !== $from_pathname &&
+			'/' !== substr( $from_pathname, -1 ) &&
+			'/' !== $from_pathname &&
+			'' === $url->search &&
+			'' === $url->hash
+		);
+		if ( $should_trim_trailing_slash ) {
+			$new_raw_url = rtrim( $new_raw_url, '/' );
+		}
+		if ( ! $new_raw_url ) {
+			return false;
+		}
+
+		$was_relative = null;
+		if ( array_key_exists( 'raw_url', $options ) && is_string( $options['raw_url'] ) ) {
+			$was_relative = ! self::can_parse( $options['raw_url'] );
+		}
+		if ( null === $was_relative ) {
+			$was_relative = false;
+		}
+
+		$relative_url = null;
+		if ( $was_relative ) {
+			$relative_url = $updated_url->pathname;
+			if ( '' !== $updated_url->search ) {
+				$relative_url .= $updated_url->search;
+			}
+			if ( '' !== $updated_url->hash ) {
+				$relative_url .= $updated_url->hash;
+			}
+		}
+
+		return new ConvertedUrl( $updated_url, $new_raw_url, $relative_url, (bool) $was_relative );
+	}
+
+	/**
 	 * Prepends a protocol to any matched URL without the double slash.
 	 *
 	 * Imagine we have a base URL of `https://example.com` and a text like `Visit myblog.com`.

--- a/components/DataLiberation/URL/class-wpurl.php
+++ b/components/DataLiberation/URL/class-wpurl.php
@@ -153,6 +153,7 @@ class WPURL {
 			$new_raw_url = rtrim( $new_raw_url, '/' );
 		}
 		if ( ! $new_raw_url ) {
+			// This may technically happen, but does it happen in practice?
 			return false;
 		}
 
@@ -160,12 +161,17 @@ class WPURL {
 		$converted_url->new_url     = $updated_url;
 		$converted_url->new_raw_url = $new_raw_url;
 
+		// Preserve the relative nature of the original URL.
 		if ( array_key_exists( 'raw_url', $options ) && is_string( $options['raw_url'] ) ) {
 			if ( ! array_key_exists( 'is_relative', $options ) ) {
 				$options['is_relative'] = self::can_parse( $options['raw_url'] );
 			}
 			if ( $options['is_relative'] ) {
 				$relative_url = $updated_url->pathname;
+				// Remove the trailing slash if it's not the root path.
+				if ( strlen( $relative_url ) > 1 && $should_trim_trailing_slash ) {
+					$relative_url = rtrim( $relative_url, '/' );
+				}
 				if ( '' !== $updated_url->search ) {
 					$relative_url .= $updated_url->search;
 				}


### PR DESCRIPTION
Moves the base URL replacement logic from `BlockMarkupUrlProcessor::replace_base_url()` to `WPURL::replace_base_url()`. This way it can be used on any URL without involving the markup parser.