### PR TITLE
Fix ZipFilesystem remote-read failures on PHP 8.5

### DIFF
--- a/components/DataLiberation/Tests/WPWhatwgUrlSearchParamsTest.php
+++ b/components/DataLiberation/Tests/WPWhatwgUrlSearchParamsTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WordPress\DataLiberation\URL\WPURL;
+use WordPress\DataLiberation\URL\WPWhatwgUrl;
+
+/**
+ * Tests for the searchParams adapter that sits on top of PHP 8.5's native
+ * Uri\WhatWg\Url. Skipped on older runtimes where the native parser does not
+ * exist and WPURL falls back to Rowbot (which has its own searchParams).
+ */
+class WPWhatwgUrlSearchParamsTest extends TestCase {
+
+	/**
+	 * @before
+	 */
+	public function require_native_parser() {
+		if ( ! class_exists( '\\Uri\\WhatWg\\Url' ) ) {
+			$this->markTestSkipped( 'Uri\\WhatWg\\Url is only available on PHP 8.5+' );
+		}
+	}
+
+	private function parse( $url ) {
+		$parsed = WPURL::parse( $url );
+		$this->assertInstanceOf( WPWhatwgUrl::class, $parsed );
+		return $parsed;
+	}
+
+	public function test_get_returns_first_value_or_null() {
+		$url = $this->parse( 'https://example.com/?foo=bar&baz=qux' );
+		$this->assertSame( 'bar', $url->searchParams->get( 'foo' ) );
+		$this->assertSame( 'qux', $url->searchParams->get( 'baz' ) );
+		$this->assertNull( $url->searchParams->get( 'missing' ) );
+	}
+
+	public function test_get_returns_first_of_repeated_keys() {
+		$url = $this->parse( 'https://example.com/?k=1&k=2&k=3' );
+		$this->assertSame( '1', $url->searchParams->get( 'k' ) );
+		$this->assertSame( array( '1', '2', '3' ), $url->searchParams->getAll( 'k' ) );
+	}
+
+	public function test_has() {
+		$url = $this->parse( 'https://example.com/?chunked=yes' );
+		$this->assertTrue( $url->searchParams->has( 'chunked' ) );
+		$this->assertFalse( $url->searchParams->has( 'missing' ) );
+	}
+
+	public function test_empty_query() {
+		$url = $this->parse( 'https://example.com/' );
+		$this->assertSame( 0, $url->searchParams->size );
+		$this->assertNull( $url->searchParams->get( 'anything' ) );
+	}
+
+	public function test_set_replaces_first_and_drops_duplicates() {
+		$url = $this->parse( 'https://example.com/?k=1&k=2&other=x' );
+		$url->searchParams->set( 'k', 'new' );
+		$this->assertSame( 'new', $url->searchParams->get( 'k' ) );
+		$this->assertSame( array( 'new' ), $url->searchParams->getAll( 'k' ) );
+		$this->assertSame( 'x', $url->searchParams->get( 'other' ) );
+	}
+
+	public function test_set_appends_when_missing_and_updates_url_search() {
+		$url = $this->parse( 'https://example.com/' );
+		$url->searchParams->set( 'a', '1' );
+		$this->assertSame( '?a=1', $url->search );
+		$this->assertSame( 'https://example.com/?a=1', $url->toString() );
+	}
+
+	public function test_append_keeps_existing_values() {
+		$url = $this->parse( 'https://example.com/?k=1' );
+		$url->searchParams->append( 'k', '2' );
+		$this->assertSame( array( '1', '2' ), $url->searchParams->getAll( 'k' ) );
+	}
+
+	public function test_delete_removes_all_matching() {
+		$url = $this->parse( 'https://example.com/?k=1&k=2&other=x' );
+		$url->searchParams->delete( 'k' );
+		$this->assertFalse( $url->searchParams->has( 'k' ) );
+		$this->assertSame( '?other=x', $url->search );
+	}
+
+	public function test_delete_clears_query_when_empty() {
+		$url = $this->parse( 'https://example.com/?only=1' );
+		$url->searchParams->delete( 'only' );
+		$this->assertSame( '', $url->search );
+		$this->assertSame( 0, $url->searchParams->size );
+	}
+
+	public function test_size_reflects_pair_count() {
+		$url = $this->parse( 'https://example.com/?a=1&b=2&a=3' );
+		$this->assertSame( 3, $url->searchParams->size );
+		$this->assertCount( 3, $url->searchParams );
+	}
+
+	public function test_iteration_yields_pairs_in_order() {
+		$url = $this->parse( 'https://example.com/?a=1&b=2&a=3' );
+		$pairs = array();
+		foreach ( $url->searchParams as $pair ) {
+			$pairs[] = $pair;
+		}
+		$this->assertSame(
+			array(
+				array( 'a', '1' ),
+				array( 'b', '2' ),
+				array( 'a', '3' ),
+			),
+			$pairs
+		);
+	}
+
+	public function test_percent_encoded_values_round_trip() {
+		$url = $this->parse( 'https://example.com/?path=%2Ffoo%2Fbar&q=hello+world' );
+		$this->assertSame( '/foo/bar', $url->searchParams->get( 'path' ) );
+		$this->assertSame( 'hello world', $url->searchParams->get( 'q' ) );
+	}
+
+	public function test_set_encodes_special_characters() {
+		$url = $this->parse( 'https://example.com/' );
+		$url->searchParams->set( 'q', 'hello world&more' );
+		$this->assertSame( 'hello world&more', $url->searchParams->get( 'q' ) );
+		$this->assertStringContainsString( 'q=hello+world%26more', $url->search );
+	}
+
+	public function test_to_string_serializes_current_pairs() {
+		$url = $this->parse( 'https://example.com/?a=1&b=2' );
+		$this->assertSame( 'a=1&b=2', $url->searchParams->toString() );
+		$this->assertSame( 'a=1&b=2', (string) $url->searchParams );
+	}
+}

--- a/components/DataLiberation/URL/class-wpwhatwgurl.php
+++ b/components/DataLiberation/URL/class-wpwhatwgurl.php
@@ -23,6 +23,9 @@ class WPWhatwgUrl {
 	/** @var \Uri\WhatWg\Url */
 	private $url;
 
+	/** @var WPWhatwgUrlSearchParams|null */
+	private $search_params;
+
 	public function __construct( \Uri\WhatWg\Url $url ) {
 		$this->url = $url;
 	}
@@ -121,6 +124,12 @@ class WPWhatwgUrl {
 
 			case 'origin':
 				return $this->compute_origin();
+
+			case 'searchParams':
+				if ( null === $this->search_params ) {
+					$this->search_params = new WPWhatwgUrlSearchParams( $this );
+				}
+				return $this->search_params;
 		}
 
 		return null;

--- a/components/DataLiberation/URL/class-wpwhatwgurlsearchparams.php
+++ b/components/DataLiberation/URL/class-wpwhatwgurlsearchparams.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace WordPress\DataLiberation\URL;
+
+/**
+ * Adapter that exposes the WHATWG URLSearchParams API on top of WPWhatwgUrl.
+ *
+ * The PHP 8.5 native Uri\WhatWg\Url parser does not expose a URLSearchParams
+ * counterpart, but the rest of the codebase (and Rowbot's URL implementation)
+ * relies on $url->searchParams->get()/has()/set()/delete()/append(). This
+ * class reads from and writes to the owning URL's query string so callers can
+ * keep using the familiar property-based API regardless of which parser
+ * backs WPURL::parse().
+ *
+ * Pairs are serialized as application/x-www-form-urlencoded — that matches
+ * the WHATWG URLSearchParams stringifier and what Rowbot produces.
+ */
+class WPWhatwgUrlSearchParams implements \Countable, \IteratorAggregate {
+
+	/** @var WPWhatwgUrl */
+	private $owner;
+
+	public function __construct( WPWhatwgUrl $owner ) {
+		$this->owner = $owner;
+	}
+
+	public function __get( $name ) {
+		if ( 'size' === $name ) {
+			return count( $this->read_pairs() );
+		}
+		return null;
+	}
+
+	public function get( $name ) {
+		foreach ( $this->read_pairs() as $pair ) {
+			if ( $pair[0] === (string) $name ) {
+				return $pair[1];
+			}
+		}
+		return null;
+	}
+
+	public function getAll( $name ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		$values = array();
+		foreach ( $this->read_pairs() as $pair ) {
+			if ( $pair[0] === (string) $name ) {
+				$values[] = $pair[1];
+			}
+		}
+		return $values;
+	}
+
+	public function has( $name ) {
+		foreach ( $this->read_pairs() as $pair ) {
+			if ( $pair[0] === (string) $name ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public function set( $name, $value ) {
+		$name   = (string) $name;
+		$value  = (string) $value;
+		$pairs  = $this->read_pairs();
+		$result = array();
+		$found  = false;
+		foreach ( $pairs as $pair ) {
+			if ( $pair[0] === $name ) {
+				if ( ! $found ) {
+					$result[] = array( $name, $value );
+					$found    = true;
+				}
+				continue;
+			}
+			$result[] = $pair;
+		}
+		if ( ! $found ) {
+			$result[] = array( $name, $value );
+		}
+		$this->write_pairs( $result );
+	}
+
+	public function append( $name, $value ) {
+		$pairs   = $this->read_pairs();
+		$pairs[] = array( (string) $name, (string) $value );
+		$this->write_pairs( $pairs );
+	}
+
+	public function delete( $name ) {
+		$name   = (string) $name;
+		$result = array();
+		foreach ( $this->read_pairs() as $pair ) {
+			if ( $pair[0] === $name ) {
+				continue;
+			}
+			$result[] = $pair;
+		}
+		$this->write_pairs( $result );
+	}
+
+	public function count(): int {
+		return count( $this->read_pairs() );
+	}
+
+	public function getIterator(): \Iterator { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return new \ArrayIterator( $this->read_pairs() );
+	}
+
+	// Method name mirrors the WHATWG URLSearchParams API.
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function toString(): string {
+		return $this->serialize( $this->read_pairs() );
+	}
+
+	public function __toString(): string {
+		return $this->toString();
+	}
+
+	/**
+	 * @return array<int, array{0: string, 1: string}>
+	 */
+	private function read_pairs() {
+		$search = $this->owner->__get( 'search' );
+		if ( '' === $search || '?' === $search ) {
+			return array();
+		}
+		$query = '?' === $search[0] ? substr( $search, 1 ) : $search;
+		$pairs = array();
+		foreach ( explode( '&', $query ) as $segment ) {
+			if ( '' === $segment ) {
+				continue;
+			}
+			$eq = strpos( $segment, '=' );
+			if ( false === $eq ) {
+				$pairs[] = array( self::decode( $segment ), '' );
+			} else {
+				$pairs[] = array(
+					self::decode( substr( $segment, 0, $eq ) ),
+					self::decode( substr( $segment, $eq + 1 ) ),
+				);
+			}
+		}
+		return $pairs;
+	}
+
+	private function write_pairs( array $pairs ) {
+		if ( empty( $pairs ) ) {
+			$this->owner->__set( 'search', '' );
+			return;
+		}
+		$this->owner->__set( 'search', '?' . $this->serialize( $pairs ) );
+	}
+
+	private function serialize( array $pairs ) {
+		$parts = array();
+		foreach ( $pairs as $pair ) {
+			$parts[] = self::encode( $pair[0] ) . '=' . self::encode( $pair[1] );
+		}
+		return implode( '&', $parts );
+	}
+
+	private static function encode( $value ) {
+		// urlencode() produces application/x-www-form-urlencoded output —
+		// spaces become "+" and the rest is percent-encoded — matching the
+		// WHATWG URLSearchParams stringifier. rawurlencode() would percent-
+		// encode spaces as %20 instead, which is wrong here.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode
+		return urlencode( $value );
+	}
+
+	private static function decode( $value ) {
+		return urldecode( $value );
+	}
+}


### PR DESCRIPTION
The new PHP 8.5 CI job surfaced two `ZipFilesystemTest::testReadRemoteZip` errors that boil down to one missing piece in the WHATWG URL adapter.

When #241 swapped Rowbot for the native `Uri\WhatWg\Url` parser on PHP 8.5+, the new `WPWhatwgUrl` adapter mirrored everything the rest of the codebase touches — `protocol`, `hostname`, `pathname`, `search`, ... — except `searchParams`. The Zip test server reads `$parsed_url->searchParams->get('chunked')` to decide whether to send chunked encoding; on 8.5 that fataled mid-request, the server died, and the client never saw a `Content-Length`. `SeekableRequestReadStream::length()` then returned `null`, `ZipFilesystem` did `null - 22 = -22`, and the underlying byte stream rejected the negative seek.

This adds a small `WPWhatwgUrlSearchParams` adapter that reads from and writes to the owning URL's query, exposing the WHATWG / Rowbot API the rest of the codebase already uses (`get`, `has`, `set`, `append`, `delete`, `size`, `toString`, iteration). Pairs round-trip as `application/x-www-form-urlencoded` to match the WHATWG stringifier.

## Test plan
- [ ] `vendor/bin/phpunit components/Zip/Tests/ZipFilesystemTest.php` passes on PHP 8.5
- [ ] CI green on the 8.4 / 8.5 matrix