### PR TITLE
Fix documentation accuracy issues

### DIFF
--- a/components/Blueprints/README.md
+++ b/components/Blueprints/README.md
@@ -9,7 +9,7 @@ see_also:
   - cli | CLI | Wrap repeatable blueprint operations in a small command.
 ---
 
-Declarative WordPress site provisioning. Write a JSON description of plugins, options, and content; let the runner execute it.
+Declarative WordPress site provisioning. Write a Blueprint JSON document for plugins, options, content, and setup steps; let the runner execute it.
 
 ## Why this exists
 
@@ -23,7 +23,7 @@ Declarative WordPress site provisioning. Write a JSON description of plugins, op
 
 ## Configure a runner for an existing site
 
-<p><code>RunnerConfiguration</code> is a fluent builder. The minimum: target site root, target site URL, execution mode.</p>
+<p><code>RunnerConfiguration</code> is a fluent builder. A real run also needs a blueprint reference; this snippet shows the site-target fields in isolation.</p>
 
 <!-- snippet:
 filename: configure.php
@@ -55,7 +55,7 @@ url:  http://playground.test/
 
 ## Generate blueprint JSON from PHP
 
-<p>CI jobs and tests stay clearer when PHP builds the blueprint from data instead of hand-writing JSON. Keep the structure plain: <code>version</code>, then a list of step arrays.</p>
+<p>CI jobs and tests stay clearer when PHP builds the blueprint from data instead of hand-writing JSON. Keep the structure plain: <code>version</code>, top-level collections such as <code>plugins</code>, and any imperative steps under the schema's step lists.</p>
 
 <!-- snippet:
 filename: build-json.php
@@ -70,26 +70,23 @@ $plugins   = array( 'gutenberg', 'classic-editor' );
 
 $blueprint = array(
 	'version' => 2,
-	'steps'   => array(
+	'plugins' => array(),
+	'additionalStepsAfterExecution' => array(
 		array(
 			'step'    => 'setSiteOptions',
 			'options' => array(
-				'blogname'              => $site_name,
-				'permalink_structure'   => '/%postname%/',
-				'show_on_front'         => 'page',
+				'blogname'            => $site_name,
+				'permalink_structure' => '/%postname%/',
+				'show_on_front'       => 'page',
 			),
 		),
 	),
 );
 
 foreach ( $plugins as $slug ) {
-	$blueprint['steps'][] = array(
-		'step'       => 'installPlugin',
-		'pluginData' => "https://downloads.wordpress.org/plugin/{$slug}.zip",
-	);
-	$blueprint['steps'][] = array(
-		'step'   => 'activatePlugin',
-		'plugin' => "{$slug}/{$slug}.php",
+	$blueprint['plugins'][] = array(
+		'source' => $slug,
+		'active' => true,
 	);
 }
 
@@ -100,7 +97,17 @@ echo json_encode( $blueprint, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n
 ```
 {
     "version": 2,
-    "steps": [
+    "plugins": [
+        {
+            "source": "gutenberg",
+            "active": true
+        },
+        {
+            "source": "classic-editor",
+            "active": true
+        }
+    ],
+    "additionalStepsAfterExecution": [
         {
             "step": "setSiteOptions",
             "options": {
@@ -108,22 +115,6 @@ echo json_encode( $blueprint, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n
                 "permalink_structure": "/%postname%/",
                 "show_on_front": "page"
             }
-        },
-        {
-            "step": "installPlugin",
-            "pluginData": "https://downloads.wordpress.org/plugin/gutenberg.zip"
-        },
-        {
-            "step": "activatePlugin",
-            "plugin": "gutenberg/gutenberg.php"
-        },
-        {
-            "step": "installPlugin",
-            "pluginData": "https://downloads.wordpress.org/plugin/classic-editor.zip"
-        },
-        {
-            "step": "activatePlugin",
-            "plugin": "classic-editor/classic-editor.php"
         }
     ]
 }
@@ -164,7 +155,7 @@ $schema = array(
 $blueprint = array(
 	'version' => 2,
 	'steps'   => array(
-		array( 'pluginData' => 'https://downloads.wordpress.org/plugin/gutenberg.zip' ),
+		array( 'source' => 'https://downloads.wordpress.org/plugin/gutenberg.zip' ),
 	),
 );
 
@@ -183,19 +174,22 @@ Blueprint root["steps"][0]: Missing required field: step.
 
 ## The Blueprint JSON shape
 
-<p>A blueprint is a JSON document with a <code>version</code> field and a <code>steps</code> array. Each step has a <code>"step"</code> discriminator and step-specific fields. This is the same shape used by <a href="https://playground.wordpress.net/">WordPress Playground</a>.</p>
+<p>A Blueprint v2 document starts with a <code>version</code> field, then uses top-level declarations such as <code>plugins</code>, <code>themes</code>, <code>content</code>, and the schema's step lists. Imperative steps use a <code>"step"</code> discriminator plus step-specific fields.</p>
 
 <pre><code>{
   "version": 2,
-  "steps": [
+  "plugins": [
+    { "source": "gutenberg", "active": true }
+  ],
+  "additionalStepsAfterExecution": [
     { "step": "setSiteOptions",
       "options": {
         "blogname": "Demo Site",
         "permalink_structure": "/%postname%/"
       } },
     { "step": "installPlugin",
-      "pluginData": "https://downloads.wordpress.org/plugin/gutenberg.zip" },
+      "source": "https://downloads.wordpress.org/plugin/classic-editor.zip" },
     { "step": "activatePlugin",
-      "plugin": "gutenberg/gutenberg.php" }
+      "pluginPath": "classic-editor/classic-editor.php" }
   ]
 }</code></pre>

--- a/components/ByteStream/README.md
+++ b/components/ByteStream/README.md
@@ -9,13 +9,13 @@ see_also:
   - httpclient | HttpClient | Process request and response bodies incrementally.
 ---
 
-Composable streaming primitives for reading, writing, transforming, hashing, and compressing byte data. Pull/peek/consume semantics let parsers backtrack without copying, and deflate, inflate, and checksum filters snap together like Lego.
+Composable streaming primitives for reading, writing, transforming, hashing, and compressing byte data. Pull/peek/consume semantics let parsers look ahead with bounded buffering, and deflate, inflate, and checksum filters snap together like Lego.
 
 ## Why this exists
 
 <p>PHP's native streams are powerful but inconsistent. <code>fread</code> on a socket may return short reads with no warning; <code>stream_filter_append</code> is awkward to compose; gzip helpers and file handles expose different APIs. The ByteStream component normalizes these behind one small interface — <code>pull / peek / consume</code> — so a parser, a hash function, and a deflate filter all see the same shape.</p>
 
-<p>The split between <em>pull</em> (buffer up to N bytes) and <em>consume</em> (advance past N bytes) is the secret. Parsers can <code>peek</code> ahead to detect a record boundary and decide whether to <code>consume</code>, without copying or allocating.</p>
+<p>The split between <em>pull</em> (buffer up to N bytes) and <em>consume</em> (advance past N bytes) is the secret. Parsers can <code>peek</code> ahead to detect a record boundary and decide whether to <code>consume</code>, while keeping buffer ownership inside the stream.</p>
 
 ## Read a file in chunks
 
@@ -88,7 +88,7 @@ third chunk
 
 ## Compress on the way in, decompress on the way out
 
-<p>Wrap a stream in <code>DeflateReadStream</code> to get compressed bytes out; wrap it in <code>InflateReadStream</code> to get decompressed bytes out. Both are full <code>ByteReadStream</code> implementations, so they nest into anything else that takes a stream.</p>
+<p>Wrap a stream in <code>DeflateReadStream</code> to get compressed bytes out; wrap it in <code>InflateReadStream</code> to get decompressed bytes out. Both are full <code>ByteReadStream</code> implementations, so they nest into anything else that takes a stream. These filters use PHP's <code>zlib</code> functions.</p>
 
 <!-- snippet:
 filename: deflate-roundtrip.php

--- a/components/CORSProxy/README.md
+++ b/components/CORSProxy/README.md
@@ -29,7 +29,7 @@ curl -s "http://127.0.0.1:5263/cors-proxy.php/https://api.github.com/repos/WordP
 
 ## Production rate limiting
 
-<p>Drop a <code>cors-proxy-config.php</code> next to <code>cors-proxy.php</code>. If that file defines a <code>playground_cors_proxy_maybe_rate_limit()</code> function, the proxy calls it before forwarding any request — your one chance to reject early. Without the file, the proxy applies its default rate limiter, which is fine for development but should be replaced for any deployment that gets real traffic.</p>
+<p>Drop a <code>cors-proxy-config.php</code> next to <code>cors-proxy.php</code>. If that file defines a <code>playground_cors_proxy_maybe_rate_limit()</code> function, the proxy calls it before forwarding any request — your one chance to reject early. Without that function the proxy relies only on its coarse built-in safeguards, so production deployments should provide their own rate limiting.</p>
 
 <p>This example uses a per-IP token bucket stored on disk. Replace with Redis or memcached for multi-host deployments.</p>
 

--- a/components/DataLiberation/README.md
+++ b/components/DataLiberation/README.md
@@ -10,7 +10,7 @@ see_also:
   - httpclient | HttpClient | Download media and remote source data while importing.
 ---
 
-Streaming WordPress import/export. WXR, SQL, block markup — without loading whole datasets into memory.
+Streaming WordPress import/export. WXR, SQL, block markup — process entities one at a time instead of building whole-dataset object graphs.
 
 ## Why this exists
 
@@ -24,7 +24,7 @@ Streaming WordPress import/export. WXR, SQL, block markup — without loading wh
 
 ## Write a WXR file in five lines
 
-<p>Stream a single post into a WXR document via <code>WXRWriter</code>. The writer holds no buffer beyond what is needed to close currently-open tags, so memory stays flat regardless of input size.</p>
+<p>Stream a single post into a WXR document via <code>WXRWriter</code>. The writer emits each entity to the output stream and only keeps the small amount of state needed for the current document.</p>
 
 <!-- snippet:
 filename: wxr-quickstart.php
@@ -122,9 +122,9 @@ terms: 3
 Blog post exported
 ```
 
-## Read entities from a WXR file with constant memory
+## Read entities from a WXR file incrementally
 
-<p><code>WXREntityReader</code> emits one entity at a time. A 10 GB WXR uses the same memory as a 10 KB one.</p>
+<p><code>WXREntityReader</code> emits one entity at a time. Memory use is driven by the current entity and parser buffers rather than the total file size.</p>
 
 <!-- snippet:
 filename: wxr-read.php
@@ -166,7 +166,7 @@ post: {"post_title":"Second","post_id":"2","post_type":"post","post_content":"Bo
 
 ## Streaming transform: rewrite URLs while copying WXR
 
-<p>Wire reader to writer to rewrite a WXR file on the fly. This pattern is how you migrate a staging export to production: swap <code>staging.example.com</code> for <code>example.com</code> without ever loading the file into memory.</p>
+<p>Wire reader to writer to rewrite a WXR file on the fly. This pattern is how you migrate a staging export to production: swap <code>staging.example.com</code> for <code>example.com</code> while holding only the current entity and output buffers.</p>
 
 <!-- snippet:
 filename: rewrite-urls.php

--- a/components/Encoding/README.md
+++ b/components/Encoding/README.md
@@ -81,9 +81,9 @@ the byte � should not be here.
 .��.
 ```
 
-## Detecting noncharacters MySQL/utf8mb4 will reject
+## Detecting Unicode noncharacters
 
-<p>Code points like U+FFFE, U+FFFF, and the U+FDD0–U+FDEF block are valid Unicode but forbidden in XML and rejected by some databases. Check before inserting user-submitted content into a strict <code>utf8mb4</code> column.</p>
+<p>Code points like U+FFFE, U+FFFF, and the U+FDD0–U+FDEF block are valid Unicode scalar values but forbidden in XML and unwelcome in many interchange formats. Check for them before serializing user-submitted content into strict XML, WXR, or other systems that reject noncharacters.</p>
 
 <!-- snippet:
 filename: noncharacters.php

--- a/components/Filesystem/README.md
+++ b/components/Filesystem/README.md
@@ -9,11 +9,11 @@ see_also:
   - git | Git | Expose repository trees through a filesystem-shaped API.
 ---
 
-One <code>Filesystem</code> interface across local disk, in-memory trees, SQLite databases, and ZIP archives. Forward-slash paths everywhere — even on Windows — so the same code runs in tests, in production, and inside read-only ZIPs.
+One <code>Filesystem</code> interface across local disk, in-memory trees, SQLite databases, and ZIP archives. Forward-slash paths everywhere — even on Windows — so the same code runs in tests, in production, and inside read-only ZIP-backed trees.
 
 ## Why this exists
 
-<p>Code that touches the filesystem is hard to test, hard to port to Windows, and impossible to point at non-disk storage without rewriting it. Swap <code>LocalFilesystem</code> for <code>InMemoryFilesystem</code> in tests and your suite stops touching <code>/tmp</code>; swap it for <code>SQLiteFilesystem</code> and your "files" become rows in a portable database; swap it for <code>ZipFilesystem</code> and you can read inside an archive with the same calls.</p>
+<p>Code that touches the filesystem is hard to test, hard to port to Windows, and impossible to point at non-disk storage without rewriting it. Swap <code>LocalFilesystem</code> for <code>InMemoryFilesystem</code> in tests and your suite stops touching <code>/tmp</code>; swap it for <code>SQLiteFilesystem</code> when the <code>sqlite3</code> extension is available and your "files" become rows in a portable database; swap it for <code>ZipFilesystem</code> and you can read inside an archive with the same calls.</p>
 
 <p>Every backend uses forward slashes regardless of host OS. No <code>DIRECTORY_SEPARATOR</code> juggling, no Windows-only test failures, no surprises when a path moves between backends.</p>
 
@@ -109,7 +109,7 @@ exists after cleanup? no
 
 ## SQLite as a portable file store
 
-<p>The whole tree lives in one SQLite database file. Use it for self-contained scratch storage that survives process boundaries without leaving loose files behind.</p>
+<p>The whole tree lives in one SQLite database file. Use it for self-contained scratch storage that survives process boundaries without leaving loose files behind. This backend requires PHP's <code>sqlite3</code> extension.</p>
 
 <!-- snippet:
 filename: sqlite.php
@@ -142,7 +142,7 @@ post-3.md: # Post 3
 
 ## Copy a tree across backends
 
-<p>The killer composability move: <code>copy_between_filesystems()</code> streams files chunk-by-chunk from any source to any target. Pull a ZIP into SQLite, snapshot SQLite to disk, mirror disk into RAM — all the same call.</p>
+<p>The killer composability move: <code>copy_between_filesystems()</code> streams files chunk-by-chunk from any source to any target. Pull a ZIP into SQLite, snapshot SQLite to disk, mirror disk into RAM — all the same call, with the relevant backend extensions available.</p>
 
 <!-- snippet:
 filename: cross-backend-copy.php

--- a/components/Git/README.md
+++ b/components/Git/README.md
@@ -9,13 +9,15 @@ see_also:
   - bytestream | ByteStream | Read and write object data without accidental buffering.
 ---
 
-A pure-PHP Git client and server. Commits, branches, diffs, HTTP push/pull — all without shelling out to <code>git</code>.
+A PHP implementation of core Git repository operations plus HTTP protocol helpers. Commits, branches, diffs, and selected push/pull workflows run without shelling out to <code>git</code>.
 
 ## Why this exists
 
 <p>Git is a useful storage model even when a server cannot run the <code>git</code> binary: snapshots, branches, object-addressed files, diffs, merges, and sync over HTTP. That matters for WordPress tools that want revision history for generated files, content snapshots, site state, or collaborative edits in constrained runtimes.</p>
 
-<p>The Git component implements the core repository operations in PHP and stores objects through the toolkit <code>Filesystem</code> interface. That means the same repository can live on disk, in memory, or in another backend, and higher-level code can commit files without knowing where objects are stored.</p>
+<p>The Git component implements the core repository operations in PHP and stores objects through the toolkit <code>Filesystem</code> interface. That means the same repository can live on disk, in memory, or in another backend, and higher-level code can commit files without knowing where objects are stored. It is a toolkit implementation for supported workflows, not a complete replacement for every <code>git</code> command and protocol edge case.</p>
+
+<p>Git object storage and pack processing use zlib compression through the ByteStream compression filters.</p>
 
 <p>The docs start with simple commits because that mental model scales: a repository is just objects plus refs. From there, branches, history walking, root commits, and merges become details you can reason about instead of magic shell behavior.</p>
 

--- a/components/HTML/README.md
+++ b/components/HTML/README.md
@@ -14,7 +14,7 @@ see_also:
   - dataliberation | DataLiberation | Rewrite URLs and media references during import/export pipelines.
 ---
 
-A pure-PHP HTML5 parser and tag rewriter mirroring WordPress core's HTML API. Treat HTML the way browsers do — without <code>libxml2</code>, <code>DOMDocument</code>, or regex hacks — and rewrite attributes in a single linear pass.
+A pure-PHP HTML parser and tag rewriter mirroring WordPress core's HTML API. Handle browser-style HTML fragments for supported markup — without <code>libxml2</code>, <code>DOMDocument</code>, or regex hacks — and rewrite attributes in a single linear pass.
 
 ## Why this exists
 
@@ -23,6 +23,8 @@ A pure-PHP HTML5 parser and tag rewriter mirroring WordPress core's HTML API. Tr
 <p>The HTML component gives WordPress-style code the same parsing model WordPress core uses: a browser-compatible tokenizer and tree-aware processor that run in pure PHP. Choose it for exact-byte rewrites, imperfect fragments, and post-content filters where a full DOM would do too much work.</p>
 
 <p>The component gives you two processors. <code>WP_HTML_Tag_Processor</code> is a forward-only cursor over tags and tokens — useful for attribute rewriting at scale. <code>WP_HTML_Processor</code> layers HTML5 tree construction on top so you can query by ancestry (breadcrumbs), serialize the parsed document, and trust that <code>&lt;p&gt;one&lt;p&gt;two</code> parses as two paragraphs the way a browser sees it.</p>
+
+<p>Scope: <code>WP_HTML_Processor</code> intentionally supports WordPress core's current subset of HTML5. It aborts on markup it cannot safely model, including table-internal content, foreign content such as SVG/MathML, and content outside the supported body parsing modes. Use <code>get_unsupported_exception()</code> when you need to explain why processing stopped.</p>
 
 <p>Footgun: <strong>Mutations are buffered.</strong> Nothing changes in the source string until you call <code>get_updated_html()</code>. If you read <code>get_attribute()</code> after a <code>set_attribute()</code> on the same tag, you see the new value — but downstream tooling reading the original string sees stale HTML until you serialize.</p>
 

--- a/components/HttpClient/README.md
+++ b/components/HttpClient/README.md
@@ -16,7 +16,7 @@ Async HTTP client without <code>curl</code> required. Uses sockets when curl is 
 
 <p>A plugin installer starts with one request to download <code>plugin.zip</code>. A migration then adds progress reporting, a ten-request media window, resumable downloads, and a remote ZIP reader that feeds ZipFilesystem directly. Those workflows need the same request API from the first GET to the final streamed archive.</p>
 
-<p>The HttpClient component gives the toolkit a small request/response model, middleware for redirects and caching, concurrent fetches, and response bodies exposed as byte streams. It runs through curl when PHP provides curl and through pure PHP sockets when it does not. Callers keep the same code path.</p>
+<p>The HttpClient component gives the toolkit a small request/response model, middleware for redirects and caching, concurrent fetches, and response bodies exposed as byte streams. It runs through curl when PHP provides curl and through PHP sockets when it does not. Callers keep the same request and response model while the transport changes underneath.</p>
 
 <p>Use it to fetch plugin metadata, submit import callbacks, mirror a media library, read a WXR export, or pipe a remote archive into Zip and Filesystem code.</p>
 
@@ -202,6 +202,8 @@ if ( extension_loaded( 'curl' ) ) {
 ## Follow redirects and inspect the final request
 
 <p>Redirects are middleware, not transport behavior. The client follows up to five redirects by default. The original <code>Request</code> keeps a chain to the final request, so importers can log where a source URL actually landed.</p>
+
+<p>Current caveat: followed redirects are reissued as <code>GET</code> requests. That matches common browser behavior for <code>303</code> and many simple downloads, but do not rely on it for preserving non-GET methods across <code>307</code> or <code>308</code> responses.</p>
 
 <!-- snippet:
 filename: redirects.php

--- a/components/Merge/README.md
+++ b/components/Merge/README.md
@@ -57,7 +57,7 @@ foreach ( $diff->get_changes() as $change ) {
 
 ## Render a unified patch
 
-<p><code>format_as_git_patch()</code> produces output that mirrors <code>git diff</code>, including hunk headers — handy for emails, CI annotations, or a "what changed?" panel.</p>
+<p><code>format_as_git_patch()</code> produces unified-patch-style output, including hunk headers — handy for emails, CI annotations, or a "what changed?" panel.</p>
 
 <!-- snippet:
 filename: git-patch.php

--- a/components/Polyfill/README.md
+++ b/components/Polyfill/README.md
@@ -3,20 +3,20 @@ slug: polyfill
 title: Polyfill
 install: wp-php-toolkit/polyfill
 
-credit_title: WordPress-shaped behavior
+credit_title: WordPress-shaped compatibility
 credit_body: |
-  When WordPress is loaded, every function in this component defers to WordPress. The standalone implementations of <code>esc_html()</code>, <code>add_filter()</code>, <code>__()</code>, and friends match WordPress core's behavior so the same code runs inside and outside the platform.
+  When WordPress is loaded, every function in this component defers to WordPress. Outside WordPress, the standalone implementations cover the subset toolkit components need from <code>esc_html()</code>, <code>add_filter()</code>, <code>__()</code>, and related helpers.
 
 see_also:
   - html | HTML | Run WordPress-shaped escaping and translation helpers beside HTML processors.
   - blockparser | BlockParser | Keep standalone block tooling familiar outside WordPress.
 ---
 
-PHP 8 string functions on PHP 7.2+, WordPress hook stubs, and translation/escaping passthroughs so toolkit code runs without WordPress.
+PHP 8 string functions on PHP 7.2+, WordPress hook stubs, and translation/escaping passthroughs so toolkit code runs without booting WordPress.
 
 ## Why this exists
 
-<p>A lot of WordPress-adjacent code wants to call <code>esc_html()</code>, <code>__()</code>, or <code>apply_filters()</code> without booting WordPress. The polyfill component provides minimal but real implementations so that code runs unchanged outside WordPress, and stays out of the way when WordPress is loaded (every function uses <code>function_exists()</code> guards).</p>
+<p>A lot of WordPress-adjacent code wants to call <code>esc_html()</code>, <code>__()</code>, or <code>apply_filters()</code> without booting WordPress. The polyfill component provides minimal implementations for the subset used by the toolkit, and stays out of the way when WordPress is loaded (every function uses <code>function_exists()</code> guards).</p>
 
 ## PHP 8 string functions on PHP 7.2
 
@@ -74,7 +74,7 @@ https://example.com/?a=1&amp;b=2
 
 ## A simple filter chain
 
-<p>The hook system is a real implementation of the WordPress filter API: registered callbacks get applied in priority order, and each one transforms the running value.</p>
+<p>The hook system implements the common filter path: registered callbacks get applied in priority order, and each one transforms the running value.</p>
 
 <!-- snippet:
 filename: filter-chain.php

--- a/components/ToolkitCodingStandards/README.md
+++ b/components/ToolkitCodingStandards/README.md
@@ -1,7 +1,6 @@
 ---
 slug: coding-standards
 title: ToolkitCodingStandards
-install: wp-php-toolkit/toolkit-coding-standards
 
 see_also:
   - polyfill | Polyfill | Share WordPress-style compatibility expectations across standalone packages.
@@ -11,9 +10,9 @@ PHP_CodeSniffer sniffs used by this project: enforce Yoda comparisons and ban th
 
 ## Why this exists
 
-<p>This package is not a general-purpose style guide. It holds project-specific PHP_CodeSniffer rules for review comments the toolkit wants automated: comparisons should follow the WordPress Yoda style, and short ternaries should not hide whether a fallback is meant for <code>null</code> only or for all falsy values.</p>
+<p>This component is not currently published as a separate Composer package and is not a general-purpose style guide. It holds project-specific PHP_CodeSniffer rules for review comments the toolkit wants automated: comparisons should follow the WordPress Yoda style, and short ternaries should not hide whether a fallback is meant for <code>null</code> only or for all falsy values.</p>
 
-<p>Use it in this monorepo, or in a project that intentionally wants the same review tradeoffs. If your project does not follow WordPress-style comparisons, the Yoda sniff is probably the wrong rule for you.</p>
+<p>Use it in this monorepo, or vendor/copy it into a project that intentionally wants the same review tradeoffs. If your project does not follow WordPress-style comparisons, the Yoda sniff is probably the wrong rule for you.</p>
 
 ## Reference the standard from your phpcs.xml
 

--- a/components/XML/README.md
+++ b/components/XML/README.md
@@ -9,11 +9,11 @@ see_also:
   - bytestream | ByteStream | Keep large XML reads incremental.
 ---
 
-A streaming, namespace-aware XML processor in pure PHP. Read and modify huge feeds, WXR exports, ePub manifests, and Office Open XML parts without ever loading the document into memory and without depending on <code>libxml2</code>.
+A streaming, namespace-aware XML processor in pure PHP. Read huge feeds, WXR exports, ePub manifests, and Office Open XML parts incrementally, then emit edited XML without depending on <code>libxml2</code>.
 
 ## Why this exists
 
-<p><code>SimpleXMLElement</code> and <code>DOMDocument</code> both need <code>libxml2</code> and both build a complete in-memory tree. <code>XMLProcessor</code> walks the document forward as a cursor, keeps modifications in a side buffer, and emits the full updated XML with <code>get_updated_xml()</code> only when you ask for it.</p>
+<p><code>SimpleXMLElement</code> and <code>DOMDocument</code> both need <code>libxml2</code> and both build a complete in-memory tree. <code>XMLProcessor</code> walks the document forward as a cursor, keeps modifications in a side buffer, and emits the full updated XML with <code>get_updated_xml()</code> only when you ask for it. Reading stays incremental; materializing the updated XML still allocates the resulting document.</p>
 
 <p>This design came from WordPress-scale documents such as WXR exports. A migration may only need to rewrite <code>wp:attachment_url</code> values or bump a feed attribute, so the processor optimizes for targeted cursor edits instead of a full validating XML stack.</p>
 
@@ -113,7 +113,7 @@ wp/status: publish
 
 ## Rewrite URLs across an entire WXR export
 
-<p>Large WXR exports can hold many URLs in <code>&lt;link&gt;</code>, <code>&lt;guid&gt;</code>, and post content. Streaming the file lets you rewrite large exports without loading the whole XML document into memory.</p>
+<p>Large WXR exports can hold many URLs in <code>&lt;link&gt;</code>, <code>&lt;guid&gt;</code>, and post content. The cursor can find and rewrite matching text nodes incrementally; calling <code>get_updated_xml()</code> returns the complete rewritten document.</p>
 
 <!-- snippet:
 filename: rewrite-wxr-urls.php

--- a/components/Zip/README.md
+++ b/components/Zip/README.md
@@ -10,17 +10,17 @@ see_also:
   - httpclient | HttpClient | Stream downloaded archives into validation or extraction workflows.
 ---
 
-Read and write ZIP archives in pure PHP — no <code>libzip</code>, no <code>ZipArchive</code>. Streams entries one at a time, so you can build EPUBs, .docx files, and multi-gigabyte plugin bundles without buffering the archive in memory.
+Read and write ZIP archives without <code>libzip</code> or <code>ZipArchive</code>. Stored entries are pure PHP; Deflate entries use PHP's <code>zlib</code> functions. Entries stream one at a time, while ZIP metadata such as the central directory is still held in memory.
 
 ## Why this exists
 
 <p>Common PHP ZIP workflows rely on the <code>ZipArchive</code> extension or shelling out to <code>zip</code>. Those are awkward in hosts without libzip, WebAssembly builds, and code paths that need to stream archive data through toolkit byte streams.</p>
 
-<p>The Zip component reads and writes Stored and Deflate archives in pure PHP. The decoder is pull-based, so listing the central directory of a 2 GB ZIP costs roughly the size of the directory itself. The encoder accepts any <code>ByteWriteStream</code> as a sink and writes one entry at a time.</p>
+<p>The Zip component reads and writes Stored and Deflate archives without <code>ZipArchive</code>. The decoder is pull-based for entry bodies, but <code>ZipFilesystem</code> indexes the central directory in memory and currently rejects archives whose central directory exceeds 2 MB. The encoder accepts any <code>ByteWriteStream</code> as a sink and writes one entry at a time.</p>
 
 ## Read a file out of a ZIP
 
-<p><code>ZipFilesystem</code> implements this toolkit's <code>Filesystem</code> interface, so once you wrap the byte reader you can call <code>get_contents()</code>, <code>ls()</code>, and <code>is_dir()</code> just like the other filesystem backends.</p>
+<p><code>ZipFilesystem</code> implements this toolkit's <code>Filesystem</code> interface, so once you wrap the byte reader you can call <code>get_contents()</code>, <code>ls()</code>, and <code>is_dir()</code> just like the other read backends.</p>
 
 <p><strong>Try this:</strong> after <em>Run</em>, add a second <code>append_file()</code> call before <code>$enc-&gt;close()</code> for a <code>notes.md</code> entry, then call <code>print_r( $zip-&gt;ls( '/' ) )</code> at the end. The directory listing reflects the new entry without re-reading the file.</p>
 
@@ -267,7 +267,7 @@ XML,
 
 ## Defend against zip-slip
 
-<p>A malicious archive can name an entry <code>../../etc/passwd</code> and trick a naive extractor into clobbering files outside the destination. <code>ZipDecoder::sanitize_path()</code> strips leading <code>../</code> segments and collapses internal <code>/../</code> sequences before exposing the path.</p>
+<p>A malicious archive can name an entry <code>../../etc/passwd</code> and trick a naive extractor into clobbering files outside the destination. <code>ZipDecoder::sanitize_path()</code> normalizes slashes and strips leading traversal segments before exposing the path. Treat it as one layer of defense; still extract through a chrooted filesystem target.</p>
 
 <!-- snippet:
 filename: zip-slip.php
@@ -394,6 +394,8 @@ files now in memory:
 
 <p>Footgun: <strong>Updating an entry in place is impossible.</strong> The central directory points at byte offsets — change one entry's compressed size and every later offset shifts. Repack into a new archive instead.</p>
 
-<p>Footgun: <strong>Never extract entry paths verbatim.</strong> Always run paths through <code>ZipDecoder::sanitize_path()</code>. Without it, a hostile archive can write outside the destination directory.</p>
+<p>Footgun: <strong>Never extract entry paths verbatim.</strong> Always run paths through <code>ZipDecoder::sanitize_path()</code> and write through a filesystem layer that prevents path escape. Without those checks, a hostile archive can write outside the destination directory.</p>
 
 <p>Footgun: <strong>Encrypted archives aren't supported.</strong> If you need to read AES-encrypted ZIPs, this isn't the component. The file format technically allows encryption, but the toolkit deliberately excludes it because the implementation surface is large and the use case is rare in WordPress contexts.</p>
+
+<p>Footgun: <strong>ZIP64 and very large central directories aren't supported by <code>ZipFilesystem</code>.</strong> Entry bodies can stream, but the archive index is bounded by <code>MAX_CENTRAL_DIRECTORY_SIZE</code>.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>PHP Toolkit — pure-PHP libraries for WordPress and the open web</title>
-<meta name="description" content="A pure-PHP toolkit for parsing HTML, reading and writing ZIP archives, streaming bytes, importing content, and a dozen other jobs that PHP normally outsources to extensions. No libxml2, no libzip, no curl, no database. Runs on PHP 7.2 through 8.3 and inside the browser via WordPress Playground.">
+<title>PHP Toolkit — PHP libraries for WordPress and the open web</title>
+<meta name="description" content="A PHP toolkit for parsing HTML, reading and writing ZIP archives, streaming bytes, importing content, and a dozen other jobs that PHP often outsources to extensions. Runs on PHP 7.2+ and inside the browser via WordPress Playground.">
 <link rel="stylesheet" href="assets/style.css?v=20260429-credits">
 </head>
 <body>
@@ -21,7 +21,7 @@
 
 <section class="hero">
 	<h1>The pieces of WordPress, without the dependencies.</h1>
-	<p class="lede">PHP Toolkit is a set of small, pure-PHP libraries for the work that WordPress core does every day — parsing HTML, reading ZIP archives, streaming bytes, importing content, making HTTP requests. No <code>libxml2</code>. No <code>libzip</code>. No <code>curl</code>. No database. Runs on PHP 7.2 through 8.3, on Linux, macOS, Windows, and inside the browser via WordPress Playground.</p>
+	<p class="lede">PHP Toolkit is a set of small PHP libraries for the work that WordPress core does every day — parsing HTML, reading ZIP archives, streaming bytes, importing content, making HTTP requests. No <code>libxml2</code>. No <code>libzip</code>. HttpClient does not require <code>curl</code>. Runs on PHP 7.2+, on Linux, macOS, Windows, and inside the browser via WordPress Playground.</p>
 
 	<div class="cta-row">
 		<a class="cta primary" href="learn/quickstart.html">Quickstart →</a>
@@ -36,7 +36,7 @@
 	<div class="doors">
 		<a class="door" href="learn/">
 			<strong>I want to learn the toolkit.</strong>
-			<span>Build a real content importer across four short chapters. We'll start with one HTML rewrite and finish with a ZIP-packaged WXR export. Every code block runs in the browser; every chapter ends with something you can keep.</span>
+			<span>Build a real content importer across four short chapters. We'll start with one HTML rewrite and finish with a ZIP-packaged WXR export. Most examples run in the browser; network-bound snippets are marked as local-only.</span>
 			<em>~45 minutes →</em>
 		</a>
 
@@ -63,7 +63,7 @@
 <section class="insight">
 	<h2>The shape of it</h2>
 
-	<p>Eighteen components. Each is a small library focused on one job, distributable as its own Composer package, depending only on PHP itself plus other toolkit components — no Composer packages outside the <code>wp-php-toolkit/*</code> family, no PHP extensions beyond <code>json</code> and <code>mbstring</code>.</p>
+	<p>Eighteen components. Each is a small library focused on one job, distributable as its own Composer package, depending mainly on PHP itself plus other toolkit components. Some optional workflows need platform extensions: compression needs <code>zlib</code>, the SQLite filesystem needs <code>sqlite3</code>, and CORSProxy currently needs <code>curl</code>.</p>
 </section>
 
 <section class="all-components" id="components">
@@ -71,7 +71,7 @@
 
 	<h3>Content and migration</h3>
 	<ul class="ref-grid">
-		<li><a href="reference/html.html"><strong>HTML</strong><span>Browser-grade HTML5 parser and tag rewriter. Cursor model, byte-for-byte edits.</span></a></li>
+		<li><a href="reference/html.html"><strong>HTML</strong><span>WordPress core HTML parser and tag rewriter. Cursor model, byte-for-byte edits.</span></a></li>
 		<li><a href="reference/blockparser.html"><strong>BlockParser</strong><span>Parse WordPress block markup into a structured tree.</span></a></li>
 		<li><a href="reference/markdown.html"><strong>Markdown</strong><span>Bidirectional Markdown ↔ block markup with frontmatter as metadata.</span></a></li>
 		<li><a href="reference/xml.html"><strong>XML</strong><span>Streaming, namespace-aware XML processor. Edit WXR exports without a tree.</span></a></li>
@@ -84,7 +84,7 @@
 		<li><a href="reference/bytestream.html"><strong>ByteStream</strong><span>Pull / peek / consume primitives. Gzip, hash, limit, window filters compose.</span></a></li>
 		<li><a href="reference/filesystem.html"><strong>Filesystem</strong><span>One interface across disk, memory, SQLite, and ZIP-backed storage.</span></a></li>
 		<li><a href="reference/zip.html"><strong>Zip</strong><span>Read and write ZIP archives one entry at a time. EPUB, .docx, plugin bundles.</span></a></li>
-		<li><a href="reference/git.html"><strong>Git</strong><span>Pure-PHP Git: commits, branches, merges, HTTP push/pull, no shelling out.</span></a></li>
+		<li><a href="reference/git.html"><strong>Git</strong><span>Pure-PHP Git primitives: commits, branches, trees, and a subset of HTTP push/pull.</span></a></li>
 		<li><a href="reference/merge.html"><strong>Merge</strong><span>Three-way diff and merge with explicit conflict records.</span></a></li>
 	</ul>
 
@@ -108,10 +108,10 @@
 	<h2>The toolkit in one line each</h2>
 	<table class="proof-table">
 	<tr><td><code>preg_replace</code> for HTML</td><td>→</td><td>HTML's <code>WP_HTML_Tag_Processor</code> rewrites attributes byte-for-byte without re-serializing. Untouched markup stays byte-identical.</td></tr>
-	<tr><td><code>ZipArchive::open()</code></td><td>→</td><td>Zip's <code>ZipFilesystem</code> opens a 2 GB archive using memory proportional to the central directory's size, not the archive's.</td></tr>
+	<tr><td><code>ZipArchive::open()</code></td><td>→</td><td>Zip's <code>ZipFilesystem</code> reads archive entries without <code>ZipArchive</code>; practical limits still apply to central-directory size and ZIP64 support.</td></tr>
 	<tr><td><code>file_get_contents</code> on a URL</td><td>→</td><td>HttpClient streams the response body, supports <code>Range</code> resume, reports progress, and uses curl when available or PHP stream sockets when it isn't.</td></tr>
-	<tr><td><code>DOMDocument::loadHTML</code></td><td>→</td><td>HTML's <code>WP_HTML_Processor</code> parses HTML5 the way browsers do — fragments, implicit tags, the works.</td></tr>
-	<tr><td><code>simplexml_load_string</code></td><td>→</td><td>XML's <code>XMLProcessor</code> walks WXR exports as a cursor and rewrites attributes byte-for-byte, never building a full tree.</td></tr>
+	<tr><td><code>DOMDocument::loadHTML</code></td><td>→</td><td>HTML's <code>WP_HTML_Processor</code> follows WordPress core's browser-aligned parser for supported markup and bails on unsupported cases.</td></tr>
+	<tr><td><code>simplexml_load_string</code></td><td>→</td><td>XML's <code>XMLProcessor</code> walks WXR exports as a cursor and rewrites attributes byte-for-byte without building a DOM tree.</td></tr>
 	</table>
 </section>
 
@@ -124,10 +124,10 @@
 		<li><strong>HTML</strong> is a port of WordPress core's <code>WP_HTML_Tag_Processor</code> and <code>WP_HTML_Processor</code>. The toolkit version tracks core; bug fixes and improvements flow in both directions. Source: <a href="https://github.com/WordPress/wordpress-develop/tree/trunk/src/wp-includes/html-api">WordPress/wordpress-develop</a>.</li>
 		<li><strong>BlockParser</strong> is WordPress core's block parser (<code>WP_Block_Parser</code>) packaged as a standalone library so importers and linters can read <a href="https://developer.wordpress.org/block-editor/reference-guides/block-api/">block markup</a> without booting WordPress. Source: <a href="https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/class-wp-block-parser.php">WordPress/wordpress-develop</a>.</li>
 		<li><strong>Markdown</strong> wraps <a href="https://commonmark.thephpleague.com/"><code>league/commonmark</code></a> for the Markdown parsing itself and <a href="https://github.com/webuni/front-matter"><code>webuni/front-matter</code></a> for the YAML frontmatter handling. The toolkit's own work is the bridge from CommonMark's AST into WordPress block markup, plus the reverse direction.</li>
-		<li><strong>Polyfill</strong>'s WordPress-shaped helpers (<code>esc_html</code>, <code>add_filter</code>, <code>__</code>) defer to WordPress when WordPress is loaded. The standalone implementations match WordPress's behavior so the same code runs both inside and outside the platform.</li>
+		<li><strong>Polyfill</strong>'s WordPress-shaped helpers (<code>esc_html</code>, <code>add_filter</code>, <code>__</code>) defer to WordPress when WordPress is loaded. The standalone implementations are minimal compatibility stubs so toolkit code can run outside the platform.</li>
 	</ul>
 
-	<p>The remaining components — Zip, ByteStream, Filesystem, XML, Encoding, DataLiberation, Git, Merge, HttpClient, HttpServer, CORSProxy, CLI, Blueprints, ToolkitCodingStandards — are toolkit originals, written for this project to fill gaps the PHP ecosystem leaves to extensions.</p>
+	<p>The remaining components — Zip, ByteStream, Filesystem, XML, Encoding, DataLiberation, Git, Merge, HttpClient, HttpServer, CORSProxy, CLI, Blueprints, ToolkitCodingStandards — expose toolkit-authored APIs. Some include vendored or patched third-party code where that keeps the package self-contained.</p>
 </section>
 
 <section class="how-runnable">

--- a/docs/learn/01-rewriting-html.html
+++ b/docs/learn/01-rewriting-html.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Chapter 1 — Rewriting HTML safely · PHP Toolkit</title>
-<meta name="description" content="Rewrite real-world HTML — lazy-load images, fix relative URLs, strip script tags — using WP_HTML_Tag_Processor's cursor model. Chapter 1 of a tutorial that builds a content importer.">
+<meta name="description" content="Rewrite real-world HTML — lazy-load images, fix relative URLs, neutralize scripts and inline event handlers — using WP_HTML_Tag_Processor's cursor model. Chapter 1 of a tutorial that builds a content importer.">
 <link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
 <script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
 <script id="toolkit-setup" type="application/json"></script>
@@ -43,7 +43,7 @@
 <p class="breadcrumb">Chapter 1 of 4</p>
 <h1>Rewriting HTML safely</h1>
 
-<p class="lede">In the quickstart you added a single attribute to a single tag. In this chapter we'll do the work the importer actually needs to do on real-world post content: add lazy loading to every image, rewrite relative links to absolute URLs, and strip the script tags and inline event handlers that creep into pasted HTML. By the end you'll have a <code>clean_post_html()</code> function the next chapter will plug into the importer.</p>
+<p class="lede">In the quickstart you added a single attribute to a single tag. In this chapter we'll do the work the importer actually needs to do on real-world post content: add lazy loading to every image, rewrite relative links to absolute URLs, and neutralize script tags and inline event handlers that creep into pasted HTML. By the end you'll have a <code>clean_post_html()</code> function the next chapter will plug into the importer.</p>
 
 <aside class="callout you-will-learn">
 	<strong>You will learn to:</strong>
@@ -86,7 +86,7 @@ HTML;
 <ol>
 	<li>The <code>&lt;img&gt;</code> has no <code>loading</code> hint, so it'll fetch eagerly even when it's far below the fold.</li>
 	<li>Two of the four <code>&lt;a&gt;</code> tags use relative URLs. They were correct on the source site; on the destination site they'll point to nothing.</li>
-	<li>There's a <code>&lt;script&gt;</code> tag and an <code>onmouseover</code> handler. They have to go.</li>
+	<li>There's a <code>&lt;script&gt;</code> tag and an <code>onmouseover</code> handler. They have to be neutralized.</li>
 </ol>
 
 <p>Each of the next three sections fixes one of these. They all use the same component — <code>WP_HTML_Tag_Processor</code> — and the same shape: open a processor over the HTML, walk it, ask the cursor to make edits, then call <code>get_updated_html()</code> for the result.</p>
@@ -186,7 +186,7 @@ echo $tags->get_updated_html();
 	<strong>Note.</strong> Real-world URL resolution has corners (relative paths with <code>..</code>, query-string-only URLs like <code>?page=2</code>, base elements). The toolkit ships a focused URL handling utility under DataLiberation that does the full job. We'll meet it in chapter 3. For now the simple classifier is good enough for the inputs the importer actually sees.
 </aside>
 
-<h2 id="strip-scripts">Strip script tags and inline event handlers</h2>
+<h2 id="strip-scripts">Neutralize scripts and inline event handlers</h2>
 
 <p>This is the security-shaped fix. A user pasted some HTML, and an <code>onmouseover</code> handler came along with it. Maybe a <code>&lt;script&gt;</code> tag too. The importer needs to neutralize both before the content lands in a database that will later be rendered into someone else's browser.</p>
 

--- a/docs/learn/02-streaming-archives.html
+++ b/docs/learn/02-streaming-archives.html
@@ -165,7 +165,7 @@ printf( "parsed %d CSV rows in 8 KB chunks; peak memory ~%d KB\n",
 </script>
 </php-snippet>
 
-<p>That pull-loop is the same shape every byte stream in the toolkit uses. <code>pull(8192)</code> means "buffer up to 8 KB"; <code>consume($n)</code> reads and advances. The trailing partial line gets carried into the next iteration. Memory used is the chunk size plus one partial line — the same regardless of whether the file is 50 KB or 5 GB.</p>
+<p>That pull-loop is the same shape every byte stream in the toolkit uses. <code>pull(8192)</code> means "buffer up to 8 KB"; <code>consume($n)</code> reads and advances. The trailing partial line gets carried into the next iteration. Memory used is the chunk size plus one partial line, so it stays bounded as long as individual lines are bounded.</p>
 
 <aside class="callout note">
 	<strong>Note.</strong> The reference page for ByteStream covers the same loop pattern in more detail, plus the filters that wrap streams: gzip, hash, limit, window. See <a href="../reference/bytestream.html">reference/bytestream.html</a>.
@@ -264,7 +264,7 @@ foreach ( $inputs as $name ) {
 </script>
 </php-snippet>
 
-<p>Run any entry path through <code>ZipDecoder::sanitize_path()</code> before using it as a key in your destination filesystem. <code>copy_between_filesystems()</code> already does this; if you build your own loop you must too.</p>
+<p><code>ZipDecoder</code> sanitizes ZIP entry names before <code>ZipFilesystem</code> exposes them, so the standard copy path sees normalized archive paths. If you parse ZIP records yourself or accept path strings from another source, run those names through <code>ZipDecoder::sanitize_path()</code> before using them as destination keys.</p>
 
 <h2 id="combine">Folding it into the importer</h2>
 
@@ -327,7 +327,7 @@ function each_post( Filesystem $stage ) {
 	<li>Stream a large entry with <code>open_read_stream()</code>, the <code>pull()</code> / <code>consume()</code> loop, and a trailing-partial-line carry.</li>
 	<li>Stage data in <code>InMemoryFilesystem</code> for in-process work, and swap to a different backend without changing the calling code.</li>
 	<li>Compose source and destination filesystems with <code>copy_between_filesystems()</code> in one helper call.</li>
-	<li>Defend against zip-slip with <code>ZipDecoder::sanitize_path()</code>.</li>
+	<li>Understand where ZIP entry names are normalized, and when to call <code>ZipDecoder::sanitize_path()</code> yourself.</li>
 </ul>
 
 <p>The stage is now ready to feed chapter 3, where the Markdown-to-blocks conversion actually happens.</p>
@@ -337,7 +337,7 @@ function each_post( Filesystem $stage ) {
 	<a class="next" href="03-importing-content.html">Next: Markdown to WXR →</a>
 </nav>
 
-<p class="next-preview">In chapter 3 we'll turn each Markdown post into WordPress block markup, run it through <code>clean_post_html()</code>, and stream the whole thing into a WXR file the WordPress importer plugin will accept. Three more components — Markdown, BlockParser, and DataLiberation — finally meet the importer.</p>
+<p class="next-preview">In chapter 3 we'll turn each Markdown post into WordPress block markup, run it through <code>clean_post_html()</code>, and stream the whole thing into a WXR-style export. Three more components — Markdown, BlockParser, and DataLiberation — finally meet the importer.</p>
 
 </article>
 </div>

--- a/docs/learn/03-importing-content.html
+++ b/docs/learn/03-importing-content.html
@@ -43,14 +43,14 @@
 <p class="breadcrumb">Chapter 3 of 4</p>
 <h1>Markdown to blocks to WXR</h1>
 
-<p class="lede">Chapter 1 cleaned a single HTML string. Chapter 2 staged a folder of Markdown files in memory. This chapter turns each of those files into the actual format the WordPress importer plugin reads: WXR, an extended-RSS export. Along the way we meet three more components — Markdown, BlockParser, and DataLiberation — and watch them compose into something none of them could do alone.</p>
+<p class="lede">Chapter 1 cleaned a single HTML string. Chapter 2 staged a folder of Markdown files in memory. This chapter turns each of those files into a WXR-style extended-RSS export stream. Along the way we meet three more components — Markdown, BlockParser, and DataLiberation — and watch them compose into something none of them could do alone.</p>
 
 <aside class="callout you-will-learn">
 	<strong>You will learn to:</strong>
 	<ul>
 		<li>Convert a Markdown document into WordPress block markup with <code>MarkdownConsumer</code>, including frontmatter as post metadata.</li>
 		<li>Inspect the produced blocks with <code>WP_Block_Parser</code> to count, audit, or rewrite them.</li>
-		<li>Stream a WXR export with <code>WXRWriter</code>, one entity at a time, with constant memory.</li>
+		<li>Stream a WXR export with <code>WXRWriter</code>, one entity at a time, without keeping the whole export in memory.</li>
 		<li>Combine those components into a single end-to-end pipeline: Markdown in, WXR out.</li>
 	</ul>
 </aside>
@@ -214,7 +214,7 @@ echo $cleaned;
 
 <h2 id="wxr">Stream a WXR file with DataLiberation</h2>
 
-<p>We have post titles, post content (clean block markup), post metadata. The format the WordPress importer reads is WXR — WordPress eXtended RSS — an XML dialect with a fixed shape. <code>DataLiberation</code>'s <code>WXRWriter</code> takes <code>ImportEntity</code> objects and streams them into a byte sink, one entity at a time, without ever holding the whole export in memory:</p>
+<p>We have post titles, post content (clean block markup), post metadata. WXR — WordPress eXtended RSS — is an XML dialect with a fixed shape. <code>DataLiberation</code>'s <code>WXRWriter</code> takes <code>ImportEntity</code> objects and streams them into a byte sink, one entity at a time. If you need direct compatibility with the WordPress importer plugin, include its required channel metadata such as <code>wp:wxr_version</code> around this stream.</p>
 
 <php-snippet blueprint="toolkit-setup" wp="none" name="wxr-stream.php">
 <script type="application/x-php">
@@ -256,7 +256,7 @@ echo "first 600 chars:\n" . substr( $wxr, 0, 600 ) . "...\n";
 </script>
 </php-snippet>
 
-<p>The writer holds only what it needs to close currently-open XML tags — fewer than ten kilobytes of state for any reasonable pipeline. Every <code>append_entity()</code> writes one item to the underlying byte sink and forgets it. You can build a WXR from twenty thousand posts on a host with sixty-four megabytes of RAM and the importer code looks no different from the two-post version above.</p>
+<p>The writer holds only what it needs to close currently-open XML tags and emit the current entity. Every <code>append_entity()</code> writes one item to the underlying byte sink and forgets it, so large exports should write to a file-backed stream instead of accumulating the final XML in memory.</p>
 
 <aside class="callout note">
 	<strong>Note.</strong> The byte sink here is <code>MemoryPipe</code> for the example. In the real importer you'd pass <code>FileWriteStream::from_path( 'export.xml', 'truncate' )</code> and the WXR would stream straight to disk without ever existing as a single in-memory string.
@@ -415,7 +415,7 @@ echo strpos( $out, 'staging.example.com' ) === false ? "old URL gone\n" : "old U
 </script>
 </php-snippet>
 
-<p>The same pattern handles every "transform an export between sites" job — staging-to-production URL rewrites, theme migrations, slug normalization. Reader on the left, writer on the right, your transformation in the middle. Feed the reader bytes incrementally (instead of <code>append_bytes( $source )</code> all at once) and pipe the writer to a file sink (instead of <code>MemoryPipe</code>), and the same code processes a 10 GB export with the memory footprint of one entity at a time.</p>
+<p>The same pattern handles every "transform an export between sites" job — staging-to-production URL rewrites, theme migrations, slug normalization. Reader on the left, writer on the right, your transformation in the middle. Feed the reader bytes incrementally (instead of <code>append_bytes( $source )</code> all at once) and pipe the writer to a file sink (instead of <code>MemoryPipe</code>), and the same code can process large exports with memory dominated by the current entity and the buffers you choose.</p>
 
 <aside class="callout note">
 	<strong>Note — asymmetric field names.</strong> <code>WXREntityReader</code> emits the post body under <code>post_content</code> (matching WordPress's database column); <code>WXRWriter</code> reads it under <code>content</code> (matching its own internal mapping). Pipelines that read on one side and write on the other have to copy the value across, as the example does.
@@ -429,7 +429,7 @@ echo strpos( $out, 'staging.example.com' ) === false ? "old URL gone\n" : "old U
 	<li>Convert Markdown plus YAML frontmatter into block markup with <code>MarkdownConsumer</code>.</li>
 	<li>Walk the produced block tree with <code>WP_Block_Parser</code> to count, audit, or rewrite blocks.</li>
 	<li>Apply HTML rewrites to block markup without breaking the surrounding block comments.</li>
-	<li>Stream a WXR document with <code>WXRWriter</code> in constant memory regardless of input size.</li>
+	<li>Stream a WXR document with <code>WXRWriter</code> while holding only the current entity and writer state.</li>
 	<li>Read an existing WXR with <code>WXREntityReader</code> and pipe its entities through a transformation into a new WXR.</li>
 </ul>
 

--- a/docs/learn/04-talking-to-the-network.html
+++ b/docs/learn/04-talking-to-the-network.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Chapter 4 — Talking to the network · PHP Toolkit</title>
-<meta name="description" content="Frontload images, run a sliding window of concurrent downloads, and stream-unzip a remote archive — all without curl. Chapter 4 of the importer tutorial.">
+<meta name="description" content="Frontload images, run a sliding window of concurrent downloads, and stream-unzip a remote archive — all without a mandatory curl dependency. Chapter 4 of the importer tutorial.">
 <link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
 <script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
 <script id="toolkit-setup" type="application/json"></script>
@@ -43,7 +43,7 @@
 <p class="breadcrumb">Chapter 4 of 4</p>
 <h1>Talking to the network</h1>
 
-<p class="lede">By the end of chapter 3 the importer produces a valid WXR from a folder of Markdown. There's one loose thread: when a post references <code>![](https://cdn.example.com/bread.jpg)</code>, the destination site has no <code>bread.jpg</code> in its media library. The WordPress importer plugin will try to fetch each remote image as it runs, but that's a fragile thing to do during an import — slow, easy to rate-limit, easy to leave behind half-fetched media. The robust answer is to fetch the images <em>before</em> the import and stage them locally so the import can reference local paths. This chapter covers the fetch side of that work using HttpClient. We'll also see how the same client mounts a remote ZIP for streaming, which means in some workflows you don't need chapter 2's local archive at all.</p>
+<p class="lede">By the end of chapter 3 the importer produces a WXR-style export stream from a folder of Markdown. There's one loose thread: when a post references <code>![](https://cdn.example.com/bread.jpg)</code>, the destination site has no <code>bread.jpg</code> in its media library. The WordPress importer plugin downloads files for attachment entities, but it does not scan arbitrary post content and import every remote image URL for you. The robust answer is to fetch the images <em>before</em> the import and stage them locally so the import can reference local paths. This chapter covers the fetch side of that work using HttpClient. We'll also see how the same client mounts a remote ZIP for streaming, which means in some workflows you don't need chapter 2's local archive at all.</p>
 
 <aside class="callout you-will-learn">
 	<strong>You will learn to:</strong>
@@ -60,7 +60,7 @@
 
 <p>The instinct is <code>file_get_contents( $url )</code> or <code>curl_exec()</code>. Both work — until they don't. <code>file_get_contents</code> on a URL needs <code>allow_url_fopen</code>, which security-conscious hosts disable. <code>curl_exec</code> needs the curl extension, which WebAssembly builds of PHP don't ship. And the simplest forms of both — no <code>CURLOPT_FILE</code>, no chunked stream wrapper — buffer the whole response into one PHP string, which is fatal for a 50 MB media file on a host with a 64 MB memory limit.</p>
 
-<p>HttpClient gives you the same shape regardless of host capabilities: an event loop, response objects with status codes and headers, response bodies as <code>ByteReadStream</code>s you can pipe somewhere instead of buffering. Under the hood it picks curl when available and PHP stream sockets otherwise. From your code's perspective those two transports are identical.</p>
+<p>HttpClient gives you the same request/response shape regardless of host capabilities: an event loop, response objects with status codes and headers, response bodies as <code>ByteReadStream</code>s you can pipe somewhere instead of buffering. Under the hood it picks curl when available and PHP stream sockets otherwise. The public API stays the same, though low-level transport errors and edge-case protocol behavior can still differ.</p>
 
 <h2 id="fetch-one">Fetch one URL</h2>
 
@@ -341,7 +341,7 @@ $reader->close_reading();
 	<li>Stream the whole thing into a WXR document with <code>WXRWriter</code>, with the cleaned post markup as <code>content</code> and rewritten image references pointing at the local paths under the staged uploads tree.</li>
 </ol>
 
-<p>The full importer is roughly a hundred lines of PHP. It depends on no extension beyond <code>json</code> and <code>mbstring</code>. It runs in browser-side WebAssembly, on PHP 7.2 through 8.3, and on every shared host that's kept up with PHP releases. That's the toolkit's whole pitch — pure-PHP libraries that handle the work the platform usually outsources to extensions.</p>
+<p>The full importer is roughly a hundred lines of PHP. It avoids <code>libxml2</code>, <code>libzip</code>, and a mandatory <code>curl</code> dependency. It runs in browser-side WebAssembly and on PHP 7.2+ when the features you choose have their optional platform extensions available. That's the toolkit's whole pitch — PHP libraries that handle much of the work the platform usually outsources to extensions.</p>
 
 <h2 id="recap">Recap</h2>
 

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Learn — PHP Toolkit</title>
-<meta name="description" content="A four-chapter tutorial that builds a real WordPress content importer using HTML, ZIP, Markdown, and DataLiberation. Every code block runs in the browser.">
+<meta name="description" content="A four-chapter tutorial that builds a WordPress content importer using HTML, ZIP, Markdown, and DataLiberation. Most snippets run in the browser.">
 <link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
 </head>
 <body>
@@ -21,12 +21,12 @@
 
 <h1>Learn the toolkit by building a content importer</h1>
 
-<p class="lede">Across four chapters and roughly forty-five minutes, you'll build a small WordPress content importer in pure PHP. It reads a folder of Markdown posts, rewrites the HTML inside them, packages everything as a ZIP-backed staging filesystem, and finally emits a WXR file ready to feed to WordPress's importer. Every snippet runs in your browser. You finish with code you can keep.</p>
+<p class="lede">Across four chapters and roughly forty-five minutes, you'll build a small WordPress content importer in PHP. It reads a folder of Markdown posts, rewrites the HTML inside them, packages everything as a ZIP-backed staging filesystem, and finally emits a WXR-style export stream. Most snippets run in your browser; network-bound examples are marked local-only. You finish with code you can keep.</p>
 
 <section class="prereqs">
 	<h2>Before you start</h2>
 	<p>You should be comfortable reading and writing PHP. You don't need to know WordPress internals — we'll explain the WordPress-specific bits as they come up. You don't need anything installed locally; the runnable snippets execute via WordPress Playground in the page.</p>
-	<p>If you want to run the same code on your own machine afterwards, every example works under PHP 7.2 or newer with <code>composer require wp-php-toolkit/&lt;component&gt;</code>.</p>
+	<p>If you want to run the same code on your own machine afterwards, the examples target PHP 7.2 or newer with <code>composer require wp-php-toolkit/&lt;component&gt;</code>, plus any optional extension used by the chosen component.</p>
 </section>
 
 <section class="path">
@@ -42,7 +42,7 @@
 		<li>
 			<a href="01-rewriting-html.html">
 				<strong>Chapter 1 — Rewriting HTML safely</strong>
-				<span>Add <code>loading="lazy"</code> to images, rewrite relative links, strip script tags. Meet the cursor model that underlies every later chapter.</span>
+				<span>Add <code>loading="lazy"</code> to images, rewrite relative links, and neutralize scripts and inline handlers. Meet the cursor model that underlies every later chapter.</span>
 			</a>
 		</li>
 		<li>
@@ -60,7 +60,7 @@
 		<li>
 			<a href="04-talking-to-the-network.html">
 				<strong>Chapter 4 — Talking to the network</strong>
-				<span>Frontload the images referenced from the imported posts using HttpClient with progress, redirects, and resumable downloads.</span>
+				<span>Frontload images before import using HttpClient with progress, redirects, and resumable downloads.</span>
 			</a>
 		</li>
 		<li>
@@ -81,9 +81,9 @@
 parsed 12 posts, 8 images
 rewrote 47 inline links
 fetched 8 image attachments (2.3 MB)
-wrote export.xml (94 KB, valid WXR 1.2)</code></pre>
+wrote export.xml (94 KB)</code></pre>
 
-	<p>It's a real tool — the WordPress importer plugin will accept the output. You'll write it in pieces, one component per chapter, and the canonical example file grows with each chapter. By chapter 4 it's a hundred lines of pure PHP that depends on no extension beyond <code>json</code> and <code>mbstring</code>.</p>
+	<p>It's a real tool, but the tutorial keeps the export writer deliberately small: if you're targeting the WordPress importer plugin directly, add the importer-required channel metadata such as <code>wp:wxr_version</code>. You'll write it in pieces, one component per chapter, and the canonical example file grows with each chapter. By chapter 4 it's a hundred lines of PHP using toolkit components that avoid <code>libxml2</code>, <code>libzip</code>, and mandatory <code>curl</code>.</p>
 
 	<p>The actual content — twelve Markdown posts about cooking, with embedded images and frontmatter — is part of the tutorial's example data and ships pre-loaded into every snippet. You'll see it in chapter 1.</p>
 </section>

--- a/docs/learn/recap.html
+++ b/docs/learn/recap.html
@@ -21,13 +21,13 @@
 
 <h1>Recap and where to go next</h1>
 
-<p class="lede">Across four chapters you built a working content importer. It reads a ZIP of Markdown posts, cleans the HTML inside each one, frontloads referenced images over HTTP, and streams a WXR file the WordPress importer plugin will accept. None of it required curl, libzip, libxml2, or DOMDocument; all of it runs on PHP 7.2 through 8.3 and inside a browser via WordPress Playground.</p>
+<p class="lede">Across four chapters you built a working content importer. It reads a ZIP of Markdown posts, cleans the HTML inside each one, frontloads referenced images over HTTP, and streams a WXR-style export. Direct WordPress importer compatibility requires the importer-required channel metadata around that stream. The path avoids <code>libzip</code>, <code>libxml2</code>, and a mandatory <code>curl</code> dependency, and runs on PHP 7.2+ when the optional features you choose are available.</p>
 
 <section class="what-you-built">
 	<h2>What you built</h2>
 
 	<table class="proof-table">
-	<tr><td>Chapter 1</td><td>→</td><td><code>clean_post_html()</code> using <code>WP_HTML_Tag_Processor</code>: lazy-load images, rewrite URLs, strip scripts, all in one pass.</td></tr>
+	<tr><td>Chapter 1</td><td>→</td><td><code>clean_post_html()</code> using <code>WP_HTML_Tag_Processor</code>: lazy-load images, rewrite URLs, neutralize scripts, all in one pass.</td></tr>
 	<tr><td>Chapter 2</td><td>→</td><td>Read the input ZIP through <code>ZipFilesystem</code>, stage it in <code>InMemoryFilesystem</code>, defend against zip-slip with <code>ZipDecoder::sanitize_path()</code>.</td></tr>
 	<tr><td>Chapter 3</td><td>→</td><td>Convert each post with <code>MarkdownConsumer</code>, audit the output with <code>WP_Block_Parser</code>, stream the WXR with <code>WXRWriter</code>.</td></tr>
 	<tr><td>Chapter 4</td><td>→</td><td>Frontload images with <code>HttpClient</code> through a sliding-window event loop; mount remote archives with <code>SeekableRequestReadStream</code>.</td></tr>
@@ -40,7 +40,7 @@
 	<p>The importer used eight components. The toolkit ships eighteen. Here's what's left, with the use case each one shows up in:</p>
 
 	<ul class="component-summary">
-		<li><strong>Git</strong> — snapshot your importer's runs into a pure-PHP Git repository for revision history. Useful for "what changed between last week's import and this week's." <a href="../reference/git.html">Reference →</a></li>
+		<li><strong>Git</strong> — snapshot your importer's runs into a PHP-backed Git repository for revision history. Useful for "what changed between last week's import and this week's." <a href="../reference/git.html">Reference →</a></li>
 		<li><strong>Merge</strong> — three-way diff and merge for content sync. If posts edit on both the source and the destination side, this is how you reconcile them. <a href="../reference/merge.html">Reference →</a></li>
 		<li><strong>HttpServer</strong> — a tiny local listening port for OAuth callbacks during a CLI workflow, fixture servers for HttpClient tests, or a status page during a long import. Not for production traffic. <a href="../reference/httpserver.html">Reference →</a></li>
 		<li><strong>CORSProxy</strong> — when you ship the importer as a browser tool, a server-side proxy to fetch URLs that don't send the right CORS headers. <a href="../reference/corsproxy.html">Reference →</a></li>
@@ -62,7 +62,7 @@
 	<p><code>WP_HTML_Tag_Processor</code> walks a string forward, records edits as a side-buffer of byte-range replacements, and emits the modified string only when you call <code>get_updated_html()</code>. The result is byte-honest — bytes you didn't edit come through bit-identical. When you need to make small changes to large markup, that property is gold. The XML component's <code>XMLProcessor</code> applies the same pattern to XML.</p>
 
 	<h3>Pull / consume streams</h3>
-	<p><code>ZipFilesystem::open_read_stream()</code>, <code>HttpClient</code> response bodies, <code>InflateReadStream</code>, and the rest all share the same shape: <code>pull(N)</code> reads up to <code>N</code> bytes from the underlying source into an internal buffer and returns how many ended up there; <code>consume(N)</code> reads <code>N</code> bytes from that buffer and advances past them. Memory used is bounded by the chunk size, never by the file size. Once you internalize this loop you can compose any byte source with any byte sink.</p>
+	<p><code>ZipFilesystem::open_read_stream()</code>, <code>HttpClient</code> response bodies, <code>InflateReadStream</code>, and the rest all share the same shape: <code>pull(N)</code> reads up to <code>N</code> bytes from the underlying source into an internal buffer and returns how many ended up there; <code>consume(N)</code> reads <code>N</code> bytes from that buffer and advances past them. Memory is governed by the stream buffers and chunk sizes you choose, not by a requirement to load the whole file. Once you internalize this loop you can compose any byte source with any byte sink.</p>
 
 	<h3>One interface, multiple backends</h3>
 	<p>Code that takes a <code>Filesystem</code> rather than a path doesn't care if the filesystem is on disk, in memory, in a SQLite database, or inside a ZIP. That's how the importer's stage works for both production (memory) and debugging (local disk) without a code change. Same pattern shows up in HttpClient (curl vs sockets transport) and ByteStream (file, memory, deflate, hash all implementing the same byte-stream interface).</p>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -21,17 +21,17 @@
 
 <h1>Reference</h1>
 
-<p class="lede">One concept guide per component. Each page assumes you know what HTML is, what a ZIP file is, what a stream is — and explains how this particular component models that thing in pure PHP. If a concept appears for the first time in <a href="../learn/">the tutorial</a>, the reference page links back.</p>
+<p class="lede">One concept guide per component. Each page assumes you know what HTML is, what a ZIP file is, what a stream is — and explains how this particular component models that thing in PHP. If a concept appears for the first time in <a href="../learn/">the tutorial</a>, the reference page links back.</p>
 
 <section class="ref-group">
 	<h2>Content and migration</h2>
 	<ul class="ref-grid">
-		<li><a href="html.html"><strong>HTML</strong><span>Browser-grade HTML5 parser and tag rewriter. Cursor model, byte-for-byte edits, breadcrumb queries.</span></a></li>
+		<li><a href="html.html"><strong>HTML</strong><span>WordPress core HTML parser and tag rewriter. Cursor model, byte-for-byte edits, breadcrumb queries.</span></a></li>
 		<li><a href="blockparser.html"><strong>BlockParser</strong><span>Parse WordPress block markup into the array shape WordPress core returns. No <code>block.json</code>, no rendering.</span></a></li>
 		<li><a href="markdown.html"><strong>Markdown</strong><span>Convert between Markdown and WordPress block markup, with frontmatter for metadata.</span></a></li>
 		<li><a href="xml.html"><strong>XML</strong><span>A cursor-based XML processor that reads, edits, and emits export-sized files without building a tree.</span></a></li>
 		<li><a href="encoding.html"><strong>Encoding</strong><span>Validate, classify, and repair UTF-8 bytes before they reach a strict parser.</span></a></li>
-		<li><a href="dataliberation.html"><strong>DataLiberation</strong><span>Stream WordPress-shaped entities between sites. URL rewriting, attachment frontloading, resumable migration.</span></a></li>
+		<li><a href="dataliberation.html"><strong>DataLiberation</strong><span>Stream WordPress-shaped entities between sites. URL rewriting, attachment frontloading, cursor-aware imports.</span></a></li>
 	</ul>
 </section>
 
@@ -39,8 +39,8 @@
 	<h2>Streams and storage</h2>
 	<ul class="ref-grid">
 		<li><a href="bytestream.html"><strong>ByteStream</strong><span>Pull / peek / consume read streams and chunked write streams. Composable filters: gzip, hash, limit, window.</span></a></li>
-		<li><a href="filesystem.html"><strong>Filesystem</strong><span>One filesystem interface, multiple backends: local disk, memory, SQLite, ZIP-backed.</span></a></li>
-		<li><a href="zip.html"><strong>Zip</strong><span>Read and write ZIP archives one entry at a time, in pure PHP. EPUB, .docx, plugin bundles.</span></a></li>
+		<li><a href="filesystem.html"><strong>Filesystem</strong><span>One filesystem interface, multiple backends: local disk, memory, SQLite, ZIP-backed reads.</span></a></li>
+		<li><a href="zip.html"><strong>Zip</strong><span>Read and write ZIP archives one entry at a time without ZipArchive. EPUB, .docx, plugin bundles.</span></a></li>
 		<li><a href="git.html"><strong>Git</strong><span>Read and write Git objects, refs, and trees in memory. Mount a commit as a filesystem.</span></a></li>
 		<li><a href="merge.html"><strong>Merge</strong><span>Three-way diffs and merges with explicit conflict records.</span></a></li>
 	</ul>


### PR DESCRIPTION
## What it does

Fixes documentation claims that were stronger than the current implementation:

- clarifies PHP/version and optional extension requirements such as `zlib`, `sqlite3`, and `curl`
- corrects WXR/importer language so examples are described as WXR-style unless importer-required metadata is present
- narrows component claims around HTML parsing scope, ZIP central-directory limits, CORSProxy rate limiting, Polyfill behavior, Git protocol coverage, and HttpClient redirects
- updates the Blueprints examples to use the v2 schema shape

## Rationale

The docs were presenting some examples as more universal or production-ready than the code supports. That creates bad expectations for users copying snippets into real migrations, browser runtimes, or hosts with missing extensions.

## Implementation

Adjusted the checked-in site pages plus the component README sources that feed generated reference docs. The accidental `report.md` artifact is no longer part of the branch.

## Testing instructions

```bash
composer install --no-interaction --no-progress
php bin/run-snippets.php --check --filter blueprints
php -l bin/build-reference.php
git diff --check
```
