### PR TITLE
Fix docs parsing of CommonMark children

### DIFF
--- a/bin/build-reference.php
+++ b/bin/build-reference.php
@@ -115,6 +115,12 @@ function render_nodes( array $nodes ): string {
 	return rtrim( (string) $renderer->renderNodes( $nodes ) );
 }
 
+function node_children( Node $node ): array {
+	$children = $node->children();
+
+	return is_array( $children ) ? $children : iterator_to_array( $children );
+}
+
 /**
  * Render the lede as inline HTML, without an outer `<p>`. If the lede
  * is a single Paragraph (the catalog convention), render its inline
@@ -123,7 +129,7 @@ function render_nodes( array $nodes ): string {
 function render_lede( array $nodes ): string {
 	$renderer = new HtmlRenderer( commonmark_env() );
 	if ( 1 === count( $nodes ) && $nodes[0] instanceof Paragraph ) {
-		$inline = iterator_to_array( $nodes[0]->children() );
+		$inline = node_children( $nodes[0] );
 		return rtrim( (string) $renderer->renderNodes( $inline ) );
 	}
 	return rtrim( (string) $renderer->renderNodes( $nodes ) );
@@ -148,7 +154,7 @@ function parse_body( string $md ): array {
 	/** @var Document $doc */
 	$doc = $parser->parse( $md );
 
-	$children = iterator_to_array( $doc->children() );
+	$children = node_children( $doc );
 
 	// Find section boundaries (top-level H2 headings).
 	$boundaries = array();

--- a/bin/run-snippets.php
+++ b/bin/run-snippets.php
@@ -186,7 +186,7 @@ function write_expected_output( string $slug, string $filename, string $new_outp
 
 	$parser = new \League\CommonMark\Parser\MarkdownParser( commonmark_env() );
 	$tree   = $parser->parse( $body );
-	$kids   = iterator_to_array( $tree->children() );
+	$kids   = node_children( $tree );
 
 	// Find the snippet metadata HtmlBlock whose meta names this filename.
 	$snippet_idx = null;


### PR DESCRIPTION
Fixes the docs deploy failure from https://github.com/WordPress/php-toolkit/actions/runs/25510294479/job/74871014893#step:5:21.

The vendored CommonMark `Node::children()` implementation can return a plain array. `bin/build-reference.php` assumed it always returned `Traversable` and passed it directly to `iterator_to_array()`, which fails under the docs deploy PHP 8.1 job.

This adds a small `node_children()` helper that accepts either arrays or `Traversable` results, then uses it in both `bin/build-reference.php` and `bin/run-snippets.php`.