### PR TITLE
[BlockMarkupProcessor] Preserve self-closing block style when rewriting URLs

### DIFF
--- a/components/DataLiberation/BlockMarkup/class-blockmarkupprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupprocessor.php
@@ -496,7 +496,8 @@ class BlockMarkupProcessor extends WP_HTML_Tag_Processor {
 			' ' .
 			$this->block_name .
 			' ' .
-			$encoded_attributes
+			$encoded_attributes .
+			( $this->is_self_closing_block() ? '/' : '' )
 		);
 
 		return true;

--- a/components/DataLiberation/Tests/BlockMarkupProcessorTest.php
+++ b/components/DataLiberation/Tests/BlockMarkupProcessorTest.php
@@ -358,6 +358,24 @@ class BlockMarkupProcessorTest extends TestCase {
 		);
 	}
 
+	public function test_set_block_attribute_value_updates_a_list_value_with_a_self_closing_block() {
+		$p = new BlockMarkupProcessor(
+			'<!-- wp:image {"sources": ["small.png", "large.png"] } /-->'
+		);
+		$this->assertTrue( $p->next_token(), 'Failed to find the block opener' );
+		$this->assertTrue( $p->next_block_attribute(), 'Failed to find the first block attribute' );
+		$this->assertTrue( $p->next_block_attribute(), 'Failed to find the second block attribute' );
+		$this->assertTrue( $p->next_block_attribute(), 'Failed to find the third block attribute' );
+
+		$p->set_block_attribute_value( 'medium.png' );
+		$this->assertEquals( 'medium.png', $p->get_block_attribute_value(), 'Failed to find the block attribute value' );
+		$this->assertEquals(
+			'<!-- wp:image {"sources":["small.png","medium.png"]} /-->',
+			$p->get_updated_html(),
+			'Failed to update the block attribute value'
+		);
+	}
+
 	public function test_set_block_attribute_can_be_called_multiple_times() {
 		$p = new BlockMarkupProcessor(
 			'<!-- wp:image {"sources": { "lowres": "small.png", "hires": "large.png" } } -->'

--- a/components/DataLiberation/Tests/BlockMarkupUrlProcessorTest.php
+++ b/components/DataLiberation/Tests/BlockMarkupUrlProcessorTest.php
@@ -193,6 +193,11 @@ class BlockMarkupUrlProcessorTest extends TestCase {
 				'https://w.org',
 				'<!-- wp:image {"src":"https:\/\/w.org"} -->',
 			),
+			'In the "url" block attribute of a navigation-link block' => array(
+				'<!-- wp:navigation-link {"url": "https://w.org"} /-->',
+				'https://w.org',
+				'<!-- wp:navigation-link {"url":"https:\/\/w.org"} /-->',
+			),
 			'In a text node'                      => array(
 				'Have you seen https://wordpress.org yet?',
 				'https://w.org',


### PR DESCRIPTION
Before this PR, `BlockMarkupProcessor` (and `BlockMarkupUrlProcessor`) would lose the self-closing solidus when rewriting block attributes:

```php
$p = new BlockMarkupUrlProcessor(
	'<!-- wp:navigation-link {"url": "https://w.org"} /-->'
);
$p->next_url();
$p->set_url('https://new-site.org', WPURL::parse('https://new-site.org'));
echo $p->__toString();
// <!-- wp:navigation-link {"url": "https://new-site.org"} -->
```

With this PR, the self-closing solidus is preserved:

```php
$p = new BlockMarkupUrlProcessor(
	'<!-- wp:navigation-link {"url": "https://w.org"} /-->'
);
$p->next_url();
$p->set_url('https://new-site.org', WPURL::parse('https://new-site.org'));
echo $p->__toString();
// <!-- wp:navigation-link {"url": "https://new-site.org"} /-->
```

## Testing instructions

CI – I've added two more test cases to prevent regressions.