### PR TITLE
docs: drop synthetic "A minimal example" / "Refinement:" prefixes from headings

### DIFF
--- a/bin/build-reference.py
+++ b/bin/build-reference.py
@@ -188,12 +188,13 @@ def render_component(components, c):
         snippet = section['snippet']
         rest, found = split_pitfalls(body_html)
         pitfalls.extend(found)
+        # Use the section's own heading verbatim — no synthetic prefixes.
+        # The first section in a component that ships a snippet doubles as
+        # the "minimal example" by convention; readers can tell it from
+        # later sections by its position, not by an editorial label.
         h2 = heading
         if not minimal_emitted and snippet:
-            h2 = 'A minimal example'
             minimal_emitted = True
-        elif snippet:
-            h2 = f'Refinement: {heading[0].lower() + heading[1:]}' if heading else heading
         out.append(f'<h2 id="{slugify(h2)}">{h(h2)}</h2>\n\n')
         if rest:
             out.append(rest + '\n\n')


### PR DESCRIPTION
## Summary

Section headings on each reference page now match the README's H2 lines verbatim. The renderer was rewriting:

- the first snippet section's heading to a synthetic \"A minimal example\"
- every later snippet section's heading to \"Refinement: <lowercased original>\"

…regardless of what the README actually said.

| Before | After |
| --- | --- |
| \`## A minimal example\` | \`## Add loading=\"lazy\" to every image\` |
| \`## Refinement: rewrite relative links…\` | \`## Rewrite relative links to absolute URLs\` |
| \`## Refinement: strip every script…\` | \`## Strip every script and inline event handler\` |

## Test plan
- [ ] \`Verify docs snippets\` workflow passes (87/87).
- [ ] Spot-check a regenerated reference page on adamziel.github.io/experiments/php-toolkit (or after deploy on wordpress.github.io/php-toolkit) — headings read like a person wrote them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)