### PR TITLE
Update fixtures for valid blueprints as per blueprints v2 spec

### DIFF
--- a/components/Blueprints/Tests/Unit/Validator/fixtures/valid/full-features.json
+++ b/components/Blueprints/Tests/Unit/Validator/fixtures/valid/full-features.json
@@ -9,7 +9,7 @@
 			"Test Author",
 			"Another Author"
 		],
-		"authorUrl": "https://example.com",
+		"homepage": "https://example.com",
 		"donateLink": "https://example.com/donate",
 		"tags": [
 			"test",
@@ -129,11 +129,9 @@
 	],
 	"additionalStepsAfterExecution": [
 		{
-			"step": "writeFile",
-			"path": "wp-content/uploads/custom-file.txt",
-			"content": {
-				"filename": "custom-file.txt",
-				"content": "This is a custom file created by the Blueprint."
+			"step": "writeFiles",
+			"files": {
+				"wp-content/uploads/custom-file.txt": "This is a custom file created by the Blueprint."
 			}
 		},
 		{

--- a/components/Blueprints/Tests/Unit/Validator/fixtures/valid/with-additional-steps.json
+++ b/components/Blueprints/Tests/Unit/Validator/fixtures/valid/with-additional-steps.json
@@ -22,7 +22,7 @@
 		},
 		{
 			"step": "activateTheme",
-			"themeFolderName": "twentytwentythree"
+			"themeDirectoryName": "twentytwentythree"
 		},
 		{
 			"step": "cp",
@@ -32,18 +32,16 @@
 		{
 			"step": "defineConstants",
 			"constants": {
-				"WP_DEBUG": "true",
-				"SCRIPT_DEBUG": "false"
+				"WP_DEBUG": true,
+				"SCRIPT_DEBUG": false
 			}
 		},
 		{
 			"step": "installPlugin",
-			"plugin": {
-				"source": "jetpack",
-				"active": true,
-				"activationOptions": {
-					"mode": "development"
-				}
+			"source": "jetpack",
+			"active": true,
+			"activationOptions": {
+				"mode": "development"
 			}
 		},
 		{
@@ -58,9 +56,10 @@
 			}
 		},
 		{
-			"step": "writeFile",
-			"path": "/path/to/file.txt",
-			"content": "Hello World"
+			"step": "writeFiles",
+			"files": {
+			   "/path/to/file.txt": "Hello World"
+			}
 		}
 	]
 }

--- a/components/Blueprints/Tests/Unit/Validator/fixtures/valid/with-post-types.json
+++ b/components/Blueprints/Tests/Unit/Validator/fixtures/valid/with-post-types.json
@@ -54,7 +54,10 @@
 					}
 				],
 				[
-					"core/paragraph"
+					"core/paragraph",
+					{
+						"content": "This is a sample book."
+					}
 				]
 			],
 			"template_lock": "all"

--- a/components/Blueprints/Tests/Unit/Validator/fixtures/valid/with-steps.json
+++ b/components/Blueprints/Tests/Unit/Validator/fixtures/valid/with-steps.json
@@ -22,7 +22,7 @@
 		},
 		{
 			"step": "activateTheme",
-			"themeFolderName": "twentytwentythree"
+			"themeDirectoryName": "twentytwentythree"
 		},
 		{
 			"step": "cp",
@@ -38,12 +38,12 @@
 		},
 		{
 			"step": "installPlugin",
-			"plugin": "woocommerce"
+			"source": "woocommerce"
 		},
 		{
 			"step": "installTheme",
 			"source": "twentytwentyfour",
-			"activate": true,
+			"active": true,
 			"importStarterContent": true
 		},
 		{
@@ -68,7 +68,7 @@
 			"code": "echo 'Hello, World!';"
 		},
 		{
-			"step": "runSql",
+			"step": "runSQL",
 			"source": "./custom-queries.sql"
 		},
 		{
@@ -92,11 +92,9 @@
 			"command": "plugin list --format=json"
 		},
 		{
-			"step": "writeFile",
-			"path": "wp-content/uploads/new-file.txt",
-			"content": {
-				"filename": "content.txt",
-				"content": "This is the content of the file."
+			"step": "writeFiles",
+			"files": {
+				"wp-content/uploads/new-file.txt": "Content of file."
 			}
 		},
 		{


### PR DESCRIPTION
In my wpcom work, I found the following valid blueprint fixtures were out of date as per blueprints v2 spec. Our validator flagged them, and it now passes with the changes in this PR.

Also, note that these fixtures files are currently not used in the repo. Nor they were in the original commit. Seems like an intermediary artifact. With this PR, we can atleast have them to be upto dated & can possibly start using them in tests that we can add. In #213 I have the entire incorrect valid fixture file in the test, but if they are indeed to kept around, it can also use the fixture file.