### PR TITLE
[XMLProcessor] Tolerate standalone="true"

### DIFF
--- a/components/XML/Tests/W3CXMLConformanceTest.php
+++ b/components/XML/Tests/W3CXMLConformanceTest.php
@@ -59,21 +59,11 @@ class W3CXMLConformanceTest extends TestCase {
 		}
 
 		if (in_array($test_id, [
-			"not-sa01",
-			"not-sa02",
-			"not-sa03",
 			"not-sa04",
 			"sa04",
 			"ibm-valid-P01-ibm01v01.xml",
-			"ibm-valid-P32-ibm32v01.xml",
-			"ibm-valid-P32-ibm32v02.xml",
-			"ibm-valid-P32-ibm32v03.xml",
-			"ibm-valid-P32-ibm32v04.xml",
-			"ibm-valid-P68-ibm68v02.xml",
-			"ibm-valid-P69-ibm69v01.xml",
-			"ibm-valid-P69-ibm69v02.xml",
 		])) {
-			$this->markTestSkipped("Skipping test case: {$test_id} – XMLProcessor does not support standalone documents");
+			$this->markTestSkipped("Skipping test case: {$test_id} – XMLProcessor does not support custom processing directive targets (e.g. <?music ... ?>)");
 			return;
 		}
 

--- a/components/XML/class-xmlprocessor.php
+++ b/components/XML/class-xmlprocessor.php
@@ -21,7 +21,6 @@ use function WordPress\Encoding\utf8_ord;
  * – XML 1.0
  * – Well-formed
  * – UTF-8 encoded
- * – Not standalone (so can use external entities)
  * – No external DTD subset expansion (external entities may exist but are not fetched).
  *
  * XML 1.1 is explicitly not a design goal here. Version 1.1 is
@@ -2070,13 +2069,6 @@ class XMLProcessor {
 					&& 'UTF-8' !== strtoupper( $this->get_qualified_attribute( 'encoding' ) )
 				) {
 					$this->bail( 'Unsupported XML encoding declared, only UTF-8 is supported.', self::ERROR_UNSUPPORTED );
-					return false;
-				}
-
-				if ( null !== $this->get_qualified_attribute( 'standalone' )
-					&& 'YES' !== strtoupper( $this->get_qualified_attribute( 'standalone' ) )
-				) {
-					$this->bail( 'Standalone XML documents are not supported.', self::ERROR_UNSUPPORTED );
 					return false;
 				}
 


### PR DESCRIPTION
Removes the parsing error when `standalone="true"` is encountered. There is no reason to prevent the caller from scanning a standalone document. The [XML 1.0 spec](https://www.w3.org/TR/xml/#sec-rmd) describes `standalone="true"` as merely a clue:

> In a standalone document declaration, the value "yes" indicates that there are no [external markup declarations](https://www.w3.org/TR/xml/#dt-extmkpdecl) which affect the information passed from the XML processor to the application. The value "no" indicates that there are or may be such external markup declarations. Note that the standalone document declaration only denotes the presence of external declarations; the presence, in a document, of references to external entities, when those entities are internally declared, does not change its standalone status.
> 
> If there are no external markup declarations, the standalone document declaration has no meaning. If there are external markup declarations but there is no standalone document declaration, the value "no" is assumed.

Since:

* XMLProcessor is a _non‑validating XML parser_
* XMLProcessor does not apply custom DTDs by design
* Many documents are implicitly standalone

We can just skip past those declarations without consequences.

## Testing instructions

CI. This PR enables additional W3C tests where `standalone="true"` is explicitly declared.