### PR TITLE
docs: lift "Where to start" under the hero, scroll-to-tiles for "Browse all components"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,25 @@
 	<div class="cta-row">
 		<a class="cta primary" href="learn/quickstart.html">Quickstart →</a>
 		<a class="cta" href="learn/">Take the tutorial</a>
-		<a class="cta" href="reference/">Browse components</a>
+		<a class="cta" href="#components">Browse components</a>
+	</div>
+</section>
+
+<section class="two-doors">
+	<h2>Where to start</h2>
+
+	<div class="doors">
+		<a class="door" href="learn/">
+			<strong>I want to learn the toolkit.</strong>
+			<span>Build a real content importer across four short chapters. We'll start with one HTML rewrite and finish with a ZIP-packaged WXR export. Every code block runs in the browser; every chapter ends with something you can keep.</span>
+			<em>~45 minutes →</em>
+		</a>
+
+		<a class="door" href="#components">
+			<strong>I'm here to look something up.</strong>
+			<span>Eighteen component pages, each with a one-line definition, a minimal runnable example, refinements, the pitfalls people actually trip on, and links back to the tutorial chapters where the concept first appears.</span>
+			<em>Browse all components ↓</em>
+		</a>
 	</div>
 </section>
 
@@ -48,7 +66,7 @@
 	<p>Eighteen components. Each is a small library focused on one job, distributable as its own Composer package, depending only on PHP itself plus other toolkit components — no Composer packages outside the <code>wp-php-toolkit/*</code> family, no PHP extensions beyond <code>json</code> and <code>mbstring</code>.</p>
 </section>
 
-<section class="all-components">
+<section class="all-components" id="components">
 	<h2>All eighteen components</h2>
 
 	<h3>Content and migration</h3>
@@ -84,24 +102,6 @@
 		<li><a href="reference/blueprints.html"><strong>Blueprints</strong><span>Versioned recipes for spinning up a WordPress site, plugins, options, content.</span></a></li>
 		<li><a href="reference/coding-standards.html"><strong>ToolkitCodingStandards</strong><span>PHPCS sniffs that encode the project's review feedback as rules.</span></a></li>
 	</ul>
-</section>
-
-<section class="two-doors">
-	<h2>Where to start</h2>
-
-	<div class="doors">
-		<a class="door" href="learn/">
-			<strong>I want to learn the toolkit.</strong>
-			<span>Build a real content importer across four short chapters. We'll start with one HTML rewrite and finish with a ZIP-packaged WXR export. Every code block runs in the browser; every chapter ends with something you can keep.</span>
-			<em>~45 minutes →</em>
-		</a>
-
-		<a class="door" href="reference/">
-			<strong>I'm here to look something up.</strong>
-			<span>Eighteen component pages, each with a one-line definition, a minimal runnable example, refinements, the pitfalls people actually trip on, and links back to the tutorial chapters where the concept first appears.</span>
-			<em>Browse all components →</em>
-		</a>
-	</div>
 </section>
 
 <section class="proofs">


### PR DESCRIPTION
## Summary

Two small landing-page tweaks at https://wordpress.github.io/php-toolkit/:

1. **Moved the "Where to start" two-doors block up.** It used to sit *below* the 18-component grid, so visitors had to scroll past every tile before getting the tutorial-vs-reference choice. Now it's right under the hero — the high-level decision is the second thing you see.
2. **"Browse all components ↓" now scrolls to the in-page tiles** via `#components` instead of navigating away to `/reference/`. The hero's "Browse components" CTA gets the same anchor for consistency. Arrow flipped from → to ↓ to match scroll-down semantics.

Added `id="components"` to `<section class="all-components">` so the anchor resolves.

## New section order

```
hero (CTAs: Quickstart · Take the tutorial · Browse components ↓)
Where to start                              ← moved up
The problem
The shape of it
All eighteen components  (id="components")  ← scroll target
The toolkit in one line each
Credits
How the runnable examples work
```

No other reordering, no CSS changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)