### PR TITLE
Remove leftover ?dump init trigger from static-files-editor

### DIFF
--- a/plugins/static-files-editor/plugin.php
+++ b/plugins/static-files-editor/plugin.php
@@ -63,15 +63,6 @@ if ( ! defined( 'WP_STATIC_FILES_EDITOR_IMAGE_MAX_DIMENSION' ) ) {
 	define( 'WP_STATIC_FILES_EDITOR_IMAGE_MAX_DIMENSION', 1280 );
 }
 
-if ( isset( $_GET['dump'] ) ) {
-	add_action(
-		'init',
-		function () {
-			WP_Static_Files_Editor_Plugin::import_static_pages();
-		}
-	);
-}
-
 require_once __DIR__ . '/data-source-page.php';
 require_once __DIR__ . '/DataSource.php';
 


### PR DESCRIPTION
The static-files-editor plugin had a top-level handler that ran `import_static_pages()` whenever a request URL contained `?dump`. It was a development shortcut from when the importer needed a quick way to refresh local state while iterating, and it predates the proper admin entry points the plugin uses today.

Nothing in the plugin UI relies on it, it isn't documented, and there's no reason for a normal install to reach it. Importing already runs on activation and through the admin paths callers actually use, so the standalone trigger is just dead weight. This patch removes those nine lines.