### PR TITLE
Switch component autoload from PSR-4 to classmap

### DIFF
--- a/components/CLI/composer.json
+++ b/components/CLI/composer.json
@@ -17,9 +17,9 @@
         "php": ">=7.2"
     },
     "autoload": {
-        "psr-4": {
-            "WordPress\\CLI\\": ""
-        },
+        "classmap": [
+            "./"
+        ],
         "exclude-from-classmap": [
             "/Tests/"
         ]

--- a/components/Filesystem/composer.json
+++ b/components/Filesystem/composer.json
@@ -18,9 +18,9 @@
         "wp-php-toolkit/bytestream": "^0.8"
     },
     "autoload": {
-        "psr-4": {
-            "WordPress\\Filesystem\\": ""
-        },
+        "classmap": [
+            "./"
+        ],
         "files": [
             "functions.php"
         ],

--- a/components/Git/composer.json
+++ b/components/Git/composer.json
@@ -20,9 +20,9 @@
         "wp-php-toolkit/http-client": "^0.8"
     },
     "autoload": {
-        "psr-4": {
-            "WordPress\\Git\\": ""
-        },
+        "classmap": [
+            "./"
+        ],
         "files": [
             "functions.php"
         ],

--- a/components/HttpClient/composer.json
+++ b/components/HttpClient/composer.json
@@ -20,9 +20,9 @@
         "wp-php-toolkit/filesystem": "^0.8"
     },
     "autoload": {
-        "psr-4": {
-            "WordPress\\HttpClient\\": ""
-        },
+        "classmap": [
+            "./"
+        ],
         "exclude-from-classmap": [
             "/Tests/"
         ]

--- a/components/HttpServer/composer.json
+++ b/components/HttpServer/composer.json
@@ -20,9 +20,9 @@
         "wp-php-toolkit/http-client": "^0.8"
     },
     "autoload": {
-        "psr-4": {
-            "WordPress\\HttpServer\\": ""
-        },
+        "classmap": [
+            "./"
+        ],
         "exclude-from-classmap": [
             "/Tests/"
         ]

--- a/components/Markdown/composer.json
+++ b/components/Markdown/composer.json
@@ -20,11 +20,9 @@
     },
     "autoload": {
         "classmap": [
+            "./",
             "vendor-patched"
         ],
-        "psr-4": {
-            "WordPress\\Markdown\\": ""
-        },
         "exclude-from-classmap": [
             "/Tests/"
         ]

--- a/components/Merge/composer.json
+++ b/components/Merge/composer.json
@@ -4,9 +4,9 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "autoload": {
-        "psr-4": {
-            "WordPress\\Merge\\": ""
-        }
+        "classmap": [
+            "./"
+        ]
     },
     "authors": [
         {

--- a/components/Zip/composer.json
+++ b/components/Zip/composer.json
@@ -20,9 +20,9 @@
         "wp-php-toolkit/http-client": "^0.8"
     },
     "autoload": {
-        "psr-4": {
-            "WordPress\\Zip\\": ""
-        },
+        "classmap": [
+            "./"
+        ],
         "files": [
             "functions.php"
         ],


### PR DESCRIPTION
Eight components declared `"autoload": {"psr-4": {"WordPress\\<Name>\\": ""}}` but used WordPress file naming (`class-zipencoder.php`, not `ZipEncoder.php`). PSR-4's CamelCase-to-filename rule never resolves those classes, so a standalone `composer require wp-php-toolkit/zip` lets `require vendor/autoload.php` succeed but leaves `WordPress\Zip\ZipEncoder` and friends unautoloadable. The bug was masked in the monorepo because the root `composer.json` uses a classmap that picks the files up anyway.

Smoke-tested against the just-published v0.7.1 confirmed the regression: `class_exists('WordPress\\Zip\\ZipEncoder')` returns `false` after `composer require wp-php-toolkit/zip:^0.7`. Same shape for `WordPress\Git\GitFilesystem` and the other affected packages.

Switching each to classmap (matching what BlockParser, HTML, ByteStream, DataLiberation, Encoding, XML, Polyfill, Blueprints already do) makes the per-component autoload work for downstream consumers in any layout.

Affected: CLI, Filesystem, Git, HttpClient, HttpServer, Markdown, Merge, Zip.

`composer test` is at parity with trunk (1 pre-existing failure, 0 errors).