### PR TITLE
docs: stop hiding snippet fallback prematurely (`:defined` race)

### DIFF
--- a/bin/build-reference.py
+++ b/bin/build-reference.py
@@ -16,7 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _load_catalog import load_components_rich
 
 DOCS = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'docs', 'reference')
-ASSET_VERSION = '20260503-script-unescape'
+ASSET_VERSION = '20260503-fallback-explicit-hide'
 
 
 PAGE_HEAD = '''<!doctype html>

--- a/docs/assets/page.js
+++ b/docs/assets/page.js
@@ -104,6 +104,15 @@
 		const code = root.querySelector('pre code');
 		if (!code) return;
 
+		// Shadow DOM has rendered content. Hide the static fallback now —
+		// not via a CSS `:defined` rule, which fires too early (the moment
+		// customElements.define() runs, before shadow-DOM render). See
+		// .snippet-fallback rules in style.css for context.
+		const fallback = el.querySelector(':scope > .snippet-fallback');
+		if (fallback) {
+			fallback.style.display = 'none';
+		}
+
 		// HTML emitted by build-reference.py escapes "</script" inside the
 		// <script type="application/x-php"> wrapper as "<\/script" so the
 		// outer tag isn't closed prematurely. The browser preserves that

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -483,10 +483,13 @@ p code, li code, td code {
 
 php-snippet { display: block; margin: 1rem 0 1.75rem; }
 
-/* Static fallback: shows the snippet code if the cross-origin Playground
-   custom element fails to register (CSP block, slow network, adblocker,
-   no-JS reader). Hidden as soon as <php-snippet> is defined so the
-   interactive widget owns the screen when it boots. */
+/* Static fallback: shows the snippet code until the cross-origin Playground
+   custom element registers AND populates its shadow DOM. page.js hides
+   this element explicitly once shadow-DOM render is confirmed in
+   patchSnippet — we do not use a CSS `:defined` rule because that fires
+   the instant `customElements.define()` runs, before the shadow DOM has
+   any content. If the cross-origin module never loads (CSP, adblock,
+   slow network, no-JS), this fallback stays visible. */
 .snippet-fallback {
 	margin: 0;
 	padding: 0.9rem;
@@ -499,7 +502,6 @@ php-snippet { display: block; margin: 1rem 0 1.75rem; }
 	line-height: 1.55;
 }
 .snippet-fallback code { color: inherit; background: none; padding: 0; }
-php-snippet:defined .snippet-fallback { display: none; }
 
 .code-example {
 	margin: 1rem 0 1.75rem;


### PR DESCRIPTION
## Summary

Reports of "no snippets visible" on https://wordpress.github.io/php-toolkit/reference/html.html despite the page shipping 9 \`<php-snippet>\` elements + 9 \`<pre class=\"snippet-fallback\">\` static fallbacks.

**Root cause:** the CSS rule

```css
php-snippet:defined .snippet-fallback { display: none; }
```

matches the moment \`customElements.define('php-snippet', ...)\` runs in Playground's module — *before* the snippet's shadow DOM has any content. In the gap between "custom element registered" and "shadow DOM populated with code + Run button," the fallback was already hidden and the widget hadn't drawn yet. On a slow client (or one where a later step in the Playground module fails) the user sees a permanent blank gap.

**Fix:** drop the \`:defined\` rule from \`style.css\` and hide the fallback explicitly from \`page.js\`'s \`patchSnippet\`, which only runs after \`shadowRoot.querySelector('pre code')\` returns a real node. By that point the snippet's UI is rendered on screen, so swapping the fallback out is safe. If the cross-origin Playground module never loads at all (CSP, adblock, slow network, no-JS), \`patchSnippet\` is never reached and the fallback stays visible — readers always see the code.

## Verification (headless chromium screenshots)

| Scenario | Before | After |
| --- | --- | --- |
| Module reachable | Custom element renders, fallback briefly invisible during shadow-DOM render | Custom element renders + Run button; fallback hidden only after shadow DOM is populated |
| Module unreachable (\`--host-rules=\"MAP playground.wordpress.net 127.0.0.1:1\"\`) | Permanent blank gap because \`:defined\` matched the moment the module's first script ran | Static \`<pre>\` fallback stays visible, readers can read the code |

87/87 snippets still match captured stdout. Asset version bumped (\`20260503-script-unescape\` → \`20260503-fallback-explicit-hide\`) so browser caches refresh.

## Test plan
- [ ] \`Verify docs snippets\` workflow passes.
- [ ] After deploy, every reference page on https://wordpress.github.io/php-toolkit/reference/ shows code in every snippet — either as the interactive widget (when the module loads) or as the static \`<pre>\` fallback (when it doesn't). No blank gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)