### PR TITLE
Fix Packagist autoload for Zip, Polyfill, and HTML

### DIFF
--- a/components/HTML/composer.json
+++ b/components/HTML/composer.json
@@ -20,6 +20,9 @@
         "classmap": [
             "./"
         ],
+        "files": [
+            "html5-named-character-references.php"
+        ],
         "exclude-from-classmap": [
             "/Tests/"
         ]

--- a/components/Polyfill/composer.json
+++ b/components/Polyfill/composer.json
@@ -14,7 +14,9 @@
         }
     ],
     "require": {
-        "php": ">=7.2"
+        "php": ">=7.2",
+        "wp-php-toolkit/blockparser": "^0.8",
+        "wp-php-toolkit/html": "^0.8"
     },
     "autoload": {
         "files": [

--- a/components/Polyfill/wordpress.php
+++ b/components/Polyfill/wordpress.php
@@ -5,12 +5,12 @@
 
  // phpcs:disable
 
-if (
-	! isset( $html5_named_character_references ) &&
-	file_exists( __DIR__ . '/../HTML/html5-named-character-references.php' )
-) {
-	require_once __DIR__ . '/../HTML/html5-named-character-references.php';
-}
+// $html5_named_character_references and the WP_Block_Parser_* classes are
+// provided by wp-php-toolkit/html and wp-php-toolkit/blockparser via
+// Composer (HTML loads its char-references file through autoload.files;
+// BlockParser is autoloaded by classmap on first use). The previous inline
+// require_once calls used monorepo-relative paths (../HTML, ../BlockParser)
+// that broke once each component was split into its own Packagist package.
 
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
@@ -27,12 +27,6 @@ if ( ! class_exists( 'WP_Error' ) ) {
 			$this->data = $data;
 		}
 	}
-}
-
-if ( ! class_exists( 'WP_Block_Parser' ) ) {
-	require_once __DIR__ . '/../BlockParser/class-wp-block-parser-block.php';
-	require_once __DIR__ . '/../BlockParser/class-wp-block-parser-frame.php';
-	require_once __DIR__ . '/../BlockParser/class-wp-block-parser.php';
 }
 
 if ( ! function_exists( '_doing_it_wrong' ) ) {

--- a/components/Polyfill/wordpress.php
+++ b/components/Polyfill/wordpress.php
@@ -5,13 +5,6 @@
 
  // phpcs:disable
 
-// $html5_named_character_references and the WP_Block_Parser_* classes are
-// provided by wp-php-toolkit/html and wp-php-toolkit/blockparser via
-// Composer (HTML loads its char-references file through autoload.files;
-// BlockParser is autoloaded by classmap on first use). The previous inline
-// require_once calls used monorepo-relative paths (../HTML, ../BlockParser)
-// that broke once each component was split into its own Packagist package.
-
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		public $code;

--- a/components/Zip/composer.json
+++ b/components/Zip/composer.json
@@ -24,7 +24,7 @@
             "WordPress\\Zip\\": ""
         },
         "files": [
-            "src/functions.php"
+            "functions.php"
         ],
         "exclude-from-classmap": [
             "/Tests/"

--- a/composer-ci-matrix-tests.json
+++ b/composer-ci-matrix-tests.json
@@ -52,6 +52,7 @@
 			"components/Encoding/compat-utf8.php",
 			"components/Encoding/utf8-encoder.php",
 			"components/Filesystem/functions.php",
+			"components/HTML/html5-named-character-references.php",
 			"components/Zip/functions.php",
 			"components/Polyfill/wordpress.php",
 			"components/Polyfill/mbstring.php",

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
 			"components/Encoding/compat-utf8.php",
 			"components/Encoding/utf8-encoder.php",
 			"components/Filesystem/functions.php",
+			"components/HTML/html5-named-character-references.php",
 			"components/Zip/functions.php",
 			"components/Polyfill/wordpress.php",
 			"components/Polyfill/mbstring.php",


### PR DESCRIPTION
After the v0.7.0 release I smoke-tested the published Packagist packages and found three autoload bugs that the monorepo layout had been hiding. Each one fires on `require vendor/autoload.php` for any consumer who pulls in the affected packages directly — both v0.6.2 and v0.7.0 reproduce them, so this is pre-existing fallout from the split-repo distribution, not a new regression.

**`wp-php-toolkit/zip`** — `autoload.files` pointed at `src/functions.php`, but the file lives at the package root. Every consumer hit a fatal `Failed to open stream: src/functions.php`.

**`wp-php-toolkit/polyfill`** — `wordpress.php` loaded sibling components via relative paths (`__DIR__/../HTML/...`, `__DIR__/../BlockParser/...`). Those resolve fine inside `components/` but point at nothing once each component lives at `vendor/wp-php-toolkit/<name>/`.

**`wp-php-toolkit/html`** — never loaded its own `html5-named-character-references.php`. It relied on Polyfill pre-populating the global, so a project that pulled in just `wp-php-toolkit/html` got a `WP_HTML_Decoder` whose `$html5_named_character_references` was null and crashed on the first entity it tried to decode.

The fix is small: Zip points at the right path, HTML loads its own character-references file via `autoload.files`, and Polyfill drops the inline `require_once` calls and declares proper Composer dependencies on `wp-php-toolkit/blockparser` and `wp-php-toolkit/html`. Composer takes care of the rest in any layout, monorepo or split. The root `composer.json` picks up the HTML char-references file directly so the monorepo keeps loading it (it used to come in indirectly through Polyfill's now-removed `require_once`).

`composer test` is at parity with trunk (1 pre-existing failure, 0 errors), and `composer lint` is clean apart from one pre-existing warning in `Git/class-gitremote.php`.

After merge, cut a `patch` release so v0.7.1 actually loads on Packagist.