### PR TITLE
CSS: Fix string token value on special string escapes

### DIFF
--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -1566,8 +1566,9 @@ class CSSProcessor {
 	 * @param int  $length          Length of the substring to decode.
 	 * @param bool $string_escapes  Optional, default false. When true, apply special CSS string
 	 *                              token escape rules:
-	 *                                - \-newline is consumed as a line continuation (ignored).
-	 *                                - \-EOF is silently discarded.
+	 *                                - 0x5C (backslash) followed by 0x0A (LF), 0x0C (FF), or 0x0D (CR)
+	 *                                  is consumed as a line continuation (ignored).
+	 *                                - 0x5C (backslash) at EOF is silently discarded.
 	 * @return string Decoded and normalized string.
 	 */
 	private function decode_range( int $start, int $length, bool $string_escapes = false ): string {

--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -1565,7 +1565,7 @@ class CSSProcessor {
 	 * @param int  $start           Start byte offset.
 	 * @param int  $length          Length of the substring to decode.
 	 * @param bool $string_escapes  Optional, default false. When true, apply additional escape
-	 *                              rules that apply only to string tokens (CSS §4.3.5).
+	 *                              rules that apply only to string tokens.
 	 * @return string Decoded and normalized string.
 	 */
 	private function decode_range( int $start, int $length, bool $string_escapes = false ): string {
@@ -1600,14 +1600,16 @@ class CSSProcessor {
 
 			// Handle escapes.
 			if ( '\\' === $char ) {
-				/*
-				 * String tokens have special escape rules per §4.3.5:
+				/**
+				 * String tokens have special escape rules:
 				 * - 0x5C (backslash) at EOF: consume the backslash, produce no value.
 				 * - 0x5C (backslash) followed by 0x0A (LF), 0x0C (FF), or 0x0D (CR):
 				 *   consume both characters as a line continuation, produce no value.
 				 * - 0x5C (backslash) followed by 0x0D 0x0A (CRLF):
 				 *   consume all three characters as a line continuation, produce no value.
 				 * These must be checked before the general escape path.
+				 *
+				 * @see **https://www.w3.org/TR/css-syntax-3/#consume-string-token
 				 */
 				if ( $string_escapes ) {
 					if ( $at + 1 >= $end ) {

--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -632,7 +632,7 @@ class CSSProcessor {
 			return null;
 		}
 
-		return $this->decode_escapes(
+		return $this->decode_range(
 			$this->token_starts_at,
 			$this->token_length,
 			self::TOKEN_STRING === $this->token_type || self::TOKEN_BAD_STRING === $this->token_type
@@ -681,29 +681,29 @@ class CSSProcessor {
 			switch ( $this->token_type ) {
 				case self::TOKEN_HASH:
 					// Hash value starts after the # character.
-					$this->token_value = $this->decode_escapes( $this->token_starts_at + 1, $this->token_length - 1 );
+					$this->token_value = $this->decode_range( $this->token_starts_at + 1, $this->token_length - 1 );
 					break;
 
 				case self::TOKEN_AT_KEYWORD:
 					// At-keyword value starts after the @ character.
-					$this->token_value = $this->decode_escapes( $this->token_starts_at + 1, $this->token_length - 1 );
+					$this->token_value = $this->decode_range( $this->token_starts_at + 1, $this->token_length - 1 );
 					break;
 
 				case self::TOKEN_FUNCTION:
 					// Function name is everything except the final (.
-					$this->token_value = $this->decode_escapes( $this->token_starts_at, $this->token_length - 1 );
+					$this->token_value = $this->decode_range( $this->token_starts_at, $this->token_length - 1 );
 					break;
 
 				case self::TOKEN_IDENT:
 					// Identifier is the entire token.
-					$this->token_value = $this->decode_escapes( $this->token_starts_at, $this->token_length );
+					$this->token_value = $this->decode_range( $this->token_starts_at, $this->token_length );
 					break;
 
 				case self::TOKEN_STRING:
 				case self::TOKEN_BAD_STRING:
 					// Decode and cache the string value.
 					if ( null !== $this->token_value_starts_at && null !== $this->token_value_length ) {
-						$this->token_value = $this->decode_escapes(
+						$this->token_value = $this->decode_range(
 							$this->token_value_starts_at,
 							$this->token_value_length,
 							true
@@ -716,7 +716,7 @@ class CSSProcessor {
 				case self::TOKEN_URL:
 					// Decode and cache the URL value.
 					if ( null !== $this->token_value_starts_at && null !== $this->token_value_length ) {
-						$this->token_value = $this->decode_escapes(
+						$this->token_value = $this->decode_range(
 							$this->token_value_starts_at,
 							$this->token_value_length
 						);
@@ -727,7 +727,7 @@ class CSSProcessor {
 
 				case self::TOKEN_DELIM:
 					// Delim value is the single code point.
-					$this->token_value = $this->decode_escapes( $this->token_starts_at, $this->token_length );
+					$this->token_value = $this->decode_range( $this->token_starts_at, $this->token_length );
 					break;
 
 				case self::TOKEN_NUMBER:
@@ -1197,7 +1197,7 @@ class CSSProcessor {
 			// Consume an ident sequence. Set the <dimension-token>'s unit to the returned value.
 			$unit_starts_at = $this->at;
 			$this->consume_ident_sequence();
-			$this->token_unit   = $this->decode_escapes( $unit_starts_at, $this->at - $unit_starts_at );
+			$this->token_unit   = $this->decode_range( $unit_starts_at, $this->at - $unit_starts_at );
 			$this->token_type   = self::TOKEN_DIMENSION;
 			$this->token_length = $this->at - $this->token_starts_at;
 			return true;
@@ -1232,7 +1232,7 @@ class CSSProcessor {
 		// Consume an ident sequence, and let string be the result.
 		$ident_start = $this->at;
 		$decoded     = $this->consume_ident_sequence();
-		$string      = $decoded ?? $this->decode_escapes( $ident_start, $this->at - $ident_start );
+		$string      = $decoded ?? $this->decode_range( $ident_start, $this->at - $ident_start );
 
 		// If string's value is an ASCII case-insensitive match for "url",
 		// and the next input code point is U+0028 LEFT PARENTHESIS (().
@@ -1553,7 +1553,17 @@ class CSSProcessor {
 	/**
 	 * Decodes and normalizes ident-like or string CSS values from a byte range.
 	 *
-	 * Applies appropriate escaping rules and normalizes newlines and null bytes.
+	 * For example:
+	 * ┌──────────────┬────────┐
+	 * │ Input        │ Output │
+	 * ├──────────────┼────────┤
+	 * │ 'xyz'        │ 'xyz'  │
+	 * │ '\x\y\z'     │ 'xyz'  │
+	 * │ 'x\79z'      │ 'xyz'  │
+	 * │ 'x\000079 z' │ 'xyz'  │
+	 * │ 'a\r\nb'     │ 'a\nb' │
+	 * │ 'a\0b'       │ 'a�b'  │
+	 * └──────────────┴────────┘
 	 *
 	 * @param int  $start           Start byte offset.
 	 * @param int  $length          Length of the substring to decode.
@@ -1563,7 +1573,7 @@ class CSSProcessor {
 	 *                                - \-EOF is silently discarded.
 	 * @return string Decoded and normalized string.
 	 */
-	private function decode_escapes( int $start, int $length, bool $string_escapes = false ): string {
+	private function decode_range( int $start, int $length, bool $string_escapes = false ): string {
 		// Fast path: check if any processing is needed.
 		$slice         = wp_scrub_utf8( substr( $this->css, $start, $length ) );
 		$special_chars = "\\\r\f\x00";

--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -1559,9 +1559,13 @@ class CSSProcessor {
 	 * Slow path: Builds the decoded string by optionally processing escapes and
 	 * normalizing line endings and null bytes.
 	 *
-	 * @param int $start           Start byte offset.
-	 * @param int $length          Length of the substring to decode.
-	 * @return string Decoded/normalized string.
+	 * @param int  $start           Start byte offset.
+	 * @param int  $length          Length of the substring to decode.
+	 * @param bool $string_escapes  Optional, default false. When true, apply special CSS string
+	 *                              token escape rules:
+	 *                                - \-newline is consumed as a line continuation (ignored).
+	 *                                - \-EOF is silently discarded.
+	 * @return string Decoded and normalized string.
 	 */
 	private function decode_escapes( int $start, int $length, bool $string_escapes = false ): string {
 		// Fast path: check if any processing is needed.

--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -1551,13 +1551,9 @@ class CSSProcessor {
 	}
 
 	/**
-	 * Decodes a string or URL value with escape sequences and normalization.
+	 * Decodes and normalizes ident-like or string CSS values from a byte range.
 	 *
-	 * Fast path: If the slice contains no special characters, returns the raw
-	 * substring with almost zero allocations.
-	 *
-	 * Slow path: Builds the decoded string by optionally processing escapes and
-	 * normalizing line endings and null bytes.
+	 * Applies appropriate escaping rules and normalizes newlines and null bytes.
 	 *
 	 * @param int  $start           Start byte offset.
 	 * @param int  $length          Length of the substring to decode.

--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -1564,11 +1564,8 @@ class CSSProcessor {
 	 *
 	 * @param int  $start           Start byte offset.
 	 * @param int  $length          Length of the substring to decode.
-	 * @param bool $string_escapes  Optional, default false. When true, apply special CSS string
-	 *                              token escape rules:
-	 *                                - 0x5C (backslash) followed by 0x0A (LF), 0x0C (FF), or 0x0D (CR)
-	 *                                  is consumed as a line continuation (ignored).
-	 *                                - 0x5C (backslash) at EOF is silently discarded.
+	 * @param bool $string_escapes  Optional, default false. When true, apply additional escape
+	 *                              rules that apply only to string tokens (CSS §4.3.5).
 	 * @return string Decoded and normalized string.
 	 */
 	private function decode_range( int $start, int $length, bool $string_escapes = false ): string {
@@ -1608,6 +1605,8 @@ class CSSProcessor {
 				 * - 0x5C (backslash) at EOF: consume the backslash, produce no value.
 				 * - 0x5C (backslash) followed by 0x0A (LF), 0x0C (FF), or 0x0D (CR):
 				 *   consume both characters as a line continuation, produce no value.
+				 * - 0x5C (backslash) followed by 0x0D 0x0A (CRLF):
+				 *   consume all three characters as a line continuation, produce no value.
 				 * These must be checked before the general escape path.
 				 */
 				if ( $string_escapes ) {

--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -632,9 +632,10 @@ class CSSProcessor {
 			return null;
 		}
 
-		return $this->decode_string_or_url(
+		return $this->decode_escapes(
 			$this->token_starts_at,
-			$this->token_length
+			$this->token_length,
+			self::TOKEN_STRING === $this->token_type || self::TOKEN_BAD_STRING === $this->token_type
 		);
 	}
 
@@ -680,34 +681,45 @@ class CSSProcessor {
 			switch ( $this->token_type ) {
 				case self::TOKEN_HASH:
 					// Hash value starts after the # character.
-					$this->token_value = $this->decode_string_or_url( $this->token_starts_at + 1, $this->token_length - 1 );
+					$this->token_value = $this->decode_escapes( $this->token_starts_at + 1, $this->token_length - 1 );
 					break;
 
 				case self::TOKEN_AT_KEYWORD:
 					// At-keyword value starts after the @ character.
-					$this->token_value = $this->decode_string_or_url( $this->token_starts_at + 1, $this->token_length - 1 );
+					$this->token_value = $this->decode_escapes( $this->token_starts_at + 1, $this->token_length - 1 );
 					break;
 
 				case self::TOKEN_FUNCTION:
 					// Function name is everything except the final (.
-					$this->token_value = $this->decode_string_or_url( $this->token_starts_at, $this->token_length - 1 );
+					$this->token_value = $this->decode_escapes( $this->token_starts_at, $this->token_length - 1 );
 					break;
 
 				case self::TOKEN_IDENT:
 					// Identifier is the entire token.
-					$this->token_value = $this->decode_string_or_url( $this->token_starts_at, $this->token_length );
+					$this->token_value = $this->decode_escapes( $this->token_starts_at, $this->token_length );
 					break;
 
 				case self::TOKEN_STRING:
 				case self::TOKEN_BAD_STRING:
-				case self::TOKEN_URL:
-					// Decode and cache the string/URL value.
+					// Decode and cache the string value.
 					if ( null !== $this->token_value_starts_at && null !== $this->token_value_length ) {
-						$this->token_value = $this->decode_string_or_url(
+						$this->token_value = $this->decode_escapes(
+							$this->token_value_starts_at,
+							$this->token_value_length,
+							true
+						);
+					} else {
+						$this->token_value = null;
+					}
+					break;
+
+				case self::TOKEN_URL:
+					// Decode and cache the URL value.
+					if ( null !== $this->token_value_starts_at && null !== $this->token_value_length ) {
+						$this->token_value = $this->decode_escapes(
 							$this->token_value_starts_at,
 							$this->token_value_length
 						);
-						$this->token_value = $this->token_value;
 					} else {
 						$this->token_value = null;
 					}
@@ -715,7 +727,7 @@ class CSSProcessor {
 
 				case self::TOKEN_DELIM:
 					// Delim value is the single code point.
-					$this->token_value = $this->decode_string_or_url( $this->token_starts_at, $this->token_length );
+					$this->token_value = $this->decode_escapes( $this->token_starts_at, $this->token_length );
 					break;
 
 				case self::TOKEN_NUMBER:
@@ -1185,7 +1197,7 @@ class CSSProcessor {
 			// Consume an ident sequence. Set the <dimension-token>'s unit to the returned value.
 			$unit_starts_at = $this->at;
 			$this->consume_ident_sequence();
-			$this->token_unit   = $this->decode_string_or_url( $unit_starts_at, $this->at - $unit_starts_at );
+			$this->token_unit   = $this->decode_escapes( $unit_starts_at, $this->at - $unit_starts_at );
 			$this->token_type   = self::TOKEN_DIMENSION;
 			$this->token_length = $this->at - $this->token_starts_at;
 			return true;
@@ -1220,7 +1232,7 @@ class CSSProcessor {
 		// Consume an ident sequence, and let string be the result.
 		$ident_start = $this->at;
 		$decoded     = $this->consume_ident_sequence();
-		$string      = $decoded ?? $this->decode_string_or_url( $ident_start, $this->at - $ident_start );
+		$string      = $decoded ?? $this->decode_escapes( $ident_start, $this->at - $ident_start );
 
 		// If string's value is an ASCII case-insensitive match for "url",
 		// and the next input code point is U+0028 LEFT PARENTHESIS (().
@@ -1551,7 +1563,7 @@ class CSSProcessor {
 	 * @param int $length          Length of the substring to decode.
 	 * @return string Decoded/normalized string.
 	 */
-	private function decode_string_or_url( int $start, int $length ): string {
+	private function decode_escapes( int $start, int $length, bool $string_escapes = false ): string {
 		// Fast path: check if any processing is needed.
 		$slice         = wp_scrub_utf8( substr( $this->css, $start, $length ) );
 		$special_chars = "\\\r\f\x00";
@@ -1581,8 +1593,35 @@ class CSSProcessor {
 
 			$char = $this->css[ $at ];
 
-			// Handle escapes (if enabled).
+			// Handle escapes.
 			if ( '\\' === $char ) {
+				/*
+				 * String tokens have special escape rules per §4.3.5:
+				 * - \-EOF: do nothing (consume the backslash, produce no value).
+				 * - \-newline: consume both (line continuation, produce no value).
+				 * These must be checked before the general escape path.
+				 */
+				if ( $string_escapes ) {
+					if ( $at + 1 >= $end ) {
+						// \-EOF: consume the backslash and stop.
+						++$at;
+						continue;
+					}
+					$next = $this->css[ $at + 1 ];
+					if ( "\n" === $next || "\f" === $next ) {
+						$at += 2;
+						continue;
+					}
+					if ( "\r" === $next ) {
+						$at += 2;
+						// \r\n counts as one newline.
+						if ( $at < $end && "\n" === $this->css[ $at ] ) {
+							++$at;
+						}
+						continue;
+					}
+				}
+
 				if ( $this->is_valid_escape( $at ) ) {
 					++$at;
 					$decoded .= $this->decode_escape_at( $at, $bytes_consumed );

--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -1609,7 +1609,7 @@ class CSSProcessor {
 				 *   consume all three characters as a line continuation, produce no value.
 				 * These must be checked before the general escape path.
 				 *
-				 * @see **https://www.w3.org/TR/css-syntax-3/#consume-string-token
+				 * @see https://www.w3.org/TR/css-syntax-3/#consume-string-token
 				 */
 				if ( $string_escapes ) {
 					if ( $at + 1 >= $end ) {

--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -635,7 +635,7 @@ class CSSProcessor {
 		return $this->decode_range(
 			$this->token_starts_at,
 			$this->token_length,
-			self::TOKEN_STRING === $this->token_type || self::TOKEN_BAD_STRING === $this->token_type
+			self::TOKEN_STRING === $this->token_type
 		);
 	}
 
@@ -1607,24 +1607,26 @@ class CSSProcessor {
 			if ( '\\' === $char ) {
 				/*
 				 * String tokens have special escape rules per §4.3.5:
-				 * - \-EOF: do nothing (consume the backslash, produce no value).
-				 * - \-newline: consume both (line continuation, produce no value).
+				 * - 0x5C (backslash) at EOF: consume the backslash, produce no value.
+				 * - 0x5C (backslash) followed by 0x0A (LF), 0x0C (FF), or 0x0D (CR):
+				 *   consume both characters as a line continuation, produce no value.
 				 * These must be checked before the general escape path.
 				 */
 				if ( $string_escapes ) {
 					if ( $at + 1 >= $end ) {
-						// \-EOF: consume the backslash and stop.
+						// 0x5C at EOF: consume the backslash and stop.
 						++$at;
 						continue;
 					}
 					$next = $this->css[ $at + 1 ];
 					if ( "\n" === $next || "\f" === $next ) {
+						// 0x5C followed by 0x0A (LF) or 0x0C (FF): line continuation.
 						$at += 2;
 						continue;
 					}
 					if ( "\r" === $next ) {
+						// 0x5C followed by 0x0D (CR): line continuation; 0x0D 0x0A counts as one newline.
 						$at += 2;
-						// \r\n counts as one newline.
 						if ( $at < $end && "\n" === $this->css[ $at ] ) {
 							++$at;
 						}

--- a/components/DataLiberation/Tests/CSSProcessorTest.php
+++ b/components/DataLiberation/Tests/CSSProcessorTest.php
@@ -27,7 +27,7 @@ class CSSProcessorTest extends TestCase {
 	 * @see https://github.com/romainmenke/css-processor-tests/
 	 * @return array
 	 */
-	static public function corpus_provider(): array {
+	public static function corpus_provider(): array {
 		return json_decode(file_get_contents(__DIR__ . '/css-test-cases.json'), true);
 	}
 
@@ -37,7 +37,7 @@ class CSSProcessorTest extends TestCase {
 	 * @param CSSProcessor $processor The CSS processor.
 	 * @return array Array of tokens with type, raw, startIndex, endIndex, structured.
 	 */
-	static public function collect_tokens( CSSProcessor $processor, $keys = null ): array {
+	public static function collect_tokens( CSSProcessor $processor, $keys = null ): array {
 		$tokens = array();
 
 		while ( $processor->next_token() ) {
@@ -1565,7 +1565,7 @@ CSS;
 		$this->assertSame( $expected_value, $processor->get_token_value() );
 	}
 
-	static public function data_string_backslash_newline(): array {
+	public static function data_string_backslash_newline(): array {
 		return array(
 			'backslash-LF'   => array( "'str\\\ning'", 'string' ),
 			'backslash-FF'   => array( "'str\\\fing'", 'string' ),
@@ -1617,7 +1617,7 @@ CSS;
 		$this->assertTrue( $found_bad_url, 'Expected a BAD_URL token but none was found.' );
 	}
 
-	static public function data_url_backslash_newline(): array {
+	public static function data_url_backslash_newline(): array {
 		return array(
 			'backslash-LF'   => array( "url(ab\\\ncd)" ),
 			'backslash-FF'   => array( "url(ab\\\fcd)" ),
@@ -1658,7 +1658,7 @@ CSS;
 		$this->assertSame( 'abc', $processor->get_token_value() );
 	}
 
-	static public function data_ident_backslash_newline(): array {
+	public static function data_ident_backslash_newline(): array {
 		return array(
 			'backslash-LF'   => array( "abc\\\n" ),
 			'backslash-FF'   => array( "abc\\\f" ),

--- a/components/DataLiberation/Tests/CSSProcessorTest.php
+++ b/components/DataLiberation/Tests/CSSProcessorTest.php
@@ -1541,4 +1541,142 @@ CSS;
 		);
 		$this->assertSame( $expected_tokens, $actual_tokens );
 	}
+
+	/**
+	 * Tests that backslash-newline in a string token contributes nothing to the value.
+	 *
+	 * CSS spec §4.3.5 consume-string-token:
+	 * > U+005C REVERSE SOLIDUS (\)
+	 * > Otherwise, if the next input code point is a newline, consume it.
+	 *
+	 * The backslash and newline are both consumed and produce no value.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-string-token
+	 * @see https://github.com/WordPress/php-toolkit/issues/222
+	 *
+	 * @dataProvider data_string_backslash_newline
+	 */
+	public function test_string_backslash_newline( string $css, string $expected_value ): void {
+		$processor = CSSProcessor::create( $css );
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( CSSProcessor::TOKEN_STRING, $processor->get_token_type() );
+		$this->assertSame( $expected_value, $processor->get_token_value() );
+	}
+
+	static public function data_string_backslash_newline(): array {
+		return array(
+			'backslash-LF'   => array( "'str\\\ning'", 'string' ),
+			'backslash-FF'   => array( "'str\\\fing'", 'string' ),
+			'backslash-CR'   => array( "'str\\\ring'", 'string' ),
+			'backslash-CRLF' => array( "'str\\\r\ning'", 'string' ),
+		);
+	}
+
+	/**
+	 * Tests that backslash-EOF in a string token contributes nothing to the value.
+	 *
+	 * CSS spec §4.3.5 consume-string-token:
+	 * > U+005C REVERSE SOLIDUS (\)
+	 * > If the next input code point is EOF, do nothing.
+	 *
+	 * The trailing backslash is consumed and produces no value.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-string-token
+	 * @see https://github.com/WordPress/php-toolkit/issues/223
+	 */
+	public function test_string_backslash_eof(): void {
+		$processor = CSSProcessor::create( "'string\\" );
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( CSSProcessor::TOKEN_STRING, $processor->get_token_type() );
+		$this->assertSame( 'string', $processor->get_token_value() );
+	}
+
+	/**
+	 * Tests that backslash-newline in an unquoted URL produces a bad-url token.
+	 *
+	 * In unquoted URLs, the backslash-newline check goes through is_valid_escape()
+	 * which returns false for newlines, triggering consume_remnants_of_bad_url().
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-url-token
+	 *
+	 * @dataProvider data_url_backslash_newline
+	 */
+	public function test_url_backslash_newline( string $css ): void {
+		$processor = CSSProcessor::create( $css );
+
+		$found_bad_url = false;
+		while ( $processor->next_token() ) {
+			if ( CSSProcessor::TOKEN_BAD_URL === $processor->get_token_type() ) {
+				$found_bad_url = true;
+				break;
+			}
+		}
+
+		$this->assertTrue( $found_bad_url, 'Expected a BAD_URL token but none was found.' );
+	}
+
+	static public function data_url_backslash_newline(): array {
+		return array(
+			'backslash-LF'   => array( "url(ab\\\ncd)" ),
+			'backslash-FF'   => array( "url(ab\\\fcd)" ),
+			'backslash-CR'   => array( "url(ab\\\rcd)" ),
+			'backslash-CRLF' => array( "url(ab\\\r\ncd)" ),
+		);
+	}
+
+	/**
+	 * Tests that backslash-EOF in an unquoted URL produces U+FFFD in the value.
+	 *
+	 * In unquoted URLs, is_valid_escape() returns true for backslash-EOF,
+	 * and consuming the escaped code point at EOF produces U+FFFD per spec.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-url-token
+	 */
+	public function test_url_backslash_eof(): void {
+		$processor = CSSProcessor::create( "url(string\\" );
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( CSSProcessor::TOKEN_URL, $processor->get_token_type() );
+		$this->assertSame( "string\u{FFFD}", $processor->get_token_value() );
+	}
+
+	/**
+	 * Tests that backslash-newline stops an ident sequence.
+	 *
+	 * In idents, is_valid_escape() returns false for backslash-newline,
+	 * so the ident stops before the backslash.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-name
+	 *
+	 * @dataProvider data_ident_backslash_newline
+	 */
+	public function test_ident_backslash_newline( string $css ): void {
+		$processor = CSSProcessor::create( $css );
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( CSSProcessor::TOKEN_IDENT, $processor->get_token_type() );
+		$this->assertSame( 'abc', $processor->get_token_value() );
+	}
+
+	static public function data_ident_backslash_newline(): array {
+		return array(
+			'backslash-LF'   => array( "abc\\\n" ),
+			'backslash-FF'   => array( "abc\\\f" ),
+			'backslash-CR'   => array( "abc\\\r" ),
+			'backslash-CRLF' => array( "abc\\\r\n" ),
+		);
+	}
+
+	/**
+	 * Tests that backslash-EOF in an ident produces U+FFFD in the value.
+	 *
+	 * In idents, is_valid_escape() returns true for backslash-EOF,
+	 * and consuming the escaped code point at EOF produces U+FFFD per spec.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#consume-name
+	 */
+	public function test_ident_backslash_eof(): void {
+		$processor = CSSProcessor::create( "abc\\" );
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( CSSProcessor::TOKEN_IDENT, $processor->get_token_type() );
+		$this->assertSame( "abc\u{FFFD}", $processor->get_token_value() );
+	}
 }

--- a/components/DataLiberation/Tests/CSSProcessorTest.php
+++ b/components/DataLiberation/Tests/CSSProcessorTest.php
@@ -5,6 +5,8 @@ use WordPress\DataLiberation\CSS\CSSProcessor;
 
 /**
  * Comprehensive CSS processor tests based on the CSS Syntax Level 3 specification.
+ *
+ * @group css
  */
 class CSSProcessorTest extends TestCase {
 

--- a/components/DataLiberation/Tests/CSSProcessorTest.php
+++ b/components/DataLiberation/Tests/CSSProcessorTest.php
@@ -1547,14 +1547,9 @@ CSS;
 	/**
 	 * Tests that backslash-newline in a string token contributes nothing to the value.
 	 *
-	 * CSS spec §4.3.5 consume-string-token:
-	 * > U+005C REVERSE SOLIDUS (\)
-	 * > Otherwise, if the next input code point is a newline, consume it.
-	 *
 	 * The backslash and newline are both consumed and produce no value.
 	 *
 	 * @see https://www.w3.org/TR/css-syntax-3/#consume-string-token
-	 * @see https://github.com/WordPress/php-toolkit/issues/222
 	 *
 	 * @dataProvider data_string_backslash_newline
 	 */
@@ -1577,14 +1572,9 @@ CSS;
 	/**
 	 * Tests that backslash-EOF in a string token contributes nothing to the value.
 	 *
-	 * CSS spec §4.3.5 consume-string-token:
-	 * > U+005C REVERSE SOLIDUS (\)
-	 * > If the next input code point is EOF, do nothing.
-	 *
 	 * The trailing backslash is consumed and produces no value.
 	 *
 	 * @see https://www.w3.org/TR/css-syntax-3/#consume-string-token
-	 * @see https://github.com/WordPress/php-toolkit/issues/223
 	 */
 	public function test_string_backslash_eof(): void {
 		$processor = CSSProcessor::create( "'string\\" );

--- a/components/DataLiberation/Tests/CSSUrlProcessorTest.php
+++ b/components/DataLiberation/Tests/CSSUrlProcessorTest.php
@@ -3,6 +3,9 @@
 use PHPUnit\Framework\TestCase;
 use WordPress\DataLiberation\URL\CSSURLProcessor;
 
+/**
+ * @group css
+ */
 class CSSURLProcessorTest extends TestCase {
 
 	/**

--- a/components/DataLiberation/Tests/css-test-cases.json
+++ b/components/DataLiberation/Tests/css-test-cases.json
@@ -273,8 +273,8 @@
 				"raw": "\"foo\\\n\"",
 				"startIndex": 0,
 				"endIndex": 7,
-				"normalized": "\"foo\\\n\"",
-				"value": "foo\\\n"
+				"normalized": "\"foo\"",
+				"value": "foo"
 			},
 			{
 				"type": "whitespace-token",
@@ -331,8 +331,8 @@
 				"raw": "\"foo\\\r\n\"",
 				"startIndex": 0,
 				"endIndex": 8,
-				"normalized": "\"foo\\\n\"",
-				"value": "foo\\\n"
+				"normalized": "\"foo\"",
+				"value": "foo"
 			},
 			{
 				"type": "whitespace-token",
@@ -1497,8 +1497,8 @@
 				"raw": "\"lQh{R5M!QyOWE}oC2{2K TIa9}zb2oXWREY]0aj5J\\\r\nBJ5CO-16W5H7noF 19䀹41H3e8Z9%tg[O5AHEY24xh'9\"",
 				"startIndex": 11,
 				"endIndex": 102,
-				"normalized": "\"lQh{R5M!QyOWE}oC2{2K TIa9}zb2oXWREY]0aj5J\\\nBJ5CO-16W5H7noF 19䀹41H3e8Z9%tg[O5AHEY24xh'9\"",
-				"value": "lQh{R5M!QyOWE}oC2{2K TIa9}zb2oXWREY]0aj5J\\\nBJ5CO-16W5H7noF 19䀹41H3e8Z9%tg[O5AHEY24xh'9"
+				"normalized": "\"lQh{R5M!QyOWE}oC2{2K TIa9}zb2oXWREY]0aj5JBJ5CO-16W5H7noF 19䀹41H3e8Z9%tg[O5AHEY24xh'9\"",
+				"value": "lQh{R5M!QyOWE}oC2{2K TIa9}zb2oXWREY]0aj5JBJ5CO-16W5H7noF 19䀹41H3e8Z9%tg[O5AHEY24xh'9"
 			},
 			{
 				"type": "string-token",
@@ -1721,8 +1721,8 @@
 				"raw": "'E{z\u0000U\u001fEG2}2Verb>nj3TVk3mu7wX1J\b.H\u000bi1Ga8f5 dserqydJ3\"xj398xy.W\" uHQbv7Bw1NtF;N3PwNY7Vx00BF o\"4CXzvP\"{594 6r}8QQKNQw135i1\\\r\nrey\thg7[5%rBK8RUC64Lu␌17O{E\\90873u}1O3vx4gHTC55Q9i4\"V3Vx4\"7r(34L]F\"ns2pPf\"V7b)EOBGH8rdC7\"\u000eVJ4OQ[ 9jtoMdINgS7o�206vo72kTcKkZR9wl30G'",
 				"startIndex": 3,
 				"endIndex": 263,
-				"normalized": "'E{z�U\u001fEG2}2Verb>nj3TVk3mu7wX1J\b.H\u000bi1Ga8f5 dserqydJ3\"xj398xy.W\" uHQbv7Bw1NtF;N3PwNY7Vx00BF o\"4CXzvP\"{594 6r}8QQKNQw135i1\\\nrey\thg7[5%rBK8RUC64Lu␌17O{E򐡳u}1O3vx4gHTC55Q9i4\"V3Vx4\"7r(34L]F\"ns2pPf\"V7b)EOBGH8rdC7\"\u000eVJ4OQ[ 9jtoMdINgS7o�206vo72kTcKkZR9wl30G'",
-				"value": "E{z�U\u001fEG2}2Verb>nj3TVk3mu7wX1J\b.H\u000bi1Ga8f5 dserqydJ3\"xj398xy.W\" uHQbv7Bw1NtF;N3PwNY7Vx00BF o\"4CXzvP\"{594 6r}8QQKNQw135i1\\\nrey\thg7[5%rBK8RUC64Lu␌17O{E򐡳u}1O3vx4gHTC55Q9i4\"V3Vx4\"7r(34L]F\"ns2pPf\"V7b)EOBGH8rdC7\"\u000eVJ4OQ[ 9jtoMdINgS7o�206vo72kTcKkZR9wl30G"
+				"normalized": "'E{z�U\u001fEG2}2Verb>nj3TVk3mu7wX1J\b.H\u000bi1Ga8f5 dserqydJ3\"xj398xy.W\" uHQbv7Bw1NtF;N3PwNY7Vx00BF o\"4CXzvP\"{594 6r}8QQKNQw135i1rey\thg7[5%rBK8RUC64Lu␌17O{E򐡳u}1O3vx4gHTC55Q9i4\"V3Vx4\"7r(34L]F\"ns2pPf\"V7b)EOBGH8rdC7\"\u000eVJ4OQ[ 9jtoMdINgS7o�206vo72kTcKkZR9wl30G'",
+				"value": "E{z�U\u001fEG2}2Verb>nj3TVk3mu7wX1J\b.H\u000bi1Ga8f5 dserqydJ3\"xj398xy.W\" uHQbv7Bw1NtF;N3PwNY7Vx00BF o\"4CXzvP\"{594 6r}8QQKNQw135i1rey\thg7[5%rBK8RUC64Lu␌17O{E򐡳u}1O3vx4gHTC55Q9i4\"V3Vx4\"7r(34L]F\"ns2pPf\"V7b)EOBGH8rdC7\"\u000eVJ4OQ[ 9jtoMdINgS7o�206vo72kTcKkZR9wl30G"
 			},
 			{
 				"type": "ident-token",
@@ -1893,8 +1893,8 @@
 				"raw": "'\\\r\n{X<E/9b}0nIa%eSz-vapw2GqeMsri#e1BQf3b\u001fPlEnFQg{ofB)L9b571J4!{mCN㐥a\\BgK48qgu9'",
 				"startIndex": 44,
 				"endIndex": 126,
-				"normalized": "'\\\n{X<E/9b}0nIa%eSz-vapw2GqeMsri#e1BQf3b\u001fPlEnFQg{ofB)L9b571J4!{mCN㐥a\u000bgK48qgu9'",
-				"value": "\\\n{X<E/9b}0nIa%eSz-vapw2GqeMsri#e1BQf3b\u001fPlEnFQg{ofB)L9b571J4!{mCN㐥a\u000bgK48qgu9"
+				"normalized": "'{X<E/9b}0nIa%eSz-vapw2GqeMsri#e1BQf3b\u001fPlEnFQg{ofB)L9b571J4!{mCN㐥a\u000bgK48qgu9'",
+				"value": "{X<E/9b}0nIa%eSz-vapw2GqeMsri#e1BQf3b\u001fPlEnFQg{ofB)L9b571J4!{mCN㐥a\u000bgK48qgu9"
 			},
 			{
 				"type": "ident-token",
@@ -4287,8 +4287,8 @@
 				"raw": "\"fo\\\no\"",
 				"startIndex": 0,
 				"endIndex": 7,
-				"normalized": "\"fo\\\no\"",
-				"value": "fo\\\no"
+				"normalized": "\"foo\"",
+				"value": "foo"
 			},
 			{
 				"type": "whitespace-token",
@@ -4308,8 +4308,8 @@
 				"raw": "\"fo\\",
 				"startIndex": 0,
 				"endIndex": 4,
-				"normalized": "\"fo�",
-				"value": "fo�"
+				"normalized": "\"fo",
+				"value": "fo"
 			}
 		]
 	},


### PR DESCRIPTION
## Summary

- Fix `\`-newline and `\`-EOF handling in CSS string token value decoding
- Rename `decode_string_or_url` → `decode_range` with a new `bool $string_escapes` parameter for [CSS string token rules (§4.3.5)](https://www.w3.org/TR/css-syntax-3/#consume-string-token): `\`-newline discards both characters (line continuation), `\`-EOF discards the backslash
- Add test coverage for these cases and fix incorrect expected values in the JSON test corpus
- Add `css` test group to allow `vendor/bin/phpunit --group css`

Note that the css test file diverged from the originals in these cases. For example, [see string/0005](https://github.com/romainmenke/css-tokenizer-tests/blob/4cdf29c796003ce1543b9d86bbf27c3b7447bab3/tests/string/0005/tokens.json) where the expected token value is `foo` like in this PR.

- fixes #222
- fixes #223

## Test plan

CI passes. Visually confirm that updated and new tests are correct.

