### PR TITLE
[CSSProcessor] Replace utf8_codepoint_at with utf8_ord

### DIFF
--- a/components/DataLiberation/URL/class-cssprocessor.php
+++ b/components/DataLiberation/URL/class-cssprocessor.php
@@ -2,7 +2,6 @@
 
 namespace WordPress\DataLiberation\URL;
 
-use function WordPress\Encoding\utf8_codepoint_at;
 use function WordPress\Encoding\codepoint_to_utf8_bytes;
 use function WordPress\Encoding\compat\_wp_scan_utf8;
 use function WordPress\Encoding\utf8_ord;

--- a/components/DataLiberation/URL/class-cssprocessor.php
+++ b/components/DataLiberation/URL/class-cssprocessor.php
@@ -5,6 +5,7 @@ namespace WordPress\DataLiberation\URL;
 use function WordPress\Encoding\utf8_codepoint_at;
 use function WordPress\Encoding\codepoint_to_utf8_bytes;
 use function WordPress\Encoding\compat\_wp_scan_utf8;
+use function WordPress\Encoding\utf8_ord;
 use function WordPress\Encoding\wp_scrub_utf8;
 
 /**
@@ -1506,7 +1507,7 @@ class CSSProcessor {
 		}
 
 		$codepoint_byte_length = $new_at - $at;
-		$codepoint             = utf8_codepoint_at( $this->css, $at );
+		$codepoint             = utf8_ord( substr( $this->css, $at, $codepoint_byte_length ) );
 		if ( null !== $codepoint && $codepoint >= 0x80 ) {
 			return $codepoint_byte_length;
 		}


### PR DESCRIPTION
Replaces the `utf8_codepoint_at()` call in `CSSProcessor` with `utf8_ord()`. This removes the last reference to `utf8_codepoint_at()` from the codebase so the next PR will remove that function, see https://github.com/WordPress/php-toolkit/pull/200 for prior context.

cc @dmsnell 