### PR TITLE
Fix Git component root-commit and full-history handling

### DIFF
--- a/components/Git/class-gitendpoint.php
+++ b/components/Git/class-gitendpoint.php
@@ -307,7 +307,7 @@ class GitEndpoint {
 				}
 
 				$parsed_commit = $reader->as_commit();
-				if ( ! isset( $parsed_commit->parents ) ) {
+				if ( empty( $parsed_commit->parents ) ) {
 					$common_parent_hash = Commit::NULL_HASH;
 					break;
 				}
@@ -321,7 +321,7 @@ class GitEndpoint {
 			}
 
 			// For each wanted commit, find objects not present in any of the have commits.
-			$new_objects = $this->repository->find_objects_added_in(
+			$new_objects = $this->repository->find_objects_added_since(
 				$want_hash,
 				$common_parent_hash
 			);

--- a/components/Git/class-gitrepository.php
+++ b/components/Git/class-gitrepository.php
@@ -234,7 +234,7 @@ class GitRepository {
 
 	public function find_objects_added_in( $new_commit_hash, $options = array() ) {
 		$new_commit  = $this->read_object( $new_commit_hash )->as_commit();
-		$parent_hash = $new_commit->get_first_parent_hash();
+		$parent_hash = empty( $new_commit->parents ) ? Commit::NULL_HASH : $new_commit->get_first_parent_hash();
 
 		return $this->find_objects_added_since( $new_commit_hash, $parent_hash, $options );
 	}
@@ -908,6 +908,27 @@ class GitRepository {
 	}
 
 	public function get_commits_range( string $head_oid, string $last_ancestor_oid, $options = array() ) {
+		// When walking back to the root (NULL_HASH ancestor), return all commits.
+		if ( Commit::is_null_hash( $last_ancestor_oid ) ) {
+			$commits = array();
+			$queue   = array( $head_oid );
+			$visited = array();
+			while ( ! empty( $queue ) ) {
+				$current_oid = array_shift( $queue );
+				if ( isset( $visited[ $current_oid ] ) || Commit::is_null_hash( $current_oid ) ) {
+					continue;
+				}
+				$visited[ $current_oid ] = true;
+				$commits[] = $current_oid;
+				$commit = $this->read_object( $current_oid )->as_commit();
+				foreach ( $commit->parents as $parent_hash ) {
+					$queue[] = $parent_hash;
+				}
+			}
+			$include_ancestor = $options['include_ancestor'] ?? true;
+			return $commits;
+		}
+
 		$commits = array();
 		$queue   = array( array( $head_oid ) );
 		$visited = array();


### PR DESCRIPTION
## Summary

Four related bugs in the Git component surface when the server-side smart-HTTP endpoints handle a repository whose history contains root commits (no parents), and when a fresh client clones for the first time (common ancestor = `NULL_HASH`).

## The four fixes

1. **`GitEndpoint::handle_fetch_request`** — `isset( \$parsed_commit->parents )` always returns true because `ParsedCommit` initializes `\$parents` to `[]`. The "commit is a root" branch therefore never fired and the server tried to resolve a non-existent parent. Switched to `empty()`.

2. **`GitEndpoint::handle_fetch_request`** — called `find_objects_added_in(\$parent, \$common_parent_hash)`, but that method's second parameter is `\$options` (an array), not an ancestor hash. The intent was `find_objects_added_since()` which is the documented "reachable from X but not from Y" operation.

3. **`GitRepository::find_objects_added_in`** — dereferenced `\$new_commit->get_first_parent_hash()` unconditionally, which returns `null` for root commits. Fall back to `Commit::NULL_HASH` when `\$new_commit->parents` is empty so the caller gets a walk starting from the root.

4. **`GitRepository::get_commits_range`** — threw when asked to walk back to `NULL_HASH` as the ancestor, which is exactly what happens on an initial clone where the client has no history. Added an explicit branch that walks the full reachable set from `\$head_oid`.

## Context

Found while implementing a smart-HTTP server (upload-pack / receive-pack) over a custom non-filesystem `GitRepository` implementation: a WordPress SQLite-backed \"branchfs\" overlay + Dolt for DB rows, exposed so developers can `git clone` a live WordPress site and `git push` changes back. See https://github.com/adamziel/experiments/tree/branched-wp/branched-wp for the full integration.

Without these four fixes, `git clone` from a repository whose history contains a root commit fails during pack generation.

## Test plan

- [ ] Existing Git component tests still pass.
- [ ] \`git clone\` from a repository with root commits succeeds (tested in the branched-wp project end-to-end with 13 acceptance-test steps).
- [ ] \`git push\` to the same repository succeeds after the client makes a commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)