### PR TITLE
CI: test against PHP 8.4 and 8.5

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
 
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
The PHPUnit matrix stopped at 8.3, which meant the URL-rewriter PR (#241) merged without ever exercising the PHP 8.5 native parser path on CI. This adds `8.4` and `8.5` to the matrix on Ubuntu, macOS, and Windows so we get coverage for the new code path retroactively — and so future changes that lean on newer runtimes get covered automatically.

Not reverting #241 — the goal here is precisely to see whether the new `WPWhatwgUrl` adapter passes on PHP 8.5 in CI.