### PR TITLE
CSS Processor: Fix consume_ident_start_codepoint bounds check

### DIFF
--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -1500,7 +1500,7 @@ class CSSProcessor {
 	 * @return int The number of bytes consumed.
 	 */
 	private function consume_ident_start_codepoint( $at ): int {
-		if ( $at > $this->length ) {
+		if ( $at >= $this->length ) {
 			return 0;
 		}
 

--- a/components/DataLiberation/Tests/CSSProcessorTest.php
+++ b/components/DataLiberation/Tests/CSSProcessorTest.php
@@ -1530,5 +1530,15 @@ CSS;
 		$this->assertSame( "background: url(\"\xC0.jpg\");", $updated );
 	}
 
-
+	/**
+	 * Test bounds check when consuming and ident start token.
+	 */
+	public function test_trailing_hyphen_at_end_of_input(): void {
+		$processor     = CSSProcessor::create( '-' );
+		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
+		$expected_tokens = array(
+			array( 'type' => CSSProcessor::TOKEN_DELIM, 'raw' => '-' ),
+		);
+		$this->assertSame( $expected_tokens, $actual_tokens );
+	}
 }

--- a/components/DataLiberation/Tests/CSSProcessorTest.php
+++ b/components/DataLiberation/Tests/CSSProcessorTest.php
@@ -1533,7 +1533,7 @@ CSS;
 	/**
 	 * Test bounds check when consuming and ident start token.
 	 */
-	public function test_trailing_hyphen_at_end_of_input(): void {
+	public function test_ident_start_codepoint_bounds_check(): void {
 		$processor     = CSSProcessor::create( '-' );
 		$actual_tokens = $this->collect_tokens( $processor, array( 'type', 'raw' ) );
 		$expected_tokens = array(


### PR DESCRIPTION
Fixes out-of-bounds string offset access when the input string ends while consuming an ident start.