### PR TITLE
Close `ProcessOutputStream` in `Runtime::eval_php_code_in_subprocess`

### DIFF
--- a/components/Blueprints/class-runtime.php
+++ b/components/Blueprints/class-runtime.php
@@ -219,7 +219,13 @@ class Runtime {
 		$process = $this->create_php_sub_process( $code, $env, $input, $timeout );
 		$process->mustRun();
 
-		$output = $process->getOutputStream( Process::OUTPUT_FILE )->consume_all();
+		$output_stream = $process->getOutputStream( Process::OUTPUT_FILE );
+		try {
+			$output = $output_stream->consume_all();
+		} finally {
+			$output_stream->close_reading();
+		}
+
 		return new EvalResult(
 			$output,
 			$process


### PR DESCRIPTION
Codex helped me diagnose and fix this issue. 

When running the following blueprint using php-cli on Windows, I ran into an error like this:

<details>
<summary>View blueprint</summary>
<pre><code>{
	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
	"landingPage": "/wp-admin/themes.php",
	"steps": [
		{
			"step": "installTheme",
			"themeData": {
				"resource": "wordpress.org/themes",
				"slug": "twentytwentyone"
			}
		},
		{
			"step": "activateTheme",
			"themeFolderName": "twentytwentyone"
		}
	]
}
</code></pre>
</details>

<details>
<summary>View logs</summary>
<pre><code>{"type":"error","message":"Failed to remove directory: C:\/Users\/fredrik\/AppData\/Local\/Temp\/wp-blueprints-runtime-69f9bf3281ae4\/tmp_69f9bf32b8d62","details":{"exception":"WordPress\\Filesystem\\FilesystemException","message":"Failed to remove directory: C:\/Users\/fredrik\/AppData\/Local\/Temp\/wp-blueprints-runtime-69f9bf3281ae4\/tmp_69f9bf32b8d62","file":"phar:\/\/C:\/Users\/fredrik\/Documents\/GitHub\/studio\/apps\/studio\/out\/Studio-win32-arm64\/resources\/cli\/wp-files\/blueprints\/blueprints.phar\/components\/Filesystem\/class-localfilesystem.php","line":157,"trace":"#0 phar:\/\/C:\/Users\/fredrik\/Documents\/GitHub\/studio\/apps\/studio\/out\/Studio-win32-arm64\/resources\/cli\/wp-files\/blueprints\/blueprints.phar\/components\/Filesystem\/Mixin\/trait-rmdirrecursive.php(21): WordPress\\Filesystem\\LocalFilesystem->rmdir_single('C:\/Users\/fredri...', Array)\n#1 phar:\/\/C:\/Users\/fredrik\/Documents\/GitHub\/studio\/apps\/studio\/out\/Studio-win32-arm64\/resources\/cli\/wp-files\/blueprints\/blueprints.phar\/components\/Filesystem\/Mixin\/trait-rmdirrecursive.php(15): WordPress\\Filesystem\\LocalFilesystem->rmdir('C:\/Users\/fredri...', Array)\n#2 phar:\/\/C:\/Users\/fredrik\/Documents\/GitHub\/studio\/apps\/studio\/out\/Studio-win32-arm64\/resources\/cli\/wp-files\/blueprints\/blueprints.phar\/components\/Filesystem\/Layer\/class-chrootlayer.php(103): WordPress\\Filesystem\\LocalFilesystem->rmdir('C:\/Users\/fredri...', Array)\n#3 phar:\/\/C:\/Users\/fredrik\/Documents\/GitHub\/studio\/apps\/studio\/out\/Studio-win32-arm64\/resources\/cli\/wp-files\/blueprints\/blueprints.phar\/components\/Blueprints\/class-runner.php(291): WordPress\\Filesystem\\Layer\\ChrootLayer->rmdir('C:\/Users\/fredri...', Array)\n#4 phar:\/\/C:\/Users\/fredrik\/Documents\/GitHub\/studio\/apps\/studio\/out\/Studio-win32-arm64\/resources\/cli\/wp-files\/blueprints\/blueprints.phar\/components\/Blueprints\/bin\/blueprint.php(398): WordPress\\Blueprints\\Runner->run()\n#5 phar:\/\/C:\/Users\/fredrik\/Documents\/GitHub\/studio\/apps\/studio\/out\/Studio-win32-arm64\/resources\/cli\/wp-files\/blueprints\/blueprints.phar\/components\/Blueprints\/bin\/blueprint.php(675): handleExecCommand(Array, Array, Array, Object(JsonProgressReporter))\n#6 C:\\Users\\fredrik\\Documents\\GitHub\\studio\\apps\\studio\\out\\Studio-win32-arm64\\resources\\cli\\wp-files\\blueprints\\blueprints.phar(12): require('phar:\/\/C:\/Users...')\n#7 {main}"}}
</code></pre>
</details>

This PR explicitly closes the `ProcessOutputStream` in `Runtime::eval_php_code_in_subprocess` before returning. I've confirmed that this fixes the issue on my Windows VM.