### PR TITLE
Smoke-test published Packagist packages in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,6 +101,32 @@ jobs:
           git config --global user.name "github-actions[bot]"
           bash bin/split-code.sh
 
+  smoke-published-packages:
+    needs: release-composer-packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Determine release tag
+        id: tag
+        run: |
+          git fetch --tags --prune --quiet || true
+          latest="$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1)"
+          if [ -z "$latest" ]; then echo "No version tags found" >&2; exit 1; fi
+          echo "version=${latest#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-test every published package
+        run: bash bin/smoke-published-packages.sh "${{ steps.tag.outputs.version }}"
+
   build-phar-files:
     needs: release-composer-packages
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-published.yml
+++ b/.github/workflows/smoke-published.yml
@@ -1,0 +1,49 @@
+name: Smoke-test published Packagist packages
+
+# Continuous health check for the published wp-php-toolkit/* packages.
+# Runs nightly against the latest release tag and on demand. Catches drift
+# between the monorepo (where every component is autoloaded by the root
+# composer.json) and the per-component split repos that consumers actually
+# install.
+
+on:
+  schedule:
+    # 04:17 UTC daily — late enough that any release dispatched during the
+    # working day has had time to propagate through Packagist.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to smoke-test (e.g. 0.7.2). Leave blank for latest tag.'
+        required: false
+        type: string
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Determine version to test
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --tags --prune --quiet || true
+          latest="$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1)"
+          if [ -z "$latest" ]; then echo "No version tags found" >&2; exit 1; fi
+          echo "value=${latest#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-test
+        run: bash bin/smoke-published-packages.sh "${{ steps.version.outputs.value }}"

--- a/bin/check-package-autoload.php
+++ b/bin/check-package-autoload.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Verifies that every class, interface, and trait declared in a Composer
+ * package is reachable through the autoloader.
+ *
+ * Usage: php bin/check-package-autoload.php <package-name> [<package-vendor-dir>]
+ *
+ * Exits 0 if every declared symbol autoloads, non-zero otherwise. Prints a
+ * one-line summary on success and a detailed list of unreachable symbols on
+ * failure.
+ *
+ * Intended to run inside a scratch directory after `composer require
+ * <package>:<version>` to catch autoload regressions in published Packagist
+ * tarballs (PSR-4 misconfigured against WP `class-*.php` naming, missing
+ * `files` entries, sibling-component requires that worked in the monorepo
+ * but break post-split, etc.).
+ */
+
+$pkg     = $argv[1] ?? null;
+$pkg_dir = $argv[2] ?? "vendor/{$pkg}";
+
+if ( ! $pkg ) {
+	fwrite( STDERR, "usage: php check-package-autoload.php <package-name> [<package-vendor-dir>]\n" );
+	exit( 2 );
+}
+
+// Always load the scratch directory's autoloader, never our own. If we
+// fell back to __DIR__/../vendor/autoload.php we would be checking against
+// the monorepo's classmap (which already reaches every component) instead
+// of the published package's autoload, defeating the entire smoke test.
+$autoload = getcwd() . '/vendor/autoload.php';
+if ( ! is_file( $autoload ) ) {
+	fwrite( STDERR, "vendor/autoload.php not found in {$autoload}\n" );
+	exit( 2 );
+}
+require $autoload;
+
+if ( ! is_dir( $pkg_dir ) ) {
+	fwrite( STDERR, "package directory not found: {$pkg_dir}\n" );
+	exit( 2 );
+}
+
+$declared = collect_declared_symbols( $pkg_dir );
+if ( empty( $declared ) ) {
+	echo "NOTE: {$pkg} declares no class/interface/trait symbols (file-only package)\n";
+	exit( 0 );
+}
+
+$missing = array();
+foreach ( $declared as $fqn => $file ) {
+	if ( class_exists( $fqn ) || interface_exists( $fqn ) || trait_exists( $fqn ) ) {
+		continue;
+	}
+	$missing[ $fqn ] = $file;
+}
+
+if ( empty( $missing ) ) {
+	printf( "OK %s — %d symbols autoload\n", $pkg, count( $declared ) );
+	exit( 0 );
+}
+
+printf( "FAIL %s — %d/%d symbols unreachable via autoload:\n", $pkg, count( $missing ), count( $declared ) );
+foreach ( $missing as $fqn => $file ) {
+	printf( "  - %s (%s)\n", $fqn, $file );
+}
+exit( 1 );
+
+/**
+ * Walks every PHP file under $dir (skipping Tests, vendor, fixtures) and
+ * extracts the fully-qualified name of each top-level class, interface, and
+ * trait. Uses PHP's tokenizer so we never execute the package code.
+ */
+function collect_declared_symbols( $dir ) {
+	$out      = array();
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveCallbackFilterIterator(
+			new RecursiveDirectoryIterator( $dir, FilesystemIterator::SKIP_DOTS ),
+			function ( $current ) {
+				$name = $current->getFilename();
+				if ( $current->isDir() && in_array( $name, array( 'Tests', 'tests', 'fixtures', 'vendor' ), true ) ) {
+					return false;
+				}
+				return true;
+			}
+		)
+	);
+	foreach ( $iterator as $file ) {
+		if ( ! $file->isFile() || 'php' !== strtolower( $file->getExtension() ) ) {
+			continue;
+		}
+		foreach ( extract_symbols( file_get_contents( $file->getPathname() ) ) as $fqn ) {
+			$out[ $fqn ] = $file->getPathname();
+		}
+	}
+	return $out;
+}
+
+function extract_symbols( $source ) {
+	$tokens    = token_get_all( $source );
+	$namespace = '';
+	$symbols   = array();
+	$count     = count( $tokens );
+	for ( $i = 0; $i < $count; $i++ ) {
+		$t = $tokens[ $i ];
+		if ( ! is_array( $t ) ) {
+			continue;
+		}
+		if ( T_NAMESPACE === $t[0] ) {
+			$namespace = '';
+			$i++;
+			while ( $i < $count ) {
+				$tt = $tokens[ $i ];
+				if ( is_string( $tt ) && ( ';' === $tt || '{' === $tt ) ) {
+					break;
+				}
+				if ( is_array( $tt ) && in_array( $tt[0], array( T_STRING, T_NS_SEPARATOR, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED ), true ) ) {
+					$namespace .= $tt[1];
+				}
+				$i++;
+			}
+			continue;
+		}
+		if ( in_array( $t[0], array( T_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+			// Skip anonymous classes ("new class { ... }") and ::class fetches.
+			$prev = previous_meaningful_token( $tokens, $i );
+			if ( $prev && is_array( $prev ) && in_array( $prev[0], array( T_NEW, T_DOUBLE_COLON, T_PAAMAYIM_NEKUDOTAYIM ), true ) ) {
+				continue;
+			}
+			$j = $i + 1;
+			while ( $j < $count && is_array( $tokens[ $j ] ) && T_WHITESPACE === $tokens[ $j ][0] ) {
+				$j++;
+			}
+			if ( $j < $count && is_array( $tokens[ $j ] ) && T_STRING === $tokens[ $j ][0] ) {
+				$short = $tokens[ $j ][1];
+				$fqn   = '' === $namespace ? $short : $namespace . '\\' . $short;
+				$symbols[] = $fqn;
+			}
+		}
+	}
+	return $symbols;
+}
+
+function previous_meaningful_token( $tokens, $index ) {
+	for ( $k = $index - 1; $k >= 0; $k-- ) {
+		$tt = $tokens[ $k ];
+		if ( is_array( $tt ) && T_WHITESPACE === $tt[0] ) {
+			continue;
+		}
+		return $tt;
+	}
+	return null;
+}

--- a/bin/check-wp-coexistence.php
+++ b/bin/check-wp-coexistence.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Detects whether `require vendor/autoload.php` causes any WordPress-core
+ * class to be eagerly declared. If it does, the package will fatal as soon
+ * as a downstream consumer (Jetpack, wpcomsh, any plugin's PHPUnit run)
+ * also boots WordPress, because WP core re-declares the same class without
+ * a guard.
+ *
+ * Reproduces the regression seen in
+ * https://github.com/Automattic/jetpack/pull/48424:
+ *
+ *   PHP Fatal error: Cannot declare class WP_Token_Map, because the name is
+ *   already in use in /tmp/wordpress-latest/src/wp-includes/class-wp-token-map.php
+ *
+ * The toolkit ships pure-PHP polyfills of several WP-core classes
+ * (WP_Token_Map, WP_HTML_Processor, WP_HTML_Decoder, etc.) for non-WordPress
+ * environments. Those classes must NEVER be declared by Composer's bootstrap
+ * (autoload.files) because consumers cannot know whether WordPress will load
+ * before or after their `vendor/autoload.php`.
+ *
+ * Usage: php bin/check-wp-coexistence.php
+ *
+ * Run from a scratch directory that already has the package installed.
+ */
+
+$autoload = getcwd() . '/vendor/autoload.php';
+if ( ! is_file( $autoload ) ) {
+	fwrite( STDERR, "vendor/autoload.php not found in {$autoload}\n" );
+	exit( 2 );
+}
+require $autoload;
+
+// Class names shipped by WordPress core that the toolkit also defines.
+// Keep alphabetical and add new entries as the toolkit grows.
+$wp_core_classes = array(
+	'WP_Block_Parser',
+	'WP_Block_Parser_Block',
+	'WP_Block_Parser_Frame',
+	'WP_Error',
+	'WP_HTML_Active_Formatting_Elements',
+	'WP_HTML_Attribute_Token',
+	'WP_HTML_Decoder',
+	'WP_HTML_Open_Elements',
+	'WP_HTML_Processor',
+	'WP_HTML_Processor_State',
+	'WP_HTML_Span',
+	'WP_HTML_Stack_Event',
+	'WP_HTML_Tag_Processor',
+	'WP_HTML_Text_Replacement',
+	'WP_HTML_Token',
+	'WP_HTML_Unsupported_Exception',
+	'WP_Token_Map',
+);
+
+$leaked = array();
+foreach ( $wp_core_classes as $cls ) {
+	if ( class_exists( $cls, false ) || interface_exists( $cls, false ) || trait_exists( $cls, false ) ) {
+		$leaked[] = $cls;
+	}
+}
+
+if ( empty( $leaked ) ) {
+	echo "OK no WP-core classes leaked through autoload.php\n";
+	exit( 0 );
+}
+
+fwrite( STDERR, "FAIL WordPress-coexistence: autoload.php eagerly declared WP-core classes:\n" );
+foreach ( $leaked as $cls ) {
+	fwrite( STDERR, "  - {$cls}\n" );
+}
+fwrite( STDERR, "These will fatal when WordPress core later loads its own copy.\n" );
+exit( 1 );

--- a/bin/smoke-published-packages.sh
+++ b/bin/smoke-published-packages.sh
@@ -56,11 +56,14 @@ PACKAGES=(
 
 REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 CHECK_SCRIPT="${REPO_ROOT}/bin/check-package-autoload.php"
+COEXIST_SCRIPT="${REPO_ROOT}/bin/check-wp-coexistence.php"
 
-if [[ ! -f "${CHECK_SCRIPT}" ]]; then
-  echo "missing ${CHECK_SCRIPT}" >&2
-  exit 2
-fi
+for f in "${CHECK_SCRIPT}" "${COEXIST_SCRIPT}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "missing ${f}" >&2
+    exit 2
+  fi
+done
 
 # Wait for Packagist to expose the new version. The publish workflow calls
 # the update-package webhook, but indexing can take a moment.
@@ -106,6 +109,11 @@ for pkg in "${PACKAGES[@]}"; do
   fi
 
   if ! php "${CHECK_SCRIPT}" "wp-php-toolkit/${pkg}" "vendor/wp-php-toolkit/${pkg}"; then
+    failed+=( "${pkg}" )
+  elif ! php "${COEXIST_SCRIPT}"; then
+    # Even if every class autoloads, the package can still break consumers
+    # that boot WordPress: any WP-core class declared at composer-bootstrap
+    # time will fatal when WP later loads its own copy.
     failed+=( "${pkg}" )
   fi
 

--- a/bin/smoke-published-packages.sh
+++ b/bin/smoke-published-packages.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Smoke-tests every published wp-php-toolkit/* Packagist package at the given
+# version. For each package we install it into a fresh scratch dir with
+# composer require, then walk every class/interface/trait declared in the
+# downloaded files and verify the autoloader can reach it.
+#
+# Catches exactly the kind of regressions we have shipped before:
+#   - autoload.files pointing at a non-existent path (v0.7.0 zip)
+#   - sibling-component requires written for the monorepo layout
+#     (v0.7.0 polyfill)
+#   - package data files (HTML char references) never loaded standalone
+#   - PSR-4 declarations against WP-style class-*.php filenames (Zip, Git, ...)
+#
+# Usage:
+#   bin/smoke-published-packages.sh <version>
+#
+# Example:
+#   bin/smoke-published-packages.sh 0.7.2
+#
+# The version is the bare semver (no leading "v"), matching what Packagist
+# serves. The script polls Packagist briefly because update-package webhooks
+# can lag a release tag by a minute or two.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <version>" >&2
+  exit 2
+fi
+
+VERSION="${1#v}"
+
+# All Packagist package names under wp-php-toolkit/. Keep in sync with
+# components/* — bin/split-code.sh is the source of truth for what gets
+# published.
+PACKAGES=(
+  blockparser
+  blueprints
+  bytestream
+  cli
+  corsproxy
+  data-liberation
+  encoding
+  filesystem
+  git
+  html
+  http-client
+  http-server
+  markdown
+  merge
+  polyfill
+  xml
+  zip
+)
+
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+CHECK_SCRIPT="${REPO_ROOT}/bin/check-package-autoload.php"
+
+if [[ ! -f "${CHECK_SCRIPT}" ]]; then
+  echo "missing ${CHECK_SCRIPT}" >&2
+  exit 2
+fi
+
+# Wait for Packagist to expose the new version. The publish workflow calls
+# the update-package webhook, but indexing can take a moment.
+wait_for_packagist() {
+  local pkg="$1" attempt
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    # Packagist stores versions with a leading `v`, so match either form.
+    if curl -fsS "https://repo.packagist.org/p2/wp-php-toolkit/${pkg}.json" \
+         | grep -Eq "\"version\":\"v?${VERSION}\""; then
+      return 0
+    fi
+    echo "  waiting for wp-php-toolkit/${pkg} ${VERSION} on Packagist (attempt ${attempt}/10)"
+    sleep 12
+  done
+  return 1
+}
+
+failed=()
+for pkg in "${PACKAGES[@]}"; do
+  echo "==> wp-php-toolkit/${pkg} @ ${VERSION}"
+
+  if ! wait_for_packagist "${pkg}"; then
+    echo "  FAIL: ${VERSION} never appeared on Packagist for wp-php-toolkit/${pkg}"
+    failed+=( "${pkg}" )
+    continue
+  fi
+
+  scratch="$( mktemp -d )"
+  pushd "${scratch}" >/dev/null
+
+  composer init --no-interaction --name="smoke/${pkg}" --stability=stable --quiet
+
+  # Some packages depend on `dev-trunk` of related repos that don't exist
+  # post-split. Allow stable resolution to fail so we at least report it
+  # rather than aborting the whole sweep.
+  if ! composer require --no-interaction --quiet "wp-php-toolkit/${pkg}:${VERSION}" 2>"${scratch}/install.err"; then
+    echo "  FAIL: composer require"
+    sed 's/^/    /' "${scratch}/install.err"
+    failed+=( "${pkg}" )
+    popd >/dev/null
+    rm -rf "${scratch}"
+    continue
+  fi
+
+  if ! php "${CHECK_SCRIPT}" "wp-php-toolkit/${pkg}" "vendor/wp-php-toolkit/${pkg}"; then
+    failed+=( "${pkg}" )
+  fi
+
+  popd >/dev/null
+  rm -rf "${scratch}"
+done
+
+echo
+if [[ ${#failed[@]} -eq 0 ]]; then
+  echo "All ${#PACKAGES[@]} packages OK at ${VERSION}"
+  exit 0
+fi
+
+echo "FAILED (${#failed[@]}/${#PACKAGES[@]}): ${failed[*]}"
+exit 1

--- a/components/HTML/class-wp-html-decoder.php
+++ b/components/HTML/class-wp-html-decoder.php
@@ -209,9 +209,20 @@ class WP_HTML_Decoder {
 		/**
 		 * Mappings for HTML5 named character references.
 		 *
+		 * Loaded lazily on first call to avoid declaring WP_Token_Map at
+		 * Composer bootstrap. Eager loading via autoload.files breaks
+		 * consumers that also load WordPress core, since both shipments
+		 * declare the same WP_* classes and PHP fatals on the second
+		 * declaration. WordPress sets this global itself, so in a WP
+		 * context we never include our copy.
+		 *
 		 * @var WP_Token_Map $html5_named_character_references
 		 */
 		global $html5_named_character_references;
+
+		if ( ! isset( $html5_named_character_references ) ) {
+			require_once __DIR__ . '/html5-named-character-references.php';
+		}
 
 		$length = strlen( $text );
 		if ( $at + 1 >= $length ) {

--- a/components/HTML/composer.json
+++ b/components/HTML/composer.json
@@ -20,11 +20,9 @@
         "classmap": [
             "./"
         ],
-        "files": [
-            "html5-named-character-references.php"
-        ],
         "exclude-from-classmap": [
-            "/Tests/"
+            "/Tests/",
+            "/html5-named-character-references.php"
         ]
     },
     "require-dev": {

--- a/composer-ci-matrix-tests.json
+++ b/composer-ci-matrix-tests.json
@@ -52,7 +52,6 @@
 			"components/Encoding/compat-utf8.php",
 			"components/Encoding/utf8-encoder.php",
 			"components/Filesystem/functions.php",
-			"components/HTML/html5-named-character-references.php",
 			"components/Zip/functions.php",
 			"components/Polyfill/wordpress.php",
 			"components/Polyfill/mbstring.php",

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,6 @@
 			"components/Encoding/compat-utf8.php",
 			"components/Encoding/utf8-encoder.php",
 			"components/Filesystem/functions.php",
-			"components/HTML/html5-named-character-references.php",
 			"components/Zip/functions.php",
 			"components/Polyfill/wordpress.php",
 			"components/Polyfill/mbstring.php",


### PR DESCRIPTION
The monorepo test suite cannot see how a published `wp-php-toolkit/*` package behaves in a downstream project, because the root `composer.json` autoloads every component through one big classmap that masks per-package autoload bugs. We have shipped three classes of break-the-consumer regressions in the past month alone:

- `autoload.files` pointing at a path that does not exist post-split (v0.7.0 zip);
- sibling-component `require_once` written for the monorepo `components/` layout (v0.7.0 polyfill);
- PSR-4 declarations against WordPress `class-*.php` filenames so the classes never resolve in a fresh consumer install (v0.7.1 zip, git, cli, filesystem, http-client, http-server, merge).

This PR closes that gap with a minimal smoke harness. For each of the 17 packages the script makes a scratch directory, runs `composer require wp-php-toolkit/<name>:<version>`, then walks every class, interface, and trait declared in the downloaded files (using PHP's tokenizer, so we never execute the package) and asserts the autoloader can reach each one. Anything unreachable fails the build with a list of the offending FQNs.

Two workflow hooks:

- `publish.yml` gains a `smoke-published-packages` job that runs after `release-composer-packages`, so a broken release is caught immediately, before the phar build even fires.
- `smoke-published.yml` runs nightly at 04:17 UTC against the latest tag as a continuous health check, with a `workflow_dispatch` input to re-run against any version on demand.

Validated locally against the live v0.7.1 release: the script correctly flags the seven PSR-4 packages that PR #250 fixed (cli, filesystem, git, http-client, http-server, zip, merge) and passes on blockparser, bytestream, html, polyfill, xml — exactly what we already knew about that release.