### PR TITLE
WPURL: Preserve trailing-slash style for origin-only URLs

### DIFF
--- a/components/DataLiberation/Tests/RewriteUrlsTest.php
+++ b/components/DataLiberation/Tests/RewriteUrlsTest.php
@@ -95,6 +95,18 @@ HTML
 				'https://legacy-blog.com/~jappleseed/1997.10.1/',
 				'https://modern-webstore.org/blog/',
 			),
+			'Origin-only URL in block attribute – no trailing slash added'                                            => array(
+				'<!-- wp:paragraph {"url":"https://example.com"} -->',
+				'<!-- wp:paragraph {"url":"https:\/\/newsite.org"} -->',
+				'https://example.com',
+				'https://newsite.org',
+			),
+			'Origin-only URL in HTML attribute – no trailing slash added'                                             => array(
+				'<a href="https://example.com">Home</a>',
+				'<a href="https://newsite.org">Home</a>',
+				'https://example.com',
+				'https://newsite.org',
+			),
 			'Domain in an HTML attribute – encoded using HTML entities'                                               => array(
 				'<a href="&#104;&#116;tps://&#108;&#101;g&#97;&#99;&#121;&#45;&#98;&#108;&#111;&#103;.&#99;&#111;&#109;/pages/contact-us">Contact us</a>',
 				'<a href="https://modern-webstore.org/pages/contact-us">Contact us</a>',

--- a/components/DataLiberation/Tests/WPURLTest.php
+++ b/components/DataLiberation/Tests/WPURLTest.php
@@ -23,4 +23,68 @@ class WPURLTest extends TestCase {
 			),
 		);
 	}
+
+	/**
+	 * @dataProvider provider_test_replace_base_url_trailing_slash
+	 */
+	public function test_replace_base_url_trailing_slash( $url, $options, $expected_result ) {
+		$result = WPURL::replace_base_url( $url, $options );
+		$this->assertNotFalse( $result, 'replace_base_url() returned false' );
+		$this->assertEquals( $expected_result, (string) $result );
+	}
+
+	public static function provider_test_replace_base_url_trailing_slash() {
+		return array(
+			'Origin-only URL without trailing slash preserves no-slash style' => array(
+				'https://example.com/',
+				array(
+					'old_base_url' => 'https://example.com',
+					'new_base_url' => 'https://newsite.com',
+					'raw_url'      => 'https://example.com',
+					'is_relative'  => false,
+				),
+				'https://newsite.com',
+			),
+			'Origin-only URL with trailing slash preserves slash'             => array(
+				'https://example.com/',
+				array(
+					'old_base_url' => 'https://example.com',
+					'new_base_url' => 'https://newsite.com',
+					'raw_url'      => 'https://example.com/',
+					'is_relative'  => false,
+				),
+				'https://newsite.com/',
+			),
+			'Origin-only URL without slash, new base has a path'             => array(
+				'https://example.com/',
+				array(
+					'old_base_url' => 'https://example.com',
+					'new_base_url' => 'https://newsite.com/blog/',
+					'raw_url'      => 'https://example.com',
+					'is_relative'  => false,
+				),
+				'https://newsite.com/blog',
+			),
+			'URL with path and no trailing slash – existing behavior'        => array(
+				'https://example.com/page',
+				array(
+					'old_base_url' => 'https://example.com',
+					'new_base_url' => 'https://newsite.com',
+					'raw_url'      => 'https://example.com/page',
+					'is_relative'  => false,
+				),
+				'https://newsite.com/page',
+			),
+			'URL with path and trailing slash – existing behavior'           => array(
+				'https://example.com/page/',
+				array(
+					'old_base_url' => 'https://example.com',
+					'new_base_url' => 'https://newsite.com',
+					'raw_url'      => 'https://example.com/page/',
+					'is_relative'  => false,
+				),
+				'https://newsite.com/page/',
+			),
+		);
+	}
 }

--- a/components/DataLiberation/URL/class-wpurl.php
+++ b/components/DataLiberation/URL/class-wpurl.php
@@ -144,10 +144,26 @@ class WPURL {
 		$new_raw_url                = $updated_url->toString();
 		$should_trim_trailing_slash = (
 			'' !== $from_pathname &&
-			'/' !== substr( $from_pathname, -1 ) &&
-			'/' !== $from_pathname &&
 			'' === $url->search &&
-			'' === $url->hash
+			'' === $url->hash &&
+			(
+				( '/' !== substr( $from_pathname, -1 ) && '/' !== $from_pathname ) ||
+				/*
+				 * WHATWG normalises an empty path to "/", which adds a
+				 * trailing slash to origin-only URLs like
+				 * "https://example.com".  When the raw URL string is
+				 * available, use it to preserve the original
+				 * trailing-slash style so that values like siteurl/home
+				 * don't get an unwanted "/" appended.
+				 */
+				(
+					'/' === $from_pathname &&
+					array_key_exists( 'raw_url', $options ) &&
+					is_string( $options['raw_url'] ) &&
+					'' !== $options['raw_url'] &&
+					'/' !== substr( $options['raw_url'], -1 )
+				)
+			)
 		);
 		if ( $should_trim_trailing_slash ) {
 			$new_raw_url = rtrim( $new_raw_url, '/' );


### PR DESCRIPTION
## Summary

`WPURL::replace_base_url()` relies on the WHATWG URL parser, which normalises an empty path to `/`. When an origin-only URL like `https://example.com` (no trailing slash) went through `replace_base_url()`, its parsed pathname was `/`, and the existing trailing-slash logic explicitly skipped trimming when `$from_pathname === '/'`. The result gained an unwanted trailing slash (`https://newsite.com/`).

This fixes it by also checking the `raw_url` option string (when available) to detect the original trailing-slash style. If the raw URL didn't end with `/` but the WHATWG parser added one, we strip it from the output. This matters for values like `siteurl` and `home` during content migrations.

## Test plan

- [x] New unit tests in `WPURLTest` covering origin-only URLs with and without trailing slash
- [x] New integration tests in `RewriteUrlsTest` for origin-only URLs in block attributes and HTML attributes
- [x] All 2298 existing DataLiberation tests pass
- [x] Linter passes