### PR TITLE
Fix smoke-test-published-packages: 6 packages broken on v0.7.2

### DIFF
--- a/bin/check-package-autoload.php
+++ b/bin/check-package-autoload.php
@@ -40,7 +40,7 @@ if ( ! is_dir( $pkg_dir ) ) {
 	exit( 2 );
 }
 
-$declared = collect_declared_symbols( $pkg_dir );
+$declared = collect_declared_symbols( $pkg_dir, load_classmap_excludes( $pkg_dir ) );
 if ( empty( $declared ) ) {
 	echo "NOTE: {$pkg} declares no class/interface/trait symbols (file-only package)\n";
 	exit( 0 );
@@ -66,19 +66,45 @@ foreach ( $missing as $fqn => $file ) {
 exit( 1 );
 
 /**
- * Walks every PHP file under $dir (skipping Tests, vendor, fixtures) and
- * extracts the fully-qualified name of each top-level class, interface, and
- * trait. Uses PHP's tokenizer so we never execute the package code.
+ * Walks every PHP file under $dir and extracts the fully-qualified name of
+ * each top-level class, interface, and trait. Uses PHP's tokenizer so we
+ * never execute the package code.
+ *
+ * Skips standard non-autoloaded directories (Tests, fixtures, vendor) and
+ * any path the package itself excluded from its classmap via the
+ * exclude-from-classmap directive in composer.json. We honour that
+ * directive because anything excluded there is, by definition, not part of
+ * the autoload surface — checking that those classes are reachable would
+ * be a false positive.
  */
-function collect_declared_symbols( $dir ) {
-	$out      = array();
-	$iterator = new RecursiveIteratorIterator(
+function collect_declared_symbols( $dir, array $excluded_paths = array() ) {
+	$out         = array();
+	$dir_norm    = rtrim( str_replace( DIRECTORY_SEPARATOR, '/', $dir ), '/' );
+	$skipped_dir = array( 'Tests', 'tests', 'fixtures', 'vendor' );
+	$iterator    = new RecursiveIteratorIterator(
 		new RecursiveCallbackFilterIterator(
 			new RecursiveDirectoryIterator( $dir, FilesystemIterator::SKIP_DOTS ),
-			function ( $current ) {
+			function ( $current ) use ( $dir_norm, $excluded_paths, $skipped_dir ) {
 				$name = $current->getFilename();
-				if ( $current->isDir() && in_array( $name, array( 'Tests', 'tests', 'fixtures', 'vendor' ), true ) ) {
+				if ( $current->isDir() && in_array( $name, $skipped_dir, true ) ) {
 					return false;
+				}
+				if ( $excluded_paths ) {
+					// Build a leading-slash, forward-slash path relative to
+					// the package root so substring matching against entries
+					// like "/Tests/" or "/vendor-patched/foo/bar/" behaves
+					// the way composer's classmap exclusion does.
+					$path = str_replace( DIRECTORY_SEPARATOR, '/', $current->getPathname() );
+					if ( 0 === strpos( $path, $dir_norm . '/' ) ) {
+						$path = substr( $path, strlen( $dir_norm ) );
+					}
+					$rel      = '/' . ltrim( $path, '/' );
+					$haystack = $current->isDir() ? rtrim( $rel, '/' ) . '/' : $rel;
+					foreach ( $excluded_paths as $excluded ) {
+						if ( false !== strpos( $haystack, $excluded ) ) {
+							return false;
+						}
+					}
 				}
 				return true;
 			}
@@ -91,6 +117,39 @@ function collect_declared_symbols( $dir ) {
 		foreach ( extract_symbols( file_get_contents( $file->getPathname() ) ) as $fqn ) {
 			$out[ $fqn ] = $file->getPathname();
 		}
+	}
+	return $out;
+}
+
+/**
+ * Reads the package's composer.json and returns its
+ * autoload.exclude-from-classmap entries, normalised to paths that start
+ * with a leading "/". Returns an empty array if the file is missing or
+ * unreadable.
+ */
+function load_classmap_excludes( $pkg_dir ) {
+	$composer_json = $pkg_dir . '/composer.json';
+	if ( ! is_file( $composer_json ) ) {
+		return array();
+	}
+	$decoded = json_decode( file_get_contents( $composer_json ), true );
+	if ( ! is_array( $decoded ) ) {
+		return array();
+	}
+	$raw = $decoded['autoload']['exclude-from-classmap'] ?? array();
+	if ( ! is_array( $raw ) ) {
+		return array();
+	}
+	$out = array();
+	foreach ( $raw as $entry ) {
+		if ( ! is_string( $entry ) || '' === $entry ) {
+			continue;
+		}
+		$entry = str_replace( '\\', '/', $entry );
+		if ( '/' !== $entry[0] ) {
+			$entry = '/' . $entry;
+		}
+		$out[] = $entry;
 	}
 	return $out;
 }

--- a/components/Blueprints/bin/blueprint.php
+++ b/components/Blueprints/bin/blueprint.php
@@ -35,7 +35,23 @@
  * ✅ @TODO: Prevent remote resources from using local bundle paths
  */
 
-require __DIR__ . '/../../../vendor/autoload.php';
+if ( ! class_exists( 'Composer\\Autoload\\ClassLoader', false ) ) {
+	$_blueprint_autoload_candidates = array(
+		// Installed as a dependency: vendor/wp-php-toolkit/blueprints/bin/.
+		__DIR__ . '/../../../autoload.php',
+		// Standalone clone of the wp-php-toolkit/blueprints repo.
+		__DIR__ . '/../vendor/autoload.php',
+		// Inside the php-toolkit monorepo.
+		__DIR__ . '/../../../vendor/autoload.php',
+	);
+	foreach ( $_blueprint_autoload_candidates as $_blueprint_autoload ) {
+		if ( file_exists( $_blueprint_autoload ) ) {
+			require $_blueprint_autoload;
+			break;
+		}
+	}
+	unset( $_blueprint_autoload_candidates, $_blueprint_autoload );
+}
 
 use WordPress\CLI\CLI;
 use WordPress\Blueprints\DataReference\AbsoluteLocalPath;

--- a/components/Blueprints/composer.json
+++ b/components/Blueprints/composer.json
@@ -36,7 +36,11 @@
             "./"
         ],
         "exclude-from-classmap": [
-            "/Tests/"
+            "/Tests/",
+            "/bin/",
+            "/Steps/scripts/",
+            "/vendor-patched/symfony/event-dispatcher/DependencyInjection/",
+            "/vendor-patched/symfony/event-dispatcher/ContainerAwareEventDispatcher.php"
         ]
     }
 }

--- a/components/CORSProxy/composer.json
+++ b/components/CORSProxy/composer.json
@@ -30,10 +30,14 @@
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {
-        "psr-4": {
-            "WordPress\\CORSProxy\\": ""
-        },
+        "classmap": [
+            "./"
+        ],
+        "files": [
+            "cors-proxy-functions.php"
+        ],
         "exclude-from-classmap": [
+            "/tests/",
             "/Tests/"
         ]
     }

--- a/components/CORSProxy/cors-proxy-functions.php
+++ b/components/CORSProxy/cors-proxy-functions.php
@@ -391,7 +391,7 @@ function rewrite_relative_redirect(
 	}
 
 	if ( ! parse_url( $redirect_location, PHP_URL_SCHEME ) ) {
-		$target_scheme     = parse_url( $request_url, PHP_URL_SCHEME ) ? PHP_URL_SCHEME ) : 'https';
+		$target_scheme     = parse_url( $request_url, PHP_URL_SCHEME ) ?: 'https';
 		$redirect_location = "$target_scheme://$redirect_location";
 	}
 

--- a/components/DataLiberation/composer.json
+++ b/components/DataLiberation/composer.json
@@ -27,6 +27,7 @@
         "php": ">=7.2",
         "wp-php-toolkit/bytestream": "^0.8",
         "wp-php-toolkit/filesystem": "^0.8",
+        "wp-php-toolkit/html": "^0.8",
         "wp-php-toolkit/http-client": "^0.8",
         "wp-php-toolkit/xml": "^0.8"
     },
@@ -39,7 +40,8 @@
             "URL/functions.php"
         ],
         "exclude-from-classmap": [
-            "/Tests/"
+            "/Tests/",
+            "/bin/"
         ]
     }
 }

--- a/components/Markdown/composer.json
+++ b/components/Markdown/composer.json
@@ -34,7 +34,12 @@
             "vendor-patched"
         ],
         "exclude-from-classmap": [
-            "/Tests/"
+            "/Tests/",
+            "/bin/",
+            "/vendor-patched/symfony/yaml/Command/",
+            "/vendor-patched/webuni/front-matter/src/Haml/",
+            "/vendor-patched/webuni/front-matter/src/Pug/",
+            "/vendor-patched/webuni/front-matter/src/Twig/"
         ]
     }
 }

--- a/components/Merge/composer.json
+++ b/components/Merge/composer.json
@@ -19,10 +19,9 @@
         "docs": "https://wordpress.github.io/php-toolkit/reference/merge.html"
     },
     "require": {
-        "php": ">=7.4",
-        "yetanotherape/diff-match-patch": "^1.0",
-        "wordpress/data-liberation": "dev-trunk",
-        "ext-mbstring": "*"
+        "php": ">=7.2",
+        "ext-mbstring": "*",
+        "wp-php-toolkit/data-liberation": "^0.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/components/Polyfill/class-wp-error.php
+++ b/components/Polyfill/class-wp-error.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Polyfill for the WordPress core WP_Error class.
+ *
+ * Loaded lazily through Composer's classmap so that simply requiring
+ * `vendor/autoload.php` does not eagerly declare `WP_Error`. Eager
+ * declaration would fatal as soon as WordPress core loads its own copy,
+ * which is the regression caught by bin/check-wp-coexistence.php.
+ */
+
+// phpcs:disable
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public $code;
+		public $message;
+		public $data;
+
+		public function __construct( $code = '', $message = '', $data = '' ) {
+			if ( empty( $code ) ) {
+				return;
+			}
+			$this->code = $code;
+			$this->message = $message;
+			$this->data = $data;
+		}
+	}
+}

--- a/components/Polyfill/class-wp-exception.php
+++ b/components/Polyfill/class-wp-exception.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * `WP_Exception` is the exception thrown by `wp_trigger_error()` when it is
+ * called with `E_USER_ERROR`. It does not exist in WordPress core, so a
+ * downstream consumer that boots WordPress will not redeclare it — but we
+ * still load this class lazily through Composer's classmap to keep the
+ * autoload.files entrypoint free of class declarations and consistent with
+ * the WP_Error polyfill alongside it.
+ */
+
+// phpcs:disable
+
+if ( ! class_exists( 'WP_Exception' ) ) {
+	class WP_Exception extends Exception {
+	}
+}

--- a/components/Polyfill/composer.json
+++ b/components/Polyfill/composer.json
@@ -29,9 +29,13 @@
         "wp-php-toolkit/html": "^0.8"
     },
     "autoload": {
+        "classmap": [
+            "./"
+        ],
         "files": [
             "wordpress.php",
-            "mbstring.php"
+            "mbstring.php",
+            "php-functions.php"
         ],
         "exclude-from-classmap": [
             "/Tests/"

--- a/components/Polyfill/wordpress.php
+++ b/components/Polyfill/wordpress.php
@@ -5,32 +5,17 @@
 
  // phpcs:disable
 
-if ( ! class_exists( 'WP_Error' ) ) {
-	class WP_Error {
-		public $code;
-		public $message;
-		public $data;
-
-		public function __construct( $code = '', $message = '', $data = '' ) {
-			if ( empty( $code ) ) {
-				return;
-			}
-			$this->code = $code;
-			$this->message = $message;
-			$this->data = $data;
-		}
-	}
-}
+// `WP_Error` and `WP_Exception` are deliberately NOT declared in this
+// file: declaring WordPress-core class names at composer-bootstrap time
+// fatals as soon as a downstream consumer loads WordPress, because WP
+// core re-declares the same names without a guard. Those polyfills live
+// in class-wp-error.php / class-wp-exception.php and are picked up by
+// the autoloader's classmap on demand.
 
 if ( ! function_exists( '_doing_it_wrong' ) ) {
 	$GLOBALS['_doing_it_wrong_messages'] = array();
 	function _doing_it_wrong( $method, $message, $version ) {
 		$GLOBALS['_doing_it_wrong_messages'][] = $message;
-	}
-}
-
-if ( ! class_exists( 'WP_Exception' ) ) {
-	class WP_Exception extends Exception {
 	}
 }
 

--- a/composer-ci-matrix-tests.json
+++ b/composer-ci-matrix-tests.json
@@ -31,6 +31,7 @@
 			"components/Blueprints/",
 			"components/Blueprints/vendor-patched/",
 			"components/CLI/",
+			"components/CORSProxy/",
 			"components/DataLiberation/",
 			"components/DataLiberation/vendor-patched/",
 			"components/Filesystem/",
@@ -43,10 +44,12 @@
 			"components/Merge/",
 			"components/Merge/vendor-patched",
 			"components/ByteStream/",
+			"components/Polyfill/",
 			"components/XML/",
 			"components/Zip/"
 		],
 		"files": [
+			"components/CORSProxy/cors-proxy-functions.php",
 			"components/DataLiberation/URL/functions.php",
 			"components/Encoding/utf8.php",
 			"components/Encoding/compat-utf8.php",
@@ -55,12 +58,12 @@
 			"components/Zip/functions.php",
 			"components/Polyfill/wordpress.php",
 			"components/Polyfill/mbstring.php",
+			"components/Polyfill/php-functions.php",
 			"components/Git/functions.php"
 		],
 		"psr-4": {
 			"Rowbot\\": "components/DataLiberation/vendor-patched/",
-			"Brick\\": "components/DataLiberation/vendor-patched/",
-			"WordPress\\CORSProxy\\": "components/CORSProxy/"
+			"Brick\\": "components/DataLiberation/vendor-patched/"
 		}
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
 			"components/Blueprints/",
 			"components/Blueprints/vendor-patched/",
 			"components/CLI/",
+			"components/CORSProxy/",
 			"components/DataLiberation/",
 			"components/DataLiberation/vendor-patched/",
 			"components/Filesystem/",
@@ -60,11 +61,13 @@
 			"components/Merge/",
 			"components/Merge/vendor-patched",
 			"components/ByteStream/",
+			"components/Polyfill/",
 			"components/ToolkitCodingStandards/",
 			"components/XML/",
 			"components/Zip/"
 		],
 		"files": [
+			"components/CORSProxy/cors-proxy-functions.php",
 			"components/DataLiberation/URL/functions.php",
 			"components/Encoding/utf8.php",
 			"components/Encoding/compat-utf8.php",
@@ -78,8 +81,7 @@
 		],
 		"psr-4": {
 			"Rowbot\\": "components/DataLiberation/vendor-patched/",
-			"Brick\\": "components/DataLiberation/vendor-patched/",
-			"WordPress\\CORSProxy\\": "components/CORSProxy/"
+			"Brick\\": "components/DataLiberation/vendor-patched/"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
## Summary

The nightly [smoke-test-published-packages](https://github.com/WordPress/php-toolkit/actions/workflows/smoke-published.yml) workflow has been failing on v0.7.2 against six packages — each for a different reason. None of these are caught by the in-monorepo PHPUnit suite because the bug only surfaces once the package is split off and consumers `composer require` it standalone.

Failing packages: `blueprints`, `corsproxy`, `data-liberation`, `markdown`, `merge`, `polyfill`.

## What changed

Per-package fixes (see commit message for full reasoning):

- **blueprints** — `bin/blueprint.php` had a hard-coded monorepo-relative path to `vendor/autoload.php`, and exposed CLI-only classes through the classmap. Now `bin/` and `Steps/scripts/` are excluded from the classmap, the CLI bootstrap probes multiple autoload locations and skips the require when composer's `ClassLoader` is already in scope, and the Symfony `DependencyInjection` bridge (which needs symfony/dependency-injection — not bundled) is excluded too.
- **corsproxy** — PSR-4 mapped `WordPress\\CORSProxy\\` to a tree whose classes are actually globally namespaced, so the classes never autoloaded. Switched to classmap + `autoload.files` for `cors-proxy-functions.php`, and fixed a phpcbf-introduced syntax error on line 394 that the file hits as soon as it's actually loaded.
- **data-liberation** — `DataLiberationHTMLProcessor` extends `WP_HTML_Processor` but the package didn't depend on `wp-php-toolkit/html`. Added the dep.
- **markdown** — vendored `symfony/yaml` and `webuni/front-matter` ship optional integrations (Console-based LintCommand, Twig/Haml/Pug filters) that need packages we don't bundle. Those subdirs are now excluded from the classmap.
- **merge** — required the non-existent `wordpress/data-liberation:dev-trunk` and pulled in `yetanotherape/diff-match-patch` as a Composer dep even though it's already in `vendor-patched/`. Replaced both with the toolkit's own `wp-php-toolkit/data-liberation`, dropped to `php: >=7.2` to match the project floor.
- **polyfill** — `wordpress.php` was loaded eagerly via `autoload.files` and declared `WP_Error` at composer-bootstrap time, which fatals as soon as a consumer also boots WordPress (the exact regression `bin/check-wp-coexistence.php` was added to catch). `WP_Error` and `WP_Exception` now live in classmap-loaded `class-*.php` files so they're declared lazily, and the missing `php-functions.php` entry was added to standalone `autoload.files`.

The smoke check itself was tightened so it doesn't false-positive against the new excludes:

- `bin/check-package-autoload.php` now reads each package's `autoload.exclude-from-classmap` and skips those paths during the symbol scan.
- The root `composer.json`'s autoload was brought in line with the per-component config (CORSProxy/Polyfill in classmap, `cors-proxy-functions.php` in `autoload.files`, bogus `WordPress\\CORSProxy\\` PSR-4 mapping removed).

## Test plan

- [x] Local replay of the smoke workflow against all 17 packages using path-repository copies of `components/` reports OK on every package
- [x] `composer lint -- -n` clean
- [x] `composer test --testsuite "Project Test Suite"` (the fast non-Blueprints suite) passes
- [ ] CI matrix (PHPCS + PHPUnit) green on this PR
- [ ] After merge, manual `Publish` workflow run cuts a new tag — the chained `smoke-published-packages` job should pass against the freshly-cut tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)