### PR TITLE
Harden publish scripts

### DIFF
--- a/bin/smoke-published-packages.sh
+++ b/bin/smoke-published-packages.sh
@@ -96,10 +96,21 @@ for pkg in "${PACKAGES[@]}"; do
 
   composer init --no-interaction --name="smoke/${pkg}" --stability=stable --quiet
 
-  # Some packages depend on `dev-trunk` of related repos that don't exist
-  # post-split. Allow stable resolution to fail so we at least report it
-  # rather than aborting the whole sweep.
-  if ! composer require --no-interaction --quiet "wp-php-toolkit/${pkg}:${VERSION}" 2>"${scratch}/install.err"; then
+  installed=0
+  for attempt in 1 2 3 4 5; do
+    # Packagist can expose the package being checked before Composer sees all
+    # of its freshly-tagged sibling dependencies from the same release.
+    if composer require --no-interaction --quiet "wp-php-toolkit/${pkg}:${VERSION}" 2>"${scratch}/install.err"; then
+      installed=1
+      break
+    fi
+
+    echo "  composer require attempt ${attempt}/5 failed for wp-php-toolkit/${pkg}, retrying..."
+    composer clear-cache --quiet || true
+    sleep "$(( attempt * 6 ))"
+  done
+
+  if [[ "$installed" -ne 1 ]]; then
     echo "  FAIL: composer require"
     sed 's/^/    /' "${scratch}/install.err"
     failed+=( "${pkg}" )

--- a/bin/split-code.sh
+++ b/bin/split-code.sh
@@ -38,7 +38,15 @@ create_repo_if_needed() {
   else
     echo "Creating repo: ${org}/${name}"
     local visflag="--${VISIBILITY}"
-    gh repo create "${org}/${name}" ${visflag} --disable-wiki >/dev/null
+    local create_output
+    if ! create_output="$(gh repo create "${org}/${name}" ${visflag} --disable-wiki 2>&1)"; then
+      if echo "$create_output" | grep -qi "name already exists"; then
+        echo "Repo exists: ${org}/${name}"
+      else
+        echo "$create_output" >&2
+        exit 1
+      fi
+    fi
     if [[ -n "$desc" ]]; then gh repo edit "${org}/${name}" --description "$desc" >/dev/null; fi
     if [[ -n "$homepage" ]]; then gh repo edit "${org}/${name}" --homepage "$homepage" >/dev/null; fi
     # Topics


### PR DESCRIPTION
## What changed

- Treat GitHub's "name already exists" response during component repo creation as an existing repository and continue the split.
- Retry `composer require` in the published-package smoke test while Packagist/Composer metadata catches up for freshly tagged sibling packages.

## Why

The failed publish run aborted when `gh repo view` missed an existing `wp-php-toolkit/http-client` repository and `gh repo create` returned `Name already exists on this account`. The follow-up smoke failures were caused by Composer seeing stale Packagist metadata for newly released sibling dependencies.

## Validation

- `bash -n bin/split-code.sh bin/smoke-published-packages.sh`
- `bash bin/smoke-published-packages.sh 0.7.5` -> `All 17 packages OK at 0.7.5`
- Verified `v0.7.5` exists on Packagist for all 17 packages.
