### PR TITLE
Stop shipping tests to Packagist

### DIFF
--- a/components/BlockParser/.gitattributes
+++ b/components/BlockParser/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/BlockParser/composer.json
+++ b/components/BlockParser/composer.json
@@ -26,12 +26,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/Blueprints/.gitattributes
+++ b/components/Blueprints/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/Blueprints/composer.json
+++ b/components/Blueprints/composer.json
@@ -28,12 +28,5 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/ByteStream/.gitattributes
+++ b/components/ByteStream/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/ByteStream/composer.json
+++ b/components/ByteStream/composer.json
@@ -26,12 +26,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/CLI/.gitattributes
+++ b/components/CLI/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/CLI/composer.json
+++ b/components/CLI/composer.json
@@ -23,12 +23,5 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/CORSProxy/.gitattributes
+++ b/components/CORSProxy/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/CORSProxy/composer.json
+++ b/components/CORSProxy/composer.json
@@ -26,12 +26,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/DataLiberation/.gitattributes
+++ b/components/DataLiberation/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/DataLiberation/composer.json
+++ b/components/DataLiberation/composer.json
@@ -31,12 +31,5 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/Encoding/.gitattributes
+++ b/components/Encoding/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/Encoding/composer.json
+++ b/components/Encoding/composer.json
@@ -25,12 +25,5 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/Filesystem/.gitattributes
+++ b/components/Filesystem/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/Filesystem/composer.json
+++ b/components/Filesystem/composer.json
@@ -30,12 +30,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/Git/.gitattributes
+++ b/components/Git/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/Git/composer.json
+++ b/components/Git/composer.json
@@ -32,12 +32,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/HTML/.gitattributes
+++ b/components/HTML/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/HTML/composer.json
+++ b/components/HTML/composer.json
@@ -26,12 +26,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/HttpClient/.gitattributes
+++ b/components/HttpClient/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/HttpClient/composer.json
+++ b/components/HttpClient/composer.json
@@ -29,12 +29,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/HttpServer/.gitattributes
+++ b/components/HttpServer/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/HttpServer/composer.json
+++ b/components/HttpServer/composer.json
@@ -29,12 +29,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/Markdown/.gitattributes
+++ b/components/Markdown/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/Markdown/composer.json
+++ b/components/Markdown/composer.json
@@ -28,12 +28,5 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/Merge/.gitattributes
+++ b/components/Merge/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/Merge/composer.json
+++ b/components/Merge/composer.json
@@ -32,12 +32,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/Polyfill/.gitattributes
+++ b/components/Polyfill/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/Polyfill/composer.json
+++ b/components/Polyfill/composer.json
@@ -24,12 +24,5 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/XML/.gitattributes
+++ b/components/XML/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/XML/composer.json
+++ b/components/XML/composer.json
@@ -27,12 +27,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }

--- a/components/Zip/.gitattributes
+++ b/components/Zip/.gitattributes
@@ -1,0 +1,5 @@
+/Tests/             export-ignore
+/.github/           export-ignore
+/.gitattributes     export-ignore
+phpunit.xml         export-ignore
+phpunit.xml.dist    export-ignore

--- a/components/Zip/composer.json
+++ b/components/Zip/composer.json
@@ -32,12 +32,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
-    },
-    "archive": {
-        "exclude": [
-            "**/.github/",
-            "**/Tests/",
-            "**/bin/"
-        ]
     }
 }


### PR DESCRIPTION
Components publish to Packagist through per-component split repos created by `git filter-repo` in `bin/split-code.sh`. Packagist then builds dist tarballs with `git archive`, which honors `.gitattributes` `export-ignore` and ignores the `archive.exclude` blocks our `composer.json` files relied on. So every release has been shipping `Tests/` and fixtures to downstream users — meaningful bloat on Git (~29 MB), XML (~15 MB), and others.

This adds a `.gitattributes` inside each `components/<Name>/` so it lands at the split repo root with the right `export-ignore` patterns, and removes the dead `archive` blocks from each component `composer.json`. Runtime is unaffected: every component already has `"exclude-from-classmap": ["/Tests/"]` in its autoload, so dropping `Tests/` from the dist tarball can't break consumers.

Cut a release after merge to flush the smaller tarballs to Packagist.