### PR TITLE
Use native API classes from PHP wrappers

### DIFF
--- a/.github/workflows/native-apis.yml
+++ b/.github/workflows/native-apis.yml
@@ -1,0 +1,52 @@
+name: Native APIs
+
+on:
+  push:
+    branches:
+      - trunk
+  pull_request:
+    paths:
+      - '.github/workflows/native-apis.yml'
+      - 'components/DataLiberation/URL/**'
+      - 'components/HTML/**'
+      - 'components/XML/**'
+      - 'extensions/native-apis/**'
+
+jobs:
+  build-and-verify:
+    name: Build and verify PHP extension
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, json
+          coverage: none
+          tools: composer:v2
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
+          php-config --version
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run Rust tests
+        working-directory: extensions/native-apis
+        run: cargo test
+
+      - name: Build native extension
+        run: extensions/native-apis/build-extension.sh
+
+      - name: Verify native extension
+        run: php -d extension=extensions/native-apis/target/release/libwp_native_apis.so extensions/native-apis/tests/verify-native-apis.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,190 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Placeholder section for upcoming changes. Entries are appended automatically by the release workflow.
-
-
+- Added a native `WordPress\DataLiberation\URL\NativeURLInTextProcessor` candidate scanner for URL-in-text detection.
+- Split public HTML, XML, and URL-in-text classes into small loaders plus PHP/native implementation sidecars so native defaults are isolated from pure PHP implementations.
+- Added public `URLInTextProcessor` support for native ASCII candidate scanning while preserving WHATWG validation.
+- Added a `--component=url` URL-in-text benchmark row for public and direct native scanner measurements.
+- Added native-default conformance coverage keeping `WP_HTML_Processor::create_full_parser()` on PHP fallback until native full-document semantics match public parser behavior.
+- Fixed native HTML pending attribute insertion serialization so multiple newly-added attributes, replaced pending attributes, and removed pending attributes match PHP fallback output.
+- Kept `DataLiberationHTMLProcessor` on PHP-backed HTML parsing because it depends on parser bookmarks and byte offsets that native delegates intentionally hide.
+- Fixed Markdown table production after cell extraction so row iteration does not skip remaining cells.
+- Documented native default controls for HTML and XML wrappers.
+- Added a `--disable-native-defaults` benchmark flag for forcing PHP fallback rows after the native extension is loaded.
+- Fixed native HTML class mutation composition when a fully removed class attribute is followed by adding a different class.
+- Fixed public native-backed XML bookmark seeks so later mutations replay PHP fallback state to the bookmarked token.
+- Fixed public native-backed XML bookmark spans so bookmarks beyond a mutation handoff remain seekable after native delegates fall back to PHP state.
+- Fixed public native-backed XML read-only scans so token iteration exposes the final `#complete` token like PHP fallback.
+- Increased public native-backed XML compact token batches to reduce native boundary crossings in large read-only token scans.
+- Optimized public native-backed XML compact token parsing by lazily decoding tag flags, depth, and cached attributes only when accessors need them.
+- Optimized public native-backed XML hot token rows by avoiding redundant lazy metadata resets during compact batch scans.
+- Optimized public native-backed XML hot token rows by avoiding unused flag and depth offset resets during compact batch scans.
+- Optimized native XML hot compact summary row construction for public native-backed token scans.
+- Optimized direct native XML token scans by lazily decoding text payloads only when text accessors need them.
+- Optimized direct native XML token scans by lazily materializing breadcrumbs only when breadcrumb accessors need them.
+- Optimized public native-backed XML token scans with a lightweight native cursor for safe complete-document reads.
+- Optimized public native-backed XML lightweight cursor row parsing by reusing queued compact batches locally.
+- Optimized public native-backed XML lightweight cursor accessors by using token metadata as the active-state sentinel.
+- Optimized public native-backed XML lightweight cursor batches by using cursor-specific native rows and inlined active-token checks.
+- Fixed direct native XML attribute reads so `get_attribute()` accepts the public namespace/local-name argument shape while preserving direct one-argument lookups.
+- Added direct native XML support for simple unprefixed current-tag attribute insertion, replacement, removal, and updated serialization.
+- Added direct native XML support for current-tag attribute insertion, replacement, and removal through in-scope namespace prefixes.
+- Added direct native XML support for current text, comment, and CDATA mutation with updated serialization.
+- Optimized public native-backed XML hot token row parsing by splitting the common tag-token path before non-tag token kind mapping.
+- Optimized public native-backed XML hot token row parsing by deriving non-tag token names from cached token types.
+- Optimized public native-backed XML hot token rows by lazily parsing non-tag compact-row fields and eagerly caching hot `id` attributes for tag rows.
+- Fixed public native-backed HTML class checks on closing tags so `has_class()` returns false like PHP fallback.
+- Enabled public native-backed HTML fragments for covered table tree-builder cases while keeping full-document parsing on PHP fallback.
+- Optimized native HTML tag-only scans by skipping discarded text and comment token construction in low-level tag processor paths.
+- Optimized low-level native HTML tag-only scans by skipping breadcrumb tracking when tree-builder state is not exposed.
+- Optimized public native-backed XML token batch parsing by avoiding per-token compact-row string copies.
+- Fixed native XML streaming reentrancy cursors so sliced resumes preserve child/sibling context while rejecting the pre-cursor parent closer like PHP fallback.
+- Added an HTML heading inventory summary API with a native Rust-backed fused path for heading-level outline audits.
+- Added an HTML ID inventory summary API with a native Rust-backed fused path for unique and duplicate ID audits.
+- Added an HTML attribute inventory summary API with a native Rust-backed fused path for attribute-name and decoded-value audits.
+- Added an HTML data-attribute inventory summary API with a native Rust-backed fused path for `data-*` usage audits.
+- Added an HTML ARIA attribute inventory summary API with a native Rust-backed fused path for `aria-*` accessibility audits.
+- Added an HTML class inventory summary API with a native Rust-backed fused path for class-attribute and unique-class audits.
+- Added an HTML resource inventory summary API with a native Rust-backed fused path for common link and media attribute audits.
+- Added an HTML image inventory summary API with a native Rust-backed fused path for image source, alt-text, and dimension audits.
+- Added an HTML script inventory summary API with a native Rust-backed fused path for script source, module, async/defer, and inline byte audits.
+- Added an XML ID inventory summary API with a native Rust-backed fused path for unique and duplicate ID audits.
+- Added an HTML form inventory summary API with a native Rust-backed fused path for form/control name audits.
+- Fixed public native-backed XML tag-token modifiable text after `next_tag()` so it matches PHP fallback semantics before mutating or serializing.
+- Fixed public native-backed HTML tag processor bookmarks to delegate bookmark lifecycle operations to the native processor.
+- Fixed public native-backed HTML processor bookmark seeking to delegate to the native processor.
+- Fixed public native-backed XML processor bookmarks to delegate bookmark lifecycle operations to the native processor.
+- Added an HTML tag inventory summary API with a native Rust-backed fused path for tag, closer, attribute, and unique-name audits.
+- Added an HTML prefix count batch API with a native Rust-backed incremental path for chunked tag and prefixed-attribute counting.
+- Optimized public HTML native-wrapper generic tag scans for unrestricted `next_tag()` queries.
+- Reduced public HTML native-wrapper dispatch overhead for unrestricted generic tag and prefixed-attribute cursor scans.
+- Added no-argument native HTML compact tag cursor entrypoints for common unrestricted scan modes.
+- Fixed public HTML native-default `next_tag()` query parsing for non-integer `match_offset` and invalid query types to match PHP fallback behavior.
+- Fixed public HTML native-default `next_tag()` query parsing so `tag_name` filters are honored when `tag_closers` is set to `visit`.
+- Fixed native HTML processing-instruction-looking comment parsing so valid targets expose `get_tag()` and invalid `<?...>` comments match PHP fallback metadata.
+- Fixed native HTML invalid closing tag and abruptly closed comment parsing to match PHP fallback token metadata.
+- Fixed native HTML CDATA-looking comments, whitespace-prefixed invalid closers, and dash-abrupt comments to match PHP fallback token metadata.
+- Fixed native HTML DOCTYPE token names so malformed and non-HTML doctypes expose the same `html` token name as PHP fallback.
+- Fixed native HTML invalid opening tags so non-alpha tag-name starts remain text tokens like PHP fallback.
+- Fixed native HTML invalid opening tag text boundaries, incomplete tag-like endings, and text-token character reference decoding to match PHP fallback.
+- Kept public HTML fragment processors on PHP fallback for tree-builder-sensitive list/table/omitted-tag fragments until native breadcrumbs model implied elements and closers.
+- Fixed native HTML processor breadcrumbs for table bodies/cells, table captions, colgroups, select option/optgroup groups, description lists, ruby text/parentheses, and repeated list item and paragraph starts by synthesizing selected implied tokens like PHP fallback.
+- Fixed native HTML processor EOF breadcrumbs so ordinary unclosed non-void elements synthesize closing tokens like PHP fallback.
+- Fixed native HTML processor paragraph breadcrumbs so block starts synthesize an implied `</p>` while inline starts remain inside the paragraph.
+- Fixed native HTML processor heading breadcrumbs so heading starts close an open heading instead of nesting inside it.
+- Fixed native HTML processor button breadcrumbs so nested button starts and explicit button closers synthesize intervening closing tokens like PHP fallback.
+- Fixed native HTML processor summary breadcrumbs so `</details>` synthesizes pending `</summary>` closers like PHP fallback.
+- Fixed native HTML processor form breadcrumbs so duplicate form starts are ignored like PHP fallback.
+- Fixed native HTML processor nobr breadcrumbs so nested starts and explicit closers synthesize intervening closing tokens like PHP fallback.
+- Fixed native HTML processor select breadcrumbs so input starts close open option/select ancestors like PHP fallback.
+- Fixed native HTML processor select breadcrumbs so hr starts close open option ancestors like PHP fallback.
+- Fixed native HTML processor select breadcrumbs so textarea starts close open option/select ancestors like PHP fallback.
+- Fixed native HTML processor fragment breadcrumbs so explicit html/body starts are ignored like PHP fallback.
+- Fixed native HTML processor table-form breadcrumbs so table child starts and text close pending forms, while explicit `</form>` stops table parsing like PHP fallback.
+- Fixed native HTML processor table breadcrumbs so selected unsupported child starts abort table parsing like PHP fallback, while comments and script-like children after table forms remain outside the form.
+- Fixed native HTML processor table section breadcrumbs so repeated sections and captions after rows or colgroups close intervening table ancestors like PHP fallback.
+- Fixed native HTML processor table breadcrumbs so stray closing tags are ignored instead of clearing open table ancestry.
+- Fixed native HTML processor table breadcrumbs so unsupported stray closing tags abort table parsing like PHP fallback.
+- Fixed native HTML processor text tokens so raw null bytes are omitted, line breaks are normalized, leading raw or character-reference whitespace is subdivided, and unsupported non-whitespace table text stops parsing like PHP fallback.
+- Enabled public native-backed HTML fragments for omitted-paragraph cases while keeping table fragments and full-document parsing on PHP fallback.
+- Enabled public native-backed HTML fragments for list, description-list, select/option/optgroup, and ruby implied-token cases while keeping tables, omitted paragraphs, and full-document parsing on PHP fallback.
+- Fixed native HTML invalid closing tags so underscore and colon starts expose funky-comment metadata like PHP fallback.
+- Fixed native HTML unusual attribute names so punctuation starts such as `.x` and `@x` are preserved like PHP fallback.
+- Fixed native HTML equals-start attribute names so malformed attributes such as `=b` and `a/=c` are preserved like PHP fallback.
+- Fixed native HTML boolean attribute removals so serialization preserves surrounding spacing like PHP fallback.
+- Fixed native HTML comment closing so `--!>` closes comments and unclosed comments do not expose tokens, matching PHP fallback.
+- Fixed public native-backed XML parse exceptions so `get_exception()` reports native syntax errors like PHP fallback.
+- Fixed native XML streaming processors so incomplete input can pause, accept appended bytes, and resume token scanning.
+- Fixed native XML processors so documents without a document element report a syntax error after token scanning.
+- Fixed native XML processors so leading whitespace outside the document element is skipped like PHP fallback.
+- Fixed native XML processors so opening tag `get_modifiable_text()` exposes decoded inner source like PHP fallback.
+- Optimized native HTML prefixed-attribute name scanners to avoid lowercase string allocations when deduplicating matches.
+- Added native HTML tag processor string-cast support for direct native processor instances.
+- Added native HTML self-closing flag accessors for direct native tag and processor instances.
+- Added native HTML namespace accessors for direct native tag and processor instances.
+- Added native HTML qualified-name accessors for direct native tag processor instances.
+- Added native HTML processor qualified-name accessors for direct native processor instances.
+- Added native HTML class-list and class-membership accessors for direct native tag and processor instances.
+- Added native HTML complete-input pause status for direct native tag processor instances.
+- Added native HTML processor complete-input pause status for direct native processor instances.
+- Added native HTML processor prefixed-attribute count access for direct native processor instances.
+- Added native HTML processor prefixed-attribute aggregate summaries for direct native processor instances.
+- Added native HTML processor tag-prefix summary batches for direct native processor instances.
+- Added native HTML processor compact tag-prefix summary batch aliases for direct native processor instances.
+- Added native HTML processor compact tag-prefix count batches for direct native processor instances.
+- Added native HTML processor tag-inventory aggregate summaries for direct native processor instances.
+- Added native HTML processor prefixed-attribute removal support for direct native processor instances.
+- Added native HTML processor document-level prefixed-attribute removal support for direct native processor instances.
+- Added native HTML processor updated HTML serialization for direct native processor instances.
+- Added native HTML processor string-cast serialization for direct native processor instances.
+- Added native HTML processor normalization/serialization through the PHP fragment serializer, text subdivision, modifiable text mutation, DOCTYPE info access, and processor full-parser/stepping support for direct native HTML instances.
+- Added native-default HTML conformance coverage proving public normalization and serialization keep PHP serializer semantics when the native extension is loaded.
+- Added native-default HTML conformance coverage proving inherited public processor aggregate scans complete after native remaining-document summaries.
+- Added native-default HTML conformance coverage proving inherited public processor tag batches complete after final short native batches.
+- Added native-default HTML conformance coverage proving direct compact tag batches complete after final short native batches.
+- Added native-default HTML and XML conformance coverage proving partially advanced document-level prefixed-attribute removals finish public processors.
+- Added native-default HTML conformance coverage proving partially advanced remaining-document aggregate summaries finish public tag and inherited processor wrappers.
+- Fixed public HTML native-default parser state after native token and token-summary advancement so started processors still reject serialization.
+- Fixed public HTML processor native-default token-summary batches so full and final short native batches leave public processors complete, matching PHP fallback exhaustion.
+- Fixed public HTML tag-processor native-default state and text-edit delegation after native token/tag advancement.
+- Fixed public HTML tag summary batch native-default state so current-tag helpers remain available after batch advancement.
+- Fixed public HTML tag-prefix count batch native-default state so current-tag helpers remain available after count-only batch advancement.
+- Fixed public HTML tag-processor native-default batches so final short native tag, tag-prefix, matching-tag, and count batches leave public processors complete, matching PHP fallback exhaustion.
+- Fixed public HTML tag aggregate native-default state so remaining-document summaries leave processors complete.
+- Added native HTML processor public token-summary batch rows for direct native processor instances.
+- Added native HTML processor public tag-summary batch rows for direct native processor instances.
+- Added native HTML processor compact tag-summary batch alias support for direct native processor instances.
+- Added native HTML processor compact matching-tag summary batch alias support for direct native processor instances.
+- Added native HTML processor compact matching-tag attribute summary batch alias support for direct native processor instances.
+- Added native HTML processor compact matching-tag multi-attribute summary batch alias support for direct native processor instances.
+- Added native HTML processor public matching-tag summary batch rows for direct native processor instances.
+- Added native HTML processor public matching-tag attribute summary batch rows for direct native processor instances.
+- Added native HTML processor public matching-tag multi-attribute summary batch rows for direct native processor instances.
+- Added native HTML processor matching-tag attribute aggregate summaries for direct native processor instances.
+- Added native XML streaming factory support for direct native processor instances.
+- Added native XML reentrancy cursor support for direct native processor instances.
+- Fixed public XML native-default content and import inventory summaries so remaining-document native scans leave processors finished.
+- Fixed public XML native-default structural inventory summaries so remaining-document native scans leave processors finished.
+- Fixed public XML native-default metadata and payload inventory summaries so remaining-document native scans leave processors finished.
+- Fixed public XML native-default token, tag, matching-tag, prefixed-attribute, and document-removal aggregate summaries so remaining-document native scans leave processors finished.
+- Fixed public XML native-default token, tag, matching-tag, and count batches so exhausted native scans leave processors finished.
+- Added public XML native-default compact batch conformance coverage for token, tag, count, matching-tag, and matching-tag count exhaustion.
+- Added native HTML public tag-summary batch rows for direct native tag processor instances.
+- Added native HTML public matching-tag summary batch rows for direct native tag processor instances.
+- Added native HTML public matching-tag attribute summary batch rows for direct native tag processor instances.
+- Added native HTML public matching-tag multi-attribute summary batch rows for direct native tag processor instances.
+- Added native HTML compact tag-prefix summary batch alias support for direct native tag processor instances.
+- Added native HTML processor tag-name access for direct native processor instances.
+- Added native HTML processor prefixed-attribute name access for direct native processor instances.
+- Added native HTML processor attribute-removal support for direct native processor instances.
+- Added native HTML processor virtual-token status support for direct native processor instances.
+- Added native HTML processor last-error diagnostics for direct native processor instances.
+- Added native HTML processor unsupported-exception diagnostics for direct native processor instances.
+- Added native HTML processor closer-expectation status for direct native processor instances.
+- Added native HTML processor static void-element checks for direct native processor instances.
+- Added native HTML processor static special-category checks for direct native processor instances.
+- Added native HTML processor breadcrumb matching for direct native processor instances.
+- Added native HTML bookmark lifecycle support for direct native tag and processor instances.
+- Added native XML read-only serialization methods for `get_updated_xml()` and string casts on direct native processor instances.
+- Added native XML `is_finished()` support for direct native processor exhaustion checks.
+- Added native XML `get_exception()` support for direct native processor diagnostics.
+- Added native XML complete-input status methods for direct native processor instances.
+- Added native XML complete-input append rejection for direct native processor instances.
+- Added native XML tag-opener and closer-expectation status methods for direct native processor instances.
+- Added native XML token byte-offset support for direct native processor instances.
+- Added native XML public token-summary batch rows for direct native processor instances.
+- Added native XML public tag-summary batch rows for direct native processor instances.
+- Added native XML public matching-tag summary batch rows for direct native processor instances.
+- Added native XML breadcrumb matching support for direct native processor instances.
+- Added native XML bookmark lifecycle support for direct native processor instances.
+- Added native XML compact tag-count batch aliases for direct native processor instances.
+- Added native XML DOCTYPE name support for direct native processor instances.
+- Added native XML DOCTYPE SYSTEM and PUBLIC literal support for direct native processor instances.
+- Added explicit read-only mutation method results for direct native XML processor instances.
+- Added an XML content inventory summary API with a native Rust-backed source-scan path for combined attribute-value and payload-byte audits.
+- Added an XML import inventory summary API with a native Rust-backed source-scan path for combined structure, attribute, and payload audits.
+- Fixed native-backed public HTML processors so attribute and class mutations are applied by the native delegate before serialization.
+- Fixed native HTML attribute mutation composition so removing a newly-added attribute cancels the pending insertion.
+- Fixed native HTML class mutation composition so read-after-remove and remove-then-add behavior matches PHP fallback semantics.
+- Fixed native HTML boolean attribute reads so parsed and newly-set boolean attributes return `true`.
+- Fixed native XML prefixed namespace declarations with empty values so they reject before exposing a token like the PHP fallback.

--- a/bin/benchmark-native-apis.php
+++ b/bin/benchmark-native-apis.php
@@ -2343,7 +2343,7 @@ function wp_toolkit_native_api_benchmark_url_in_text_processor() {
 function wp_toolkit_native_api_benchmark_native_url_in_text_processor() {
 	$text            = wp_toolkit_native_api_benchmark_url_in_text_document();
 	$native_class    = 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor';
-	$processor       = new $native_class( $text );
+	$processor       = new $native_class( $text, 'https://example.com' );
 	$count           = 0;
 	$total_url_bytes = 0;
 

--- a/bin/benchmark-native-apis.php
+++ b/bin/benchmark-native-apis.php
@@ -1,0 +1,4463 @@
+<?php
+/**
+ * Benchmark representative HTML, XML, and URL-in-text API workloads.
+ *
+ * @package WordPress
+ */
+
+use WordPress\DataLiberation\URL\URLInTextProcessor;
+use WordPress\XML\XMLProcessor;
+
+$options    = wp_toolkit_native_api_benchmark_parse_options( $argv );
+$iterations = $options['iterations'];
+$component  = $options['component'];
+$mode       = $options['mode'];
+$required   = $options['required'];
+$results    = array();
+
+if ( $options['disable_native_defaults'] && ! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) ) {
+	define( 'WP_NATIVE_APIS_DISABLE_DEFAULTS', true );
+}
+
+require_once dirname( __DIR__ ) . '/bootstrap.php';
+
+$GLOBALS['wp_toolkit_native_api_benchmark_name_filter'] = $options['name'];
+
+if ( 'all' === $component || 'html' === $component ) {
+	if ( wp_toolkit_native_api_benchmark_should_run( $mode, 'php' ) ) {
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-processor',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_tags'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-prefix-count',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_tag_prefix_count'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-batch',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_tag_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-matching-tag-batch',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_matching_tag_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-matching-tag-attribute-batch',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_matching_tag_attribute_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-matching-tag-attributes-batch',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_matching_tag_attributes_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-link-audit-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_link_audit_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_tag_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-heading-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_heading_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-id-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_id_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-attribute-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_attribute_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-data-attribute-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_data_attribute_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-aria-attribute-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_aria_attribute_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-class-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_class_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-resource-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_resource_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-image-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_image_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-script-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_script_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-form-inventory-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_form_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-prefix-batch',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_tag_prefix_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-prefix-count-batch',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_tag_prefix_count_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-prefix-summary',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_tag_prefix_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-sanitizer',
+			'php',
+			$iterations,
+			'WP_HTML_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_html_tag_sanitizer'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-processor',
+			'php',
+			$iterations,
+			'WP_HTML_Processor',
+			'wp_toolkit_native_api_benchmark_html_processor'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-token-batch',
+			'php',
+			$iterations,
+			'WP_HTML_Processor',
+			'wp_toolkit_native_api_benchmark_html_token_batch'
+		);
+	}
+
+	if ( wp_toolkit_native_api_benchmark_should_run( $mode, 'native' ) ) {
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-processor',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_tags'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-prefix-count',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_tag_prefix_count'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-batch',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_tag_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-matching-tag-batch',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_matching_tag_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-matching-tag-attribute-batch',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_matching_tag_attribute_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-matching-tag-attributes-batch',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_matching_tag_attributes_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-link-audit-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_link_audit_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_tag_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-heading-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_heading_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-id-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_id_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-attribute-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_attribute_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-data-attribute-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_data_attribute_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-aria-attribute-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_aria_attribute_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-class-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_class_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-resource-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_resource_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-image-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_image_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-script-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_script_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-form-inventory-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_form_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-prefix-batch',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_tag_prefix_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-prefix-count-batch',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_tag_prefix_count_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-prefix-summary',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_tag_prefix_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-tag-sanitizer',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Tag_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_tag_sanitizer'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-processor',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_processor'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'html-token-batch',
+			'native',
+			$iterations,
+			'WP_HTML_Native_Processor',
+			'wp_toolkit_native_api_benchmark_native_html_token_batch'
+		);
+	}
+}
+
+if ( 'all' === $component || 'xml' === $component ) {
+	if ( wp_toolkit_native_api_benchmark_should_run( $mode, 'php' ) ) {
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-processor',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_processor'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-token-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_token_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-document-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_document_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-element-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_element_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-depth-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_depth_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-leaf-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_leaf_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-structural-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_structural_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-attribute-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_attribute_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-id-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_id_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-namespace-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_namespace_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-text-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_text_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-processing-instruction-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_processing_instruction_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-comment-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_comment_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-payload-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_payload_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-content-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_content_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-import-inventory-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_import_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-token-batch',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_token_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-tag-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_tag_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-tag-batch',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_tag_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-matching-tag-batch',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_matching_tag_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-matching-tag-count-batch',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_matching_tag_count_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-matching-tag-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_matching_tag_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-matching-tag-attributes-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_matching_tag_attributes_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-tag-count-batch',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_tag_count_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-prefix-summary',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_prefix_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-prefix-sanitizer',
+			'php',
+			$iterations,
+			XMLProcessor::class,
+			'wp_toolkit_native_api_benchmark_xml_prefix_sanitizer'
+		);
+	}
+
+	if ( wp_toolkit_native_api_benchmark_should_run( $mode, 'native' ) ) {
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-processor',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_processor'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-token-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_token_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-document-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_document_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-element-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_element_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-depth-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_depth_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-leaf-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_leaf_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-structural-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_structural_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-attribute-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_attribute_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-id-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_id_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-namespace-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_namespace_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-text-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_text_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-processing-instruction-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_processing_instruction_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-comment-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_comment_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-payload-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_payload_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-content-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_content_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-import-inventory-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_import_inventory_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-token-batch',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_token_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-tag-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_tag_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-tag-batch',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_tag_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-matching-tag-batch',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_matching_tag_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-matching-tag-count-batch',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_matching_tag_count_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-matching-tag-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_matching_tag_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-matching-tag-attributes-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_matching_tag_attributes_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-tag-count-batch',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_tag_count_batch'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-prefix-summary',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_prefix_summary'
+		);
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'xml-prefix-sanitizer',
+			'native',
+			$iterations,
+			'WordPress\\XML\\NativeXMLProcessor',
+			'wp_toolkit_native_api_benchmark_native_xml_prefix_sanitizer'
+		);
+	}
+}
+
+if ( 'all' === $component || 'url' === $component ) {
+	if ( wp_toolkit_native_api_benchmark_should_run( $mode, 'php' ) ) {
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'url-in-text-processor',
+			'php',
+			$iterations,
+			URLInTextProcessor::class,
+			'wp_toolkit_native_api_benchmark_url_in_text_processor'
+		);
+	}
+
+	if ( wp_toolkit_native_api_benchmark_should_run( $mode, 'native' ) ) {
+		$results[] = wp_toolkit_native_api_benchmark_run(
+			'url-in-text-processor',
+			'native',
+			$iterations,
+			'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor',
+			'wp_toolkit_native_api_benchmark_native_url_in_text_processor'
+		);
+	}
+}
+
+$results = array_values( array_filter( $results ) );
+
+if ( null !== $options['name'] && empty( $results ) ) {
+	fwrite( STDERR, "No benchmark workload matched --name={$options['name']}.\n" );
+	exit( 1 );
+}
+
+echo json_encode( $results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ), "\n";
+
+wp_toolkit_native_api_benchmark_maybe_fail_for_missing_results( $results, $required );
+
+/**
+ * Parse command line options.
+ *
+ * @param array $argv Raw CLI arguments.
+ * @return array
+ */
+function wp_toolkit_native_api_benchmark_parse_options( $argv ) {
+	$options = array(
+		'iterations'              => 25,
+		'component'               => 'all',
+		'mode'                    => 'php',
+		'required'                => false,
+		'name'                    => null,
+		'disable_native_defaults' => false,
+	);
+
+	foreach ( array_slice( $argv, 1 ) as $arg ) {
+		if ( 0 === strpos( $arg, '--iterations=' ) ) {
+			$options['iterations'] = max( 1, (int) substr( $arg, strlen( '--iterations=' ) ) );
+			continue;
+		}
+
+		if ( 0 === strpos( $arg, '--component=' ) ) {
+			$options['component'] = strtolower( substr( $arg, strlen( '--component=' ) ) );
+			continue;
+		}
+
+		if ( 0 === strpos( $arg, '--mode=' ) ) {
+			$options['mode'] = strtolower( substr( $arg, strlen( '--mode=' ) ) );
+			continue;
+		}
+
+		if ( 0 === strpos( $arg, '--name=' ) ) {
+			$options['name'] = substr( $arg, strlen( '--name=' ) );
+			continue;
+		}
+
+		if ( '--help' === $arg || '-h' === $arg ) {
+			fwrite(
+				STDOUT,
+				"Usage: php bin/benchmark-native-apis.php [--iterations=25] [--component=all|html|xml|url] [--mode=php|native|both] [--name=workload] [--disable-native-defaults] [--require-native]\n"
+			);
+			exit( 0 );
+		}
+
+		if ( '--disable-native-defaults' === $arg ) {
+			$options['disable_native_defaults'] = true;
+			continue;
+		}
+
+		if ( '--require-native' === $arg ) {
+			$options['required'] = 'native';
+			continue;
+		}
+	}
+
+	if ( ! in_array( $options['component'], array( 'all', 'html', 'xml', 'url' ), true ) ) {
+		fwrite( STDERR, "Invalid --component value. Expected all, html, xml, or url.\n" );
+		exit( 1 );
+	}
+
+	if ( ! in_array( $options['mode'], array( 'php', 'native', 'both' ), true ) ) {
+		fwrite( STDERR, "Invalid --mode value. Expected php, native, or both.\n" );
+		exit( 1 );
+	}
+
+	return $options;
+}
+
+/**
+ * Fail the benchmark when a required implementation row is unavailable.
+ *
+ * PHP-only development environments intentionally emit unavailable native rows
+ * without failing. Release and post-build benchmarking jobs should pass
+ * --require-native so missing extension classes fail loudly.
+ *
+ * @param array       $results Benchmark result rows.
+ * @param string|bool $required Required implementation mode.
+ */
+function wp_toolkit_native_api_benchmark_maybe_fail_for_missing_results( $results, $required ) {
+	if ( false === $required ) {
+		return;
+	}
+
+	$missing = array();
+	foreach ( $results as $result ) {
+		if ( $required !== $result['implementation'] || ! empty( $result['available'] ) ) {
+			continue;
+		}
+
+		$missing[] = sprintf(
+			'%s (%s): %s',
+			$result['name'],
+			$result['implementation'],
+			isset( $result['message'] ) ? $result['message'] : 'implementation is unavailable'
+		);
+	}
+
+	if ( ! $missing ) {
+		return;
+	}
+
+	fwrite(
+		STDERR,
+		"Required benchmark implementations are unavailable:\n - " . implode( "\n - ", $missing ) . "\n"
+	);
+	exit( 1 );
+}
+
+/**
+ * Checks whether the selected implementation mode should run.
+ *
+ * @param string $selected_mode Selected benchmark mode.
+ * @param string $target_mode   Candidate implementation mode.
+ * @return bool Whether to run the implementation.
+ */
+function wp_toolkit_native_api_benchmark_should_run( $selected_mode, $target_mode ) {
+	return 'both' === $selected_mode || $selected_mode === $target_mode;
+}
+
+/**
+ * Run a benchmark workload.
+ *
+ * @param string   $name       Workload name.
+ * @param string   $mode       Implementation mode.
+ * @param int      $iterations Iteration count.
+ * @param string   $class_name Expected class name.
+ * @param callable $callback   Workload callback.
+ * @return array
+ */
+function wp_toolkit_native_api_benchmark_run( $name, $mode, $iterations, $class_name, $callback ) {
+	if (
+		isset( $GLOBALS['wp_toolkit_native_api_benchmark_name_filter'] ) &&
+		null !== $GLOBALS['wp_toolkit_native_api_benchmark_name_filter'] &&
+		$name !== $GLOBALS['wp_toolkit_native_api_benchmark_name_filter']
+	) {
+		return null;
+	}
+
+	if ( ! class_exists( $class_name ) ) {
+		return array(
+			'name'           => $name,
+			'implementation' => $mode,
+			'class'          => $class_name,
+			'available'      => false,
+			'message'        => "Class {$class_name} is not available.",
+		);
+	}
+
+	gc_collect_cycles();
+	$start_memory = memory_get_usage( true );
+	$start_peak   = memory_get_peak_usage( true );
+	$start_wall   = microtime( true );
+	$start_cpu    = wp_toolkit_native_api_benchmark_cpu_time();
+	$operations   = 0;
+
+	for ( $i = 0; $i < $iterations; $i++ ) {
+		$operations += call_user_func( $callback );
+	}
+
+	$end_cpu = wp_toolkit_native_api_benchmark_cpu_time();
+	$wall    = microtime( true ) - $start_wall;
+	$cpu     = null === $start_cpu || null === $end_cpu ? null : $end_cpu - $start_cpu;
+	$peak    = memory_get_peak_usage( true );
+
+	return array(
+		'name'             => $name,
+		'implementation'   => $mode,
+		'class'            => $class_name,
+		'available'        => true,
+		'iterations'       => $iterations,
+		'operations'       => $operations,
+		'wall_seconds'     => round( $wall, 6 ),
+		'cpu_seconds'      => null === $cpu ? null : round( $cpu, 6 ),
+		'peak_memory'      => $peak,
+		'peak_memory_delta' => max( 0, $peak - $start_peak ),
+		'memory_delta'     => memory_get_usage( true ) - $start_memory,
+	);
+}
+
+/**
+ * Get process CPU time when available.
+ *
+ * @return float|null
+ */
+function wp_toolkit_native_api_benchmark_cpu_time() {
+	if ( ! function_exists( 'getrusage' ) ) {
+		return null;
+	}
+
+	$usage = getrusage();
+	if ( ! isset( $usage['ru_utime.tv_sec'], $usage['ru_utime.tv_usec'], $usage['ru_stime.tv_sec'], $usage['ru_stime.tv_usec'] ) ) {
+		return null;
+	}
+
+	return (float) $usage['ru_utime.tv_sec']
+		+ ( $usage['ru_utime.tv_usec'] / 1000000 )
+		+ (float) $usage['ru_stime.tv_sec']
+		+ ( $usage['ru_stime.tv_usec'] / 1000000 );
+}
+
+/**
+ * Benchmark the lower-level HTML tag processor.
+ *
+ * @return int Number of tags visited.
+ */
+function wp_toolkit_native_api_benchmark_html_tags() {
+	$html       = wp_toolkit_native_api_benchmark_html_document();
+	$processor  = new WP_HTML_Tag_Processor( $html );
+	$tag_count  = 0;
+	$attr_count = 0;
+
+	while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+		++$tag_count;
+		$names = $processor->get_attribute_names_with_prefix( 'data-' );
+		if ( is_array( $names ) ) {
+			$attr_count += count( $names );
+		}
+	}
+
+	return $tag_count + $attr_count;
+}
+
+/**
+ * Benchmark the lower-level HTML tag processor with prefix-count reads.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_tag_prefix_count() {
+	$html       = wp_toolkit_native_api_benchmark_html_document();
+	$processor  = new WP_HTML_Tag_Processor( $html );
+	$tag_count  = 0;
+	$attr_count = 0;
+
+	while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+		++$tag_count;
+		$count = $processor->count_attribute_names_with_prefix( 'data-' );
+		if ( is_int( $count ) ) {
+			$attr_count += $count;
+		}
+	}
+
+	return $tag_count + $attr_count;
+}
+
+/**
+ * Benchmark the lower-level HTML tag processor with chunked tag summaries.
+ *
+ * @return int Number of tags visited.
+ */
+function wp_toolkit_native_api_benchmark_html_tag_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$count     = 0;
+
+	do {
+		$batch = $processor->next_tag_compact_summary_batch( 256, true );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_html_tag_batch( $batch );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	return $count;
+}
+
+/**
+ * Benchmark the lower-level HTML tag processor with chunked tag-name summaries.
+ *
+ * @return int Number of matching tags visited.
+ */
+function wp_toolkit_native_api_benchmark_html_matching_tag_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$count     = 0;
+
+	do {
+		$batch = $processor->next_matching_tag_compact_summary_batch( 'a', 256, true );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_html_tag_batch( $batch );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	return $count;
+}
+
+/**
+ * Benchmark the lower-level HTML tag processor with chunked tag-name and attribute summaries.
+ *
+ * @return int Number of matching tags visited plus attribute bytes consumed.
+ */
+function wp_toolkit_native_api_benchmark_html_matching_tag_attribute_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$count     = 0;
+
+	do {
+		$batch = $processor->next_matching_tag_attribute_compact_summary_batch( 'a', 'href', 256, true );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_html_tag_attribute_batch( $batch );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	return $count;
+}
+
+/**
+ * Benchmark the lower-level HTML tag processor with chunked tag-name and multi-attribute summaries.
+ *
+ * @return int Number of matching tags visited plus attribute bytes consumed.
+ */
+function wp_toolkit_native_api_benchmark_html_matching_tag_attributes_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_link_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$count     = 0;
+
+	do {
+		$batch = $processor->next_matching_tag_attributes_compact_summary_batch( 'a', array( 'href', 'title', 'rel' ), 256, true );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_html_tag_attributes_batch( $batch, 3 );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	return $count;
+}
+
+/**
+ * Benchmark a fused lower-level HTML link-audit summary.
+ *
+ * @return int Number of matching tags plus attributes and attribute bytes consumed.
+ */
+function wp_toolkit_native_api_benchmark_html_link_audit_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_link_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_matching_tag_attributes( 'a', array( 'href', 'title', 'rel' ), true );
+
+	if ( ! is_array( $summary ) || ! isset( $summary['tag_count'], $summary['attribute_count'], $summary['attribute_value_bytes'] ) ) {
+		throw new RuntimeException( 'HTML link audit summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['attribute_count'] + (int) $summary['attribute_value_bytes'];
+}
+
+/**
+ * Benchmark a fused lower-level HTML tag inventory summary.
+ *
+ * @return int Number of tags plus attributes and unique tag names counted.
+ */
+function wp_toolkit_native_api_benchmark_html_tag_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_tag_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['attribute_count'], $summary['unique_tag_name_count'] )
+	) {
+		throw new RuntimeException( 'HTML tag inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['attribute_count'] + (int) $summary['unique_tag_name_count'];
+}
+
+/**
+ * Benchmark a fused lower-level HTML heading inventory summary.
+ *
+ * @return int Number of tags plus headings counted.
+ */
+function wp_toolkit_native_api_benchmark_html_heading_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_heading_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['heading_count'], $summary['h2_count'] )
+	) {
+		throw new RuntimeException( 'HTML heading inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['heading_count'] + (int) $summary['h2_count'];
+}
+
+/**
+ * Benchmark a fused lower-level HTML ID inventory summary.
+ *
+ * @return int Number of tags plus ID counts and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_id_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_id_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_id_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['id_tag_count'], $summary['duplicate_id_count'], $summary['id_value_bytes'] )
+	) {
+		throw new RuntimeException( 'HTML ID inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['id_tag_count'] + (int) $summary['duplicate_id_count'] + (int) $summary['id_value_bytes'];
+}
+
+/**
+ * Benchmark a fused lower-level HTML attribute inventory summary.
+ *
+ * @return int Number of tags plus attributes and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_attribute_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_attribute_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['attribute_count'], $summary['attribute_value_bytes'] )
+	) {
+		throw new RuntimeException( 'HTML attribute inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['attribute_count'] + (int) $summary['attribute_value_bytes'];
+}
+
+/**
+ * Benchmark a fused lower-level HTML data-attribute inventory summary.
+ *
+ * @return int Number of tags plus data attributes and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_data_attribute_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_data_attribute_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['data_attribute_count'], $summary['data_attribute_value_bytes'] )
+	) {
+		throw new RuntimeException( 'HTML data-attribute inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['data_attribute_count'] + (int) $summary['data_attribute_value_bytes'];
+}
+
+/**
+ * Benchmark a fused lower-level HTML ARIA attribute inventory summary.
+ *
+ * @return int Number of tags plus ARIA attributes and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_aria_attribute_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_aria_attribute_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['aria_attribute_count'], $summary['aria_attribute_value_bytes'] )
+	) {
+		throw new RuntimeException( 'HTML ARIA attribute inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['aria_attribute_count'] + (int) $summary['aria_attribute_value_bytes'];
+}
+
+/**
+ * Benchmark a fused lower-level HTML class inventory summary.
+ *
+ * @return int Number of tags plus class names and class value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_class_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_class_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['class_name_count'], $summary['class_value_bytes'] )
+	) {
+		throw new RuntimeException( 'HTML class inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['class_name_count'] + (int) $summary['class_value_bytes'];
+}
+
+/**
+ * Benchmark a fused lower-level HTML resource inventory summary.
+ *
+ * @return int Number of tags plus resource attributes and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_resource_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_resource_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['resource_attribute_count'], $summary['resource_value_bytes'] )
+	) {
+		throw new RuntimeException( 'HTML resource inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['resource_attribute_count'] + (int) $summary['resource_value_bytes'];
+}
+
+/**
+ * Benchmark a fused lower-level HTML image inventory summary.
+ *
+ * @return int Number of tags plus images, attributes, and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_image_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_image_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_image_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['image_count'], $summary['src_value_bytes'], $summary['alt_value_bytes'] )
+	) {
+		throw new RuntimeException( 'HTML image inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['image_count'] + (int) $summary['src_value_bytes'] + (int) $summary['alt_value_bytes'];
+}
+
+/**
+ * Benchmark a fused lower-level HTML script inventory summary.
+ *
+ * @return int Number of tags plus scripts, attributes, and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_script_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_script_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_script_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['script_count'], $summary['inline_script_bytes'], $summary['src_value_bytes'] )
+	) {
+		throw new RuntimeException( 'HTML script inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (
+		(int) $summary['tag_count'] +
+		(int) $summary['script_count'] +
+		(int) $summary['inline_script_bytes'] +
+		(int) $summary['src_value_bytes']
+	);
+}
+
+/**
+ * Benchmark a fused lower-level HTML form inventory summary.
+ *
+ * @return int Number of tags plus controls and name bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_form_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_form_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_form_inventory( true );
+
+	if (
+		! is_array( $summary ) ||
+		! isset( $summary['tag_count'], $summary['control_count'], $summary['control_name_value_bytes'] )
+	) {
+		throw new RuntimeException( 'HTML form inventory summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['control_count'] + (int) $summary['control_name_value_bytes'];
+}
+
+/**
+ * Benchmark the lower-level HTML tag processor with chunked prefix summaries.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_tag_prefix_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$count     = 0;
+
+	do {
+		$batch = $processor->next_tag_prefix_compact_summary_batch( 'data-', 256, true );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_html_tag_prefix_batch( $batch );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	return $count;
+}
+
+/**
+ * Benchmark the lower-level HTML tag processor with chunked prefix-count summaries.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_tag_prefix_count_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$count     = 0;
+
+	do {
+		$summary = $processor->next_tag_prefix_count_compact_batch( 'data-', 256, true );
+		if ( is_string( $summary ) && '' !== $summary ) {
+			$count += wp_toolkit_native_api_benchmark_count_html_tag_prefix_count_batch( $summary );
+		}
+	} while ( is_string( $summary ) && '' !== $summary );
+
+	return $count;
+}
+
+/**
+ * Benchmark a fused lower-level HTML prefix-count summary.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_html_tag_prefix_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->summarize_attribute_names_with_prefix( 'data-', true );
+
+	if ( ! is_array( $summary ) || ! isset( $summary['tag_count'], $summary['attribute_count'] ) ) {
+		throw new RuntimeException( 'HTML tag prefix summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['attribute_count'];
+}
+
+/**
+ * Benchmark the native lower-level HTML tag processor.
+ *
+ * @return int Number of tags visited.
+ */
+function wp_toolkit_native_api_benchmark_native_html_tags() {
+	$html        = wp_toolkit_native_api_benchmark_html_document();
+	$processor   = new WP_HTML_Native_Tag_Processor( $html );
+	$has_strings = method_exists( $processor, 'get_attribute_names_with_prefix_string' );
+	$tag_count   = 0;
+	$attr_count  = 0;
+
+	while ( $processor->next_tag_any( true, 1 ) ) {
+		++$tag_count;
+		if ( $has_strings ) {
+			$names = $processor->get_attribute_names_with_prefix_string( 'data-' );
+			if ( is_string( $names ) && '' !== $names ) {
+				$attr_count += substr_count( $names, "\x1f" ) + 1;
+			}
+		} else {
+			$names = $processor->get_attribute_names_with_prefix( 'data-' );
+			if ( is_array( $names ) ) {
+				$attr_count += count( $names );
+			}
+		}
+	}
+
+	return $tag_count + $attr_count;
+}
+
+/**
+ * Benchmark the native lower-level HTML tag processor with prefix-count reads.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_tag_prefix_count() {
+	$html       = wp_toolkit_native_api_benchmark_html_document();
+	$processor  = new WP_HTML_Native_Tag_Processor( $html );
+	$tag_count  = 0;
+	$attr_count = 0;
+
+	while ( $processor->next_tag_any( true, 1 ) ) {
+		++$tag_count;
+		$count = $processor->count_attribute_names_with_prefix( 'data-' );
+		if ( is_int( $count ) ) {
+			$attr_count += $count;
+		}
+	}
+
+	return $tag_count + $attr_count;
+}
+
+/**
+ * Benchmark the native lower-level HTML tag processor with chunked tag summaries.
+ *
+ * @return int Number of tags visited.
+ */
+function wp_toolkit_native_api_benchmark_native_html_tag_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+	$count     = 0;
+
+	if ( method_exists( $processor, 'next_tag_compact_summary_batch' ) ) {
+		do {
+			$batch = $processor->next_tag_compact_summary_batch( 256, true );
+			if ( is_string( $batch ) && '' !== $batch ) {
+				$count += wp_toolkit_native_api_benchmark_count_html_tag_batch( $batch );
+			}
+		} while ( is_string( $batch ) && '' !== $batch );
+
+		return $count;
+	}
+
+	while ( $processor->next_tag_any( true, 1 ) ) {
+		++$count;
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the native lower-level HTML tag processor with chunked tag-name summaries.
+ *
+ * @return int Number of matching tags visited.
+ */
+function wp_toolkit_native_api_benchmark_native_html_matching_tag_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+	$count     = 0;
+
+	if ( method_exists( $processor, 'next_matching_tag_compact_summary_batch' ) ) {
+		do {
+			$batch = $processor->next_matching_tag_compact_summary_batch( 'a', 256, true );
+			if ( is_string( $batch ) && '' !== $batch ) {
+				$count += wp_toolkit_native_api_benchmark_count_html_tag_batch( $batch );
+			}
+		} while ( is_string( $batch ) && '' !== $batch );
+
+		return $count;
+	}
+
+	while ( $processor->next_tag_any( true, 1 ) ) {
+		if ( 'A' === $processor->get_tag() ) {
+			++$count;
+		}
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the native lower-level HTML tag processor with chunked tag-name and attribute summaries.
+ *
+ * @return int Number of matching tags visited plus attribute bytes consumed.
+ */
+function wp_toolkit_native_api_benchmark_native_html_matching_tag_attribute_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+	$count     = 0;
+
+	if ( method_exists( $processor, 'next_matching_tag_attribute_compact_summary_batch' ) ) {
+		do {
+			$batch = $processor->next_matching_tag_attribute_compact_summary_batch( 'a', 'href', 256, true );
+			if ( is_string( $batch ) && '' !== $batch ) {
+				$count += wp_toolkit_native_api_benchmark_count_html_tag_attribute_batch( $batch );
+			}
+		} while ( is_string( $batch ) && '' !== $batch );
+
+		return $count;
+	}
+
+	while ( $processor->next_tag_any( true, 1 ) ) {
+		if ( 'A' === $processor->get_tag() ) {
+			++$count;
+			$value = $processor->get_attribute( 'href' );
+			if ( is_string( $value ) ) {
+				$count += strlen( $value );
+			}
+		}
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the native lower-level HTML tag processor with chunked tag-name and multi-attribute summaries.
+ *
+ * @return int Number of matching tags visited plus attribute bytes consumed.
+ */
+function wp_toolkit_native_api_benchmark_native_html_matching_tag_attributes_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_link_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+	$count     = 0;
+
+	if ( method_exists( $processor, 'next_matching_tag_attributes_compact_summary_batch' ) ) {
+		do {
+			$batch = $processor->next_matching_tag_attributes_compact_summary_batch( 'a', "href\x1ftitle\x1frel", 256, true );
+			if ( is_string( $batch ) && '' !== $batch ) {
+				$count += wp_toolkit_native_api_benchmark_count_html_tag_attributes_batch( $batch, 3 );
+			}
+		} while ( is_string( $batch ) && '' !== $batch );
+
+		return $count;
+	}
+
+	while ( $processor->next_tag_any( true, 1 ) ) {
+		if ( 'A' === $processor->get_tag() ) {
+			++$count;
+			foreach ( array( 'href', 'title', 'rel' ) as $attribute_name ) {
+				$value = $processor->get_attribute( $attribute_name );
+				if ( is_string( $value ) ) {
+					$count += strlen( $value );
+				}
+			}
+		}
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the native lower-level HTML link-audit summary.
+ *
+ * @return int Number of matching tags plus attributes and attribute bytes consumed.
+ */
+function wp_toolkit_native_api_benchmark_native_html_link_audit_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_link_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( method_exists( $processor, 'summarize_matching_tag_attributes' ) ) {
+		$summary = $processor->summarize_matching_tag_attributes( 'a', "href\x1ftitle\x1frel", true );
+		if ( is_string( $summary ) ) {
+			$parts = explode( "\x1f", $summary, 3 );
+			if ( 3 === count( $parts ) ) {
+				return (int) $parts[0] + (int) $parts[1] + (int) $parts[2];
+			}
+		}
+	}
+
+	return wp_toolkit_native_api_benchmark_native_html_matching_tag_attributes_batch();
+}
+
+/**
+ * Benchmark the native lower-level HTML tag inventory summary.
+ *
+ * @return int Number of tags plus attributes and unique tag names counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_tag_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_tag_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_tag_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML tag inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 5 );
+	if ( 5 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML tag inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[3] + (int) $parts[4];
+}
+
+/**
+ * Benchmark the native lower-level HTML heading inventory summary.
+ *
+ * @return int Number of tags plus headings counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_heading_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_heading_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_heading_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML heading inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 8 );
+	if ( 8 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML heading inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[1] + (int) $parts[3];
+}
+
+/**
+ * Benchmark the native lower-level HTML ID inventory summary.
+ *
+ * @return int Number of tags plus ID counts and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_id_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_id_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_id_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_id_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML ID inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 5 );
+	if ( 5 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML ID inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[1] + (int) $parts[3] + (int) $parts[4];
+}
+
+/**
+ * Benchmark the native lower-level HTML attribute inventory summary.
+ *
+ * @return int Number of tags plus attributes and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_attribute_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_attribute_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_attribute_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML attribute inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 4 );
+	if ( 4 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML attribute inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[1] + (int) $parts[3];
+}
+
+/**
+ * Benchmark the native lower-level HTML data-attribute inventory summary.
+ *
+ * @return int Number of tags plus data attributes and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_data_attribute_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_data_attribute_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_data_attribute_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML data-attribute inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 5 );
+	if ( 5 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML data-attribute inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[2] + (int) $parts[4];
+}
+
+/**
+ * Benchmark the native lower-level HTML ARIA attribute inventory summary.
+ *
+ * @return int Number of tags plus ARIA attributes and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_aria_attribute_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_aria_attribute_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_aria_attribute_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML ARIA attribute inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 5 );
+	if ( 5 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML ARIA attribute inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[2] + (int) $parts[4];
+}
+
+/**
+ * Benchmark the native lower-level HTML class inventory summary.
+ *
+ * @return int Number of tags plus class names and class value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_class_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_class_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_class_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML class inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 5 );
+	if ( 5 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML class inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[2] + (int) $parts[4];
+}
+
+/**
+ * Benchmark the native lower-level HTML resource inventory summary.
+ *
+ * @return int Number of tags plus resource attributes and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_resource_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_resource_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_resource_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML resource inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 5 );
+	if ( 5 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML resource inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[2] + (int) $parts[4];
+}
+
+/**
+ * Benchmark the native lower-level HTML image inventory summary.
+ *
+ * @return int Number of tags plus images, attributes, and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_image_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_image_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_image_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_image_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML image inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 8 );
+	if ( 8 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML image inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[1] + (int) $parts[6] + (int) $parts[7];
+}
+
+/**
+ * Benchmark the native lower-level HTML script inventory summary.
+ *
+ * @return int Number of tags plus scripts, attributes, and value bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_script_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_script_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_script_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_script_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML script inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 8 );
+	if ( 8 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML script inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[1] + (int) $parts[6] + (int) $parts[7];
+}
+
+/**
+ * Benchmark the native lower-level HTML form inventory summary.
+ *
+ * @return int Number of tags plus controls and name bytes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_form_inventory_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_form_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( ! method_exists( $processor, 'summarize_form_inventory' ) ) {
+		return 0;
+	}
+
+	$summary = $processor->summarize_form_inventory( true );
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native HTML form inventory summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 6 );
+	if ( 6 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native HTML form inventory summary benchmark returned an invalid compact row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[2] + (int) $parts[5];
+}
+
+/**
+ * Benchmark the native lower-level HTML tag processor with chunked prefix summaries.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_tag_prefix_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+	$count     = 0;
+
+	if ( method_exists( $processor, 'next_tag_prefix_summary_batch' ) ) {
+		do {
+			$batch = $processor->next_tag_prefix_summary_batch( 'data-', 256, true );
+			if ( is_string( $batch ) && '' !== $batch ) {
+				$count += wp_toolkit_native_api_benchmark_count_html_tag_prefix_batch( $batch );
+			}
+		} while ( is_string( $batch ) && '' !== $batch );
+
+		return $count;
+	}
+
+	return wp_toolkit_native_api_benchmark_native_html_tag_prefix_count();
+}
+
+/**
+ * Benchmark the native lower-level HTML tag processor with chunked prefix-count summaries.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_tag_prefix_count_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+	$count     = 0;
+
+	if ( ! method_exists( $processor, 'next_tag_prefix_count_compact_batch' ) ) {
+		return wp_toolkit_native_api_benchmark_native_html_tag_prefix_batch();
+	}
+
+	do {
+		$summary = $processor->next_tag_prefix_count_compact_batch( 'data-', 256, true );
+		if ( is_string( $summary ) && '' !== $summary ) {
+			$count += wp_toolkit_native_api_benchmark_count_html_tag_prefix_count_batch( $summary );
+		}
+	} while ( is_string( $summary ) && '' !== $summary );
+
+	return $count;
+}
+
+/**
+ * Counts compact HTML tag batch rows without allocating per-row arrays.
+ *
+ * @param string $batch Compact tag summary batch.
+ * @return int Number of tags visited.
+ */
+function wp_toolkit_native_api_benchmark_count_html_tag_batch( $batch ) {
+	$count  = 0;
+	$offset = 0;
+	$length = strlen( $batch );
+
+	while ( $offset < $length ) {
+		$row_end = strpos( $batch, "\x1e", $offset );
+		if ( false === $row_end ) {
+			$row_end = $length;
+		}
+
+		$first = strpos( $batch, "\x1f", $offset );
+		if ( false === $first || $first >= $row_end ) {
+			throw new RuntimeException( 'HTML tag batch benchmark returned an invalid summary row.' );
+		}
+
+		++$count;
+		$offset = $row_end + 1;
+	}
+
+	return $count;
+}
+
+/**
+ * Counts compact HTML tag-attribute batch rows without allocating per-row arrays.
+ *
+ * @param string $batch Compact tag-attribute summary batch.
+ * @return int Number of tags visited plus attribute bytes consumed.
+ */
+function wp_toolkit_native_api_benchmark_count_html_tag_attribute_batch( $batch ) {
+	$count  = 0;
+	$offset = 0;
+	$length = strlen( $batch );
+
+	while ( $offset < $length ) {
+		$row_end = strpos( $batch, "\x1e", $offset );
+		if ( false === $row_end ) {
+			$row_end = $length;
+		}
+
+		$first = strpos( $batch, "\x1f", $offset );
+		if ( false === $first || $first >= $row_end ) {
+			throw new RuntimeException( 'HTML tag attribute batch benchmark returned an invalid summary row.' );
+		}
+
+		$second = strpos( $batch, "\x1f", $first + 1 );
+		if ( false === $second || $second >= $row_end ) {
+			throw new RuntimeException( 'HTML tag attribute batch benchmark returned an invalid summary row.' );
+		}
+
+		++$count;
+		if ( '1' === substr( $batch, $second + 1, 1 ) ) {
+			$count += $row_end - $second - 2;
+		}
+		$offset = $row_end + 1;
+	}
+
+	return $count;
+}
+
+/**
+ * Counts compact HTML tag multi-attribute batch rows without allocating per-row arrays.
+ *
+ * @param string $batch           Compact tag-attribute summary batch.
+ * @param int    $attribute_count Number of attribute fields per row.
+ * @return int Number of tags visited plus attribute bytes consumed.
+ */
+function wp_toolkit_native_api_benchmark_count_html_tag_attributes_batch( $batch, $attribute_count ) {
+	$count  = 0;
+	$offset = 0;
+	$length = strlen( $batch );
+
+	while ( $offset < $length ) {
+		$row_end = strpos( $batch, "\x1e", $offset );
+		if ( false === $row_end ) {
+			$row_end = $length;
+		}
+
+		$field_start = $offset;
+		for ( $field_index = 0; $field_index < 2 + $attribute_count; ++$field_index ) {
+			$field_end = strpos( $batch, "\x1f", $field_start );
+			if ( false === $field_end || $field_end > $row_end ) {
+				$field_end = $row_end;
+			}
+
+			if ( $field_start > $row_end || ( $field_index < 1 + $attribute_count && $field_end >= $row_end ) ) {
+				throw new RuntimeException( 'HTML tag attributes batch benchmark returned an invalid summary row.' );
+			}
+
+			if ( $field_index >= 2 && '1' === substr( $batch, $field_start, 1 ) ) {
+				$count += $field_end - $field_start - 1;
+			}
+
+			$field_start = $field_end + 1;
+		}
+
+		++$count;
+		$offset = $row_end + 1;
+	}
+
+	return $count;
+}
+
+/**
+ * Counts compact HTML tag-prefix batch rows without allocating per-row arrays.
+ *
+ * @param string $batch Compact tag-prefix summary batch.
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_count_html_tag_prefix_batch( $batch ) {
+	$count  = 0;
+	$offset = 0;
+	$length = strlen( $batch );
+
+	while ( $offset < $length ) {
+		$row_end = strpos( $batch, "\x1e", $offset );
+		if ( false === $row_end ) {
+			$row_end = $length;
+		}
+
+		$first = strpos( $batch, "\x1f", $offset );
+		if ( false === $first || $first >= $row_end ) {
+			throw new RuntimeException( 'HTML tag prefix batch benchmark returned an invalid summary row.' );
+		}
+
+		$second = strpos( $batch, "\x1f", $first + 1 );
+		if ( false === $second || $second >= $row_end ) {
+			throw new RuntimeException( 'HTML tag prefix batch benchmark returned an invalid summary row.' );
+		}
+
+		++$count;
+		$count += (int) substr( $batch, $second + 1, $row_end - $second - 1 );
+		$offset = $row_end + 1;
+	}
+
+	return $count;
+}
+
+/**
+ * Counts a compact HTML tag-prefix count batch.
+ *
+ * @param string $summary Compact tag and attribute count summary.
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_count_html_tag_prefix_count_batch( $summary ) {
+	$parts = explode( "\x1f", $summary, 2 );
+	if ( 2 !== count( $parts ) ) {
+		throw new RuntimeException( 'HTML tag prefix count batch benchmark returned an invalid summary row.' );
+	}
+
+	return (int) $parts[0] + (int) $parts[1];
+}
+
+/**
+ * Benchmark the native lower-level HTML prefix-count summary.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_html_tag_prefix_summary() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Native_Tag_Processor( $html );
+
+	if ( method_exists( $processor, 'summarize_attribute_names_with_prefix' ) ) {
+		$summary = $processor->summarize_attribute_names_with_prefix( 'data-', true );
+		if ( is_string( $summary ) ) {
+			$parts = explode( "\x1f", $summary, 2 );
+			if ( 2 === count( $parts ) ) {
+				return (int) $parts[0] + (int) $parts[1];
+			}
+		}
+	}
+
+	return wp_toolkit_native_api_benchmark_native_html_tag_prefix_count();
+}
+
+/**
+ * Benchmark an HTML prefix-scan and remove-attribute sanitization workflow.
+ *
+ * @return int Number of tags visited plus attributes removed.
+ */
+function wp_toolkit_native_api_benchmark_html_tag_sanitizer() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$summary   = $processor->remove_attributes_with_prefix_from_document( 'data-', true );
+
+	if ( ! is_array( $summary ) || ! isset( $summary['tag_count'], $summary['removed_count'], $summary['html'] ) ) {
+		throw new RuntimeException( 'HTML tag sanitizer benchmark returned an invalid summary.' );
+	}
+
+	$updated_html = $summary['html'];
+	if ( false !== strpos( $updated_html, 'data-' ) ) {
+		throw new RuntimeException( 'HTML tag sanitizer benchmark left data-* attributes in the output.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['removed_count'];
+}
+
+/**
+ * Benchmark the native lower-level HTML prefix-scan and remove-attribute path.
+ *
+ * @return int Number of tags visited plus attributes removed.
+ */
+function wp_toolkit_native_api_benchmark_native_html_tag_sanitizer() {
+	$html          = wp_toolkit_native_api_benchmark_html_document();
+	$processor     = new WP_HTML_Native_Tag_Processor( $html );
+	$tag_count     = 0;
+	$removed_count = 0;
+
+	if ( method_exists( $processor, 'remove_attributes_with_prefix_from_document' ) ) {
+		$summary = $processor->remove_attributes_with_prefix_from_document( 'data-', true );
+		if ( is_string( $summary ) ) {
+			$parts = explode( "\x1f", $summary, 3 );
+			if ( 3 === count( $parts ) ) {
+				if ( false !== strpos( $parts[2], 'data-' ) ) {
+					throw new RuntimeException( 'Native HTML tag sanitizer benchmark left data-* attributes in the output.' );
+				}
+
+				return (int) $parts[0] + (int) $parts[1];
+			}
+		}
+	}
+
+	while ( $processor->next_tag_any( true, 1 ) ) {
+		++$tag_count;
+		if ( method_exists( $processor, 'remove_attributes_with_prefix' ) ) {
+			$count = $processor->remove_attributes_with_prefix( 'data-' );
+			if ( is_int( $count ) ) {
+				$removed_count += $count;
+			}
+			continue;
+		}
+
+		$names = $processor->get_attribute_names_with_prefix( 'data-' );
+		if ( ! is_array( $names ) ) {
+			continue;
+		}
+
+		foreach ( $names as $name ) {
+			if ( $processor->remove_attribute( $name ) ) {
+				++$removed_count;
+			}
+		}
+	}
+
+	$updated_html = $processor->get_updated_html();
+	if ( false !== strpos( $updated_html, 'data-' ) ) {
+		throw new RuntimeException( 'Native HTML tag sanitizer benchmark left data-* attributes in the output.' );
+	}
+
+	return $tag_count + $removed_count;
+}
+
+/**
+ * Benchmark the full HTML processor.
+ *
+ * @return int Number of tokens visited.
+ */
+function wp_toolkit_native_api_benchmark_html_processor() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = WP_HTML_Processor::create_fragment( $html );
+	$count     = 0;
+
+	while ( $processor->next_token() ) {
+		++$count;
+		$processor->get_token_type();
+		$processor->get_token_name();
+		$processor->get_breadcrumbs();
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the native full HTML processor.
+ *
+ * @return int Number of tokens visited.
+ */
+function wp_toolkit_native_api_benchmark_native_html_processor() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = WP_HTML_Native_Processor::create_fragment( $html );
+	$count     = 0;
+
+	while ( $processor->next_token() ) {
+		++$count;
+		$processor->get_token_type();
+		$processor->get_token_name();
+		$processor->get_breadcrumbs();
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark public HTML processor token summary batches.
+ *
+ * @return int Number of tokens visited.
+ */
+function wp_toolkit_native_api_benchmark_html_token_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = WP_HTML_Processor::create_fragment( $html );
+	$count     = 0;
+
+	do {
+		$batch = $processor->next_token_compact_summary_batch( 256 );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_html_token_batch( $batch );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	return $count;
+}
+
+/**
+ * Benchmark native HTML processor token summary batches.
+ *
+ * @return int Number of tokens visited.
+ */
+function wp_toolkit_native_api_benchmark_native_html_token_batch() {
+	$html      = wp_toolkit_native_api_benchmark_html_document();
+	$processor = WP_HTML_Native_Processor::create_fragment( $html );
+	$count     = 0;
+
+	do {
+		$batch = $processor->next_token_compact_summary_batch( 256 );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_html_token_batch( $batch );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	return $count;
+}
+
+/**
+ * Counts compact HTML token batch rows without allocating per-row arrays.
+ *
+ * @param string $batch Compact token summary batch.
+ * @return int Number of tokens visited.
+ */
+function wp_toolkit_native_api_benchmark_count_html_token_batch( $batch ) {
+	$count  = 0;
+	$offset = 0;
+	$length = strlen( $batch );
+
+	while ( $offset < $length ) {
+		$row_end = strpos( $batch, "\x1e", $offset );
+		if ( false === $row_end ) {
+			$row_end = $length;
+		}
+
+		$first = strpos( $batch, "\x1f", $offset );
+		if ( false === $first || $first >= $row_end ) {
+			throw new RuntimeException( 'HTML token batch benchmark returned an invalid summary row.' );
+		}
+
+		++$count;
+		$offset = $row_end + 1;
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the public URL-in-text processor.
+ *
+ * @return int Number of URLs visited.
+ */
+function wp_toolkit_native_api_benchmark_url_in_text_processor() {
+	$text      = wp_toolkit_native_api_benchmark_url_in_text_document();
+	$processor = new URLInTextProcessor( $text, 'https://example.com' );
+	$count     = 0;
+
+	while ( $processor->next_url() ) {
+		++$count;
+		$raw_url    = $processor->get_raw_url();
+		$parsed_url = $processor->get_parsed_url();
+		if ( false === $raw_url || false === $parsed_url ) {
+			throw new RuntimeException( 'URLInTextProcessor benchmark exposed an invalid URL row.' );
+		}
+	}
+
+	if ( 360 !== $count ) {
+		throw new RuntimeException( "URLInTextProcessor benchmark expected 360 URLs, found {$count}." );
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the direct native URL-in-text processor.
+ *
+ * @return int Number of URLs visited.
+ */
+function wp_toolkit_native_api_benchmark_native_url_in_text_processor() {
+	$text            = wp_toolkit_native_api_benchmark_url_in_text_document();
+	$native_class    = 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor';
+	$processor       = new $native_class( $text );
+	$count           = 0;
+	$total_url_bytes = 0;
+
+	while ( $processor->next_url() ) {
+		++$count;
+		$raw_url = $processor->get_raw_url();
+		if ( ! is_string( $raw_url ) || '' === $raw_url ) {
+			throw new RuntimeException( 'Native URL-in-text benchmark exposed an invalid URL row.' );
+		}
+		$total_url_bytes += $processor->get_url_length();
+		$processor->get_url_starts_at();
+		$processor->had_protocol();
+	}
+
+	if ( 360 !== $count || 0 === $total_url_bytes ) {
+		throw new RuntimeException( "Native URL-in-text benchmark expected 360 URLs, found {$count}." );
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the XML processor.
+ *
+ * @return int Number of tokens visited.
+ */
+function wp_toolkit_native_api_benchmark_xml_processor() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+	$count     = 0;
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	while ( $processor->next_token() ) {
+		++$count;
+		$processor->get_token_type();
+		$processor->get_token_name();
+		if ( null !== $processor->get_tag_local_name() ) {
+			$processor->get_tag_namespace_and_local_name();
+			$processor->get_attribute( '', 'id' );
+		}
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark a fused public XML token summary.
+ *
+ * @return int Number of tokens visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_xml_token_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_token_stream( 'id' );
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['attribute_count'] ) ) {
+		throw new RuntimeException( 'XML token summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['token_count'] + (int) $summary['attribute_count'];
+}
+
+/**
+ * Benchmark a fused public XML document inventory summary.
+ *
+ * @return int Number of inventoried tokens and structural markers.
+ */
+function wp_toolkit_native_api_benchmark_xml_document_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_inventory_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_document_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['tag_count'], $summary['closing_tag_count'], $summary['max_depth'] ) ) {
+		throw new RuntimeException( 'XML document inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		3 !== (int) $summary['max_depth'] ||
+		0 === (int) $summary['comment_count'] ||
+		0 === (int) $summary['cdata_count']
+	) {
+		throw new RuntimeException( 'XML document inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['tag_count'] +
+		(int) $summary['closing_tag_count'] +
+		(int) $summary['text_token_count'] +
+		(int) $summary['comment_count'] +
+		(int) $summary['cdata_count'] +
+		(int) $summary['empty_element_count']
+	);
+}
+
+/**
+ * Benchmark a fused public XML element inventory summary.
+ *
+ * @return int Number of inventoried element-name markers.
+ */
+function wp_toolkit_native_api_benchmark_xml_element_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_element_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_element_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['tag_count'], $summary['unique_tag_name_count'], $summary['duplicate_tag_name_count'] ) ) {
+		throw new RuntimeException( 'XML element inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		7 !== (int) $summary['unique_tag_name_count'] ||
+		0 === (int) $summary['duplicate_tag_name_count'] ||
+		0 === (int) $summary['namespaced_tag_count'] ||
+		0 === (int) $summary['empty_element_count']
+	) {
+		throw new RuntimeException( 'XML element inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['tag_count'] +
+		(int) $summary['closing_tag_count'] +
+		(int) $summary['unique_tag_name_count'] +
+		(int) $summary['duplicate_tag_name_count'] +
+		(int) $summary['namespaced_tag_count'] +
+		(int) $summary['empty_element_count']
+	);
+}
+
+/**
+ * Benchmark a fused public XML depth inventory summary.
+ *
+ * @return int Number of inventoried tags and depth markers.
+ */
+function wp_toolkit_native_api_benchmark_xml_depth_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_depth_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_depth_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['tag_count'], $summary['total_tag_depth'], $summary['max_depth'] ) ) {
+		throw new RuntimeException( 'XML depth inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		(int) $summary['max_depth'] < 4 ||
+		0 === (int) $summary['empty_element_count'] ||
+		0 === (int) $summary['nested_tag_count'] ||
+		0 === (int) $summary['total_tag_depth']
+	) {
+		throw new RuntimeException( 'XML depth inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['tag_count'] +
+		(int) $summary['closing_tag_count'] +
+		(int) $summary['empty_element_count'] +
+		(int) $summary['root_level_tag_count'] +
+		(int) $summary['nested_tag_count'] +
+		(int) $summary['total_tag_depth']
+	);
+}
+
+/**
+ * Benchmark a fused public XML leaf inventory summary.
+ *
+ * @return int Number of inventoried tags and leaf/branch markers.
+ */
+function wp_toolkit_native_api_benchmark_xml_leaf_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_depth_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_leaf_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['leaf_element_count'], $summary['branch_element_count'] ) ) {
+		throw new RuntimeException( 'XML leaf inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['empty_element_count'] ||
+		0 === (int) $summary['leaf_element_count'] ||
+		0 === (int) $summary['branch_element_count'] ||
+		(int) $summary['max_child_element_count'] < 2
+	) {
+		throw new RuntimeException( 'XML leaf inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['tag_count'] +
+		(int) $summary['closing_tag_count'] +
+		(int) $summary['empty_element_count'] +
+		(int) $summary['leaf_element_count'] +
+		(int) $summary['branch_element_count'] +
+		(int) $summary['max_child_element_count']
+	);
+}
+
+/**
+ * Benchmark a fused public XML structural inventory summary.
+ *
+ * @return int Number of inventoried structural markers.
+ */
+function wp_toolkit_native_api_benchmark_xml_structural_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_depth_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_structural_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['unique_tag_name_count'], $summary['total_tag_depth'], $summary['leaf_element_count'] ) ) {
+		throw new RuntimeException( 'XML structural inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['empty_element_count'] ||
+		0 === (int) $summary['nested_tag_count'] ||
+		0 === (int) $summary['total_tag_depth'] ||
+		0 === (int) $summary['leaf_element_count'] ||
+		0 === (int) $summary['branch_element_count'] ||
+		(int) $summary['max_child_element_count'] < 2
+	) {
+		throw new RuntimeException( 'XML structural inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['tag_count'] +
+		(int) $summary['closing_tag_count'] +
+		(int) $summary['unique_tag_name_count'] +
+		(int) $summary['duplicate_tag_name_count'] +
+		(int) $summary['namespaced_tag_count'] +
+		(int) $summary['empty_element_count'] +
+		(int) $summary['root_level_tag_count'] +
+		(int) $summary['nested_tag_count'] +
+		(int) $summary['total_tag_depth'] +
+		(int) $summary['leaf_element_count'] +
+		(int) $summary['branch_element_count'] +
+		(int) $summary['max_child_element_count']
+	);
+}
+
+/**
+ * Benchmark a fused public XML attribute inventory summary.
+ *
+ * @return int Number of inventoried tokens and attributes.
+ */
+function wp_toolkit_native_api_benchmark_xml_attribute_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_attribute_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_attribute_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['attribute_count'], $summary['max_attribute_count'] ) ) {
+		throw new RuntimeException( 'XML attribute inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['attribute_count'] ||
+		0 === (int) $summary['namespaced_attribute_count'] ||
+		0 === (int) $summary['tags_with_attributes_count'] ||
+		(int) $summary['max_attribute_count'] < 3
+	) {
+		throw new RuntimeException( 'XML attribute inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['attribute_count'] +
+		(int) $summary['namespaced_attribute_count'] +
+		(int) $summary['tags_with_attributes_count'] +
+		(int) $summary['max_attribute_count']
+	);
+}
+
+/**
+ * Benchmark a fused public XML ID inventory summary.
+ *
+ * @return int Number of inventoried tokens and IDs.
+ */
+function wp_toolkit_native_api_benchmark_xml_id_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_id_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_id_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['id_attribute_count'], $summary['duplicate_id_count'] ) ) {
+		throw new RuntimeException( 'XML ID inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['id_attribute_count'] ||
+		0 === (int) $summary['unique_id_count'] ||
+		0 === (int) $summary['duplicate_id_count'] ||
+		0 === (int) $summary['id_value_bytes']
+	) {
+		throw new RuntimeException( 'XML ID inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['id_attribute_count'] +
+		(int) $summary['unique_id_count'] +
+		(int) $summary['duplicate_id_count'] +
+		(int) $summary['id_value_bytes']
+	);
+}
+
+/**
+ * Benchmark a fused public XML namespace inventory summary.
+ *
+ * @return int Number of inventoried namespace-related tokens and attributes.
+ */
+function wp_toolkit_native_api_benchmark_xml_namespace_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_namespace_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_namespace_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['namespaced_tag_count'], $summary['unique_namespace_count'] ) ) {
+		throw new RuntimeException( 'XML namespace inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['namespaced_tag_count'] ||
+		0 === (int) $summary['namespaced_attribute_count'] ||
+		(int) $summary['unique_namespace_count'] < 2
+	) {
+		throw new RuntimeException( 'XML namespace inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['namespaced_tag_count'] +
+		(int) $summary['attribute_count'] +
+		(int) $summary['namespaced_attribute_count'] +
+		(int) $summary['unique_namespace_count']
+	);
+}
+
+/**
+ * Benchmark a fused public XML text inventory summary.
+ *
+ * @return int Number of inventoried text tokens and bytes.
+ */
+function wp_toolkit_native_api_benchmark_xml_text_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_text_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_text_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['text_token_count'], $summary['total_text_bytes'] ) ) {
+		throw new RuntimeException( 'XML text inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['text_token_count'] ||
+		0 === (int) $summary['cdata_count'] ||
+		0 === (int) $summary['non_empty_text_count'] ||
+		0 === (int) $summary['whitespace_text_count'] ||
+		(int) $summary['max_text_bytes'] < 10
+	) {
+		throw new RuntimeException( 'XML text inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['text_token_count'] +
+		(int) $summary['cdata_count'] +
+		(int) $summary['non_empty_text_count'] +
+		(int) $summary['whitespace_text_count'] +
+		(int) $summary['total_text_bytes']
+	);
+}
+
+/**
+ * Benchmark a fused public XML processing instruction inventory summary.
+ *
+ * @return int Number of inventoried processing instruction tokens and bytes.
+ */
+function wp_toolkit_native_api_benchmark_xml_processing_instruction_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_processing_instruction_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_processing_instruction_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['processing_instruction_count'], $summary['total_instruction_bytes'] ) ) {
+		throw new RuntimeException( 'XML processing instruction inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['processing_instruction_count'] ||
+		0 === (int) $summary['xml_declaration_count'] ||
+		0 === (int) $summary['non_empty_instruction_count'] ||
+		(int) $summary['max_instruction_bytes'] < 20
+	) {
+		throw new RuntimeException( 'XML processing instruction inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['processing_instruction_count'] +
+		(int) $summary['xml_declaration_count'] +
+		(int) $summary['non_empty_instruction_count'] +
+		(int) $summary['total_instruction_bytes']
+	);
+}
+
+/**
+ * Benchmark a fused public XML comment inventory summary.
+ *
+ * @return int Number of inventoried comment tokens and bytes.
+ */
+function wp_toolkit_native_api_benchmark_xml_comment_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_comment_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_comment_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['comment_count'], $summary['total_comment_bytes'] ) ) {
+		throw new RuntimeException( 'XML comment inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['comment_count'] ||
+		0 === (int) $summary['non_empty_comment_count'] ||
+		0 === (int) $summary['empty_comment_count'] ||
+		(int) $summary['max_comment_bytes'] < 20
+	) {
+		throw new RuntimeException( 'XML comment inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['comment_count'] +
+		(int) $summary['non_empty_comment_count'] +
+		(int) $summary['empty_comment_count'] +
+		(int) $summary['total_comment_bytes']
+	);
+}
+
+/**
+ * Benchmark a fused public XML payload inventory summary.
+ *
+ * @return int Number of inventoried payload tokens and bytes.
+ */
+function wp_toolkit_native_api_benchmark_xml_payload_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_payload_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_payload_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['text_token_count'], $summary['total_payload_bytes'] ) ) {
+		throw new RuntimeException( 'XML payload inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['text_token_count'] ||
+		0 === (int) $summary['cdata_count'] ||
+		0 === (int) $summary['comment_count'] ||
+		0 === (int) $summary['processing_instruction_count'] ||
+		(int) $summary['max_payload_bytes'] < 20
+	) {
+		throw new RuntimeException( 'XML payload inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['text_token_count'] +
+		(int) $summary['cdata_count'] +
+		(int) $summary['comment_count'] +
+		(int) $summary['processing_instruction_count'] +
+		(int) $summary['total_payload_bytes']
+	);
+}
+
+/**
+ * Benchmark a fused public XML content inventory summary.
+ *
+ * @return int Number of inventoried content tokens, attributes, and bytes.
+ */
+function wp_toolkit_native_api_benchmark_xml_content_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_payload_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_content_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['attribute_count'], $summary['total_payload_bytes'] ) ) {
+		throw new RuntimeException( 'XML content inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['attribute_count'] ||
+		0 === (int) $summary['text_token_count'] ||
+		0 === (int) $summary['cdata_count'] ||
+		0 === (int) $summary['comment_count'] ||
+		0 === (int) $summary['processing_instruction_count'] ||
+		(int) $summary['max_attribute_value_bytes'] < 2 ||
+		(int) $summary['max_payload_bytes'] < 20
+	) {
+		throw new RuntimeException( 'XML content inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['tag_count'] +
+		(int) $summary['attribute_count'] +
+		(int) $summary['text_token_count'] +
+		(int) $summary['cdata_count'] +
+		(int) $summary['comment_count'] +
+		(int) $summary['processing_instruction_count'] +
+		(int) $summary['total_attribute_value_bytes'] +
+		(int) $summary['total_payload_bytes']
+	);
+}
+
+/**
+ * Benchmark a fused public XML import inventory summary.
+ *
+ * @return int Number of inventoried structure, content, and byte counts.
+ */
+function wp_toolkit_native_api_benchmark_xml_import_inventory_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_payload_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_import_inventory();
+	if ( ! is_array( $summary ) || ! isset( $summary['token_count'], $summary['attribute_count'], $summary['total_payload_bytes'] ) ) {
+		throw new RuntimeException( 'XML import inventory benchmark returned an invalid summary.' );
+	}
+
+	if (
+		0 === (int) $summary['tag_count'] ||
+		0 === (int) $summary['leaf_element_count'] ||
+		0 === (int) $summary['attribute_count'] ||
+		0 === (int) $summary['text_token_count'] ||
+		0 === (int) $summary['cdata_count'] ||
+		0 === (int) $summary['comment_count'] ||
+		0 === (int) $summary['processing_instruction_count'] ||
+		(int) $summary['max_payload_bytes'] < 20
+	) {
+		throw new RuntimeException( 'XML import inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $summary['token_count'] +
+		(int) $summary['tag_count'] +
+		(int) $summary['closing_tag_count'] +
+		(int) $summary['unique_tag_name_count'] +
+		(int) $summary['leaf_element_count'] +
+		(int) $summary['branch_element_count'] +
+		(int) $summary['attribute_count'] +
+		(int) $summary['text_token_count'] +
+		(int) $summary['cdata_count'] +
+		(int) $summary['comment_count'] +
+		(int) $summary['processing_instruction_count'] +
+		(int) $summary['total_attribute_value_bytes'] +
+		(int) $summary['total_payload_bytes']
+	);
+}
+
+/**
+ * Benchmark a public XML token summary batch loop.
+ *
+ * @return int Number of tokens visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_xml_token_batch() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+	$count     = 0;
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	do {
+		$batch = $processor->next_token_compact_summary_batch( 256 );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			foreach ( explode( "\x1e", $batch ) as $row ) {
+				$parts = explode( "\x1f", $row, 6 );
+				if ( 6 !== count( $parts ) ) {
+					throw new RuntimeException( 'XML token batch benchmark returned an invalid summary row.' );
+				}
+
+				++$count;
+				if ( isset( $parts[5][0] ) && '1' === $parts[5][0] ) {
+					++$count;
+				}
+			}
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	return $count;
+}
+
+/**
+ * Benchmark a fused public XML tag summary.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_xml_tag_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_tag_stream( 'id' );
+	if ( ! is_array( $summary ) || ! isset( $summary['tag_count'], $summary['attribute_count'] ) ) {
+		throw new RuntimeException( 'XML tag summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['attribute_count'];
+}
+
+/**
+ * Benchmark a public XML tag summary batch loop.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_xml_tag_batch() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+	$count     = 0;
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	do {
+		$batch = $processor->next_tag_compact_summary_batch( 256, 'id' );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_xml_tag_batch( $batch );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	return $count;
+}
+
+/**
+ * Benchmark a public XML matching tag summary batch loop.
+ *
+ * @return int Number of matching tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_xml_matching_tag_batch() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+	$count     = 0;
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	do {
+		$batch = $processor->next_matching_tag_compact_summary_batch( 256, 'https://wordpress.org', 'item', 'id' );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_xml_tag_batch( $batch );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	return $count;
+}
+
+/**
+ * Benchmark a public XML matching tag count batch loop.
+ *
+ * @return int Number of matching tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_xml_matching_tag_count_batch() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+	$count     = 0;
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	do {
+		$summary = $processor->next_matching_tag_count_compact_batch( 256, 'https://wordpress.org', 'item', 'id' );
+		if ( is_string( $summary ) ) {
+			$parts = explode( "\x1f", $summary, 3 );
+			if ( 3 !== count( $parts ) ) {
+				throw new RuntimeException( 'XML matching tag count batch benchmark returned an invalid summary row.' );
+			}
+
+			$count += (int) $parts[1] + (int) $parts[2];
+		}
+	} while ( is_string( $summary ) );
+
+	return $count;
+}
+
+/**
+ * Benchmark a document-level XML matching tag summary.
+ *
+ * @return int Number of matching tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_xml_matching_tag_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_matching_tag_stream( 'https://wordpress.org', 'item', 'id' );
+	if ( ! is_array( $summary ) || ! isset( $summary['tag_count'], $summary['attribute_count'] ) ) {
+		throw new RuntimeException( 'XML matching tag summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['attribute_count'];
+}
+
+/**
+ * Benchmark a document-level XML matching tag multi-attribute summary.
+ *
+ * @return int Number of matching tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_xml_matching_tag_attributes_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_matching_attribute_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_matching_tag_attributes_stream(
+		'https://wordpress.org',
+		'item',
+		array( 'id', 'slug', 'status' )
+	);
+	if ( ! is_array( $summary ) || ! isset( $summary['tag_count'], $summary['attribute_count'] ) ) {
+		throw new RuntimeException( 'XML matching tag attributes summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['attribute_count'];
+}
+
+/**
+ * Benchmark a public XML tag count batch loop.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_xml_tag_count_batch() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+	$count     = 0;
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	do {
+		$summary = $processor->next_tag_count_compact_batch( 256, 'id' );
+		if ( is_string( $summary ) ) {
+			$parts = explode( "\x1f", $summary, 3 );
+			if ( 3 !== count( $parts ) ) {
+				throw new RuntimeException( 'XML tag count batch benchmark returned an invalid summary row.' );
+			}
+
+			$count += (int) $parts[1] + (int) $parts[2];
+		}
+	} while ( is_string( $summary ) );
+
+	return $count;
+}
+
+/**
+ * Benchmark a document-level XML attribute-prefix summary.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_xml_prefix_summary() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_attribute_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->summarize_attribute_names_with_prefix( null, 'data-' );
+	if ( ! is_array( $summary ) || ! isset( $summary['tag_count'], $summary['attribute_count'] ) ) {
+		throw new RuntimeException( 'XML prefix summary benchmark returned an invalid summary.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['attribute_count'];
+}
+
+/**
+ * Benchmark document-level XML prefixed-attribute removal.
+ *
+ * @return int Number of tags visited plus matching attributes removed.
+ */
+function wp_toolkit_native_api_benchmark_xml_prefix_sanitizer() {
+	$xml       = wp_toolkit_native_api_benchmark_xml_attribute_document();
+	$processor = XMLProcessor::create_from_string( $xml );
+
+	if ( false === $processor ) {
+		throw new RuntimeException( 'XMLProcessor could not parse benchmark document.' );
+	}
+
+	$summary = $processor->remove_attributes_with_prefix_from_document( null, 'data-' );
+	if ( ! is_array( $summary ) || ! isset( $summary['tag_count'], $summary['removed_count'], $summary['xml'] ) ) {
+		throw new RuntimeException( 'XML prefix sanitizer benchmark returned an invalid summary.' );
+	}
+
+	if ( false !== strpos( $summary['xml'], ' data-' ) ) {
+		throw new RuntimeException( 'XML prefix sanitizer benchmark left data-* attributes in the output.' );
+	}
+
+	return (int) $summary['tag_count'] + (int) $summary['removed_count'];
+}
+
+/**
+ * Benchmark the native XML processor.
+ *
+ * @return int Number of tokens visited.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_processor() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$count      = 0;
+
+	while ( $processor->next_token() ) {
+		++$count;
+		$processor->get_token_type();
+		$processor->get_token_name();
+		$processor->get_attribute( 'id' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the native fused XML token summary.
+ *
+ * @return int Number of tokens visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_token_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_token_stream( 'id' );
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML token summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 3 );
+	if ( 3 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML token summary benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return (int) $parts[0] + (int) $parts[2];
+}
+
+/**
+ * Benchmark native XML document inventory summary.
+ *
+ * @return int Number of inventoried tokens and structural markers.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_document_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_inventory_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_document_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML document inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 8 );
+	if ( 8 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML document inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 3 !== (int) $parts[6] || 0 === (int) $parts[4] || 0 === (int) $parts[5] ) {
+		throw new RuntimeException( 'Native XML document inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5] +
+		(int) $parts[7]
+	);
+}
+
+/**
+ * Benchmark native XML element inventory summary.
+ *
+ * @return int Number of inventoried element-name markers.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_element_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_element_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_element_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML element inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 7 );
+	if ( 7 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML element inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 7 !== (int) $parts[3] || 0 === (int) $parts[4] || 0 === (int) $parts[5] || 0 === (int) $parts[6] ) {
+		throw new RuntimeException( 'Native XML element inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5] +
+		(int) $parts[6]
+	);
+}
+
+/**
+ * Benchmark native XML depth inventory summary.
+ *
+ * @return int Number of inventoried tags and depth markers.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_depth_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_depth_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_depth_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML depth inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 8 );
+	if ( 8 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML depth inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( (int) $parts[7] < 4 || 0 === (int) $parts[3] || 0 === (int) $parts[5] || 0 === (int) $parts[6] ) {
+		throw new RuntimeException( 'Native XML depth inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5] +
+		(int) $parts[6]
+	);
+}
+
+/**
+ * Benchmark native XML leaf inventory summary.
+ *
+ * @return int Number of inventoried tags and leaf/branch markers.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_leaf_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_depth_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_leaf_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML leaf inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 7 );
+	if ( 7 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML leaf inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[3] || 0 === (int) $parts[4] || 0 === (int) $parts[5] || (int) $parts[6] < 2 ) {
+		throw new RuntimeException( 'Native XML leaf inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5] +
+		(int) $parts[6]
+	);
+}
+
+/**
+ * Benchmark native XML structural inventory summary.
+ *
+ * @return int Number of inventoried structural markers.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_structural_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_depth_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_structural_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML structural inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 14 );
+	if ( 14 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML structural inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[6] || 0 === (int) $parts[8] || 0 === (int) $parts[9] || 0 === (int) $parts[11] || 0 === (int) $parts[12] || (int) $parts[13] < 2 ) {
+		throw new RuntimeException( 'Native XML structural inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5] +
+		(int) $parts[6] +
+		(int) $parts[7] +
+		(int) $parts[8] +
+		(int) $parts[9] +
+		(int) $parts[11] +
+		(int) $parts[12] +
+		(int) $parts[13]
+	);
+}
+
+/**
+ * Benchmark native XML attribute inventory summary.
+ *
+ * @return int Number of inventoried tokens and attributes.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_attribute_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_attribute_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_attribute_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML attribute inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 6 );
+	if ( 6 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML attribute inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[2] || 0 === (int) $parts[3] || 0 === (int) $parts[4] || (int) $parts[5] < 3 ) {
+		throw new RuntimeException( 'Native XML attribute inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5]
+	);
+}
+
+/**
+ * Benchmark native XML ID inventory summary.
+ *
+ * @return int Number of inventoried tokens and IDs.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_id_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_id_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_id_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML ID inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 6 );
+	if ( 6 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML ID inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[2] || 0 === (int) $parts[3] || 0 === (int) $parts[4] || 0 === (int) $parts[5] ) {
+		throw new RuntimeException( 'Native XML ID inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5]
+	);
+}
+
+/**
+ * Benchmark native XML namespace inventory summary.
+ *
+ * @return int Number of inventoried namespace-related tokens and attributes.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_namespace_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_namespace_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_namespace_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML namespace inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 6 );
+	if ( 6 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML namespace inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[2] || 0 === (int) $parts[4] || (int) $parts[5] < 2 ) {
+		throw new RuntimeException( 'Native XML namespace inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5]
+	);
+}
+
+/**
+ * Benchmark native XML text inventory summary.
+ *
+ * @return int Number of inventoried text tokens and bytes.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_text_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_text_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_text_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML text inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 7 );
+	if ( 7 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML text inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[1] || 0 === (int) $parts[2] || 0 === (int) $parts[3] || 0 === (int) $parts[4] || (int) $parts[6] < 10 ) {
+		throw new RuntimeException( 'Native XML text inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5]
+	);
+}
+
+/**
+ * Benchmark native XML processing instruction inventory summary.
+ *
+ * @return int Number of inventoried processing instruction tokens and bytes.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_processing_instruction_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_processing_instruction_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_processing_instruction_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML processing instruction inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 6 );
+	if ( 6 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML processing instruction inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[1] || 0 === (int) $parts[2] || 0 === (int) $parts[3] || (int) $parts[5] < 20 ) {
+		throw new RuntimeException( 'Native XML processing instruction inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4]
+	);
+}
+
+/**
+ * Benchmark native XML comment inventory summary.
+ *
+ * @return int Number of inventoried comment tokens and bytes.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_comment_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_comment_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_comment_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML comment inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 6 );
+	if ( 6 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML comment inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[1] || 0 === (int) $parts[2] || 0 === (int) $parts[3] || (int) $parts[5] < 20 ) {
+		throw new RuntimeException( 'Native XML comment inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4]
+	);
+}
+
+/**
+ * Benchmark native XML payload inventory summary.
+ *
+ * @return int Number of inventoried payload tokens and bytes.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_payload_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_payload_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_payload_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML payload inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 7 );
+	if ( 7 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML payload inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[1] || 0 === (int) $parts[2] || 0 === (int) $parts[3] || 0 === (int) $parts[4] || (int) $parts[6] < 20 ) {
+		throw new RuntimeException( 'Native XML payload inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5]
+	);
+}
+
+/**
+ * Benchmark native XML content inventory summary.
+ *
+ * @return int Number of inventoried content tokens, attributes, and bytes.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_content_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_payload_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_content_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML content inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 11 );
+	if ( 11 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML content inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[2] || 0 === (int) $parts[3] || 0 === (int) $parts[4] || 0 === (int) $parts[5] || 0 === (int) $parts[6] || (int) $parts[8] < 2 || (int) $parts[10] < 20 ) {
+		throw new RuntimeException( 'Native XML content inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[4] +
+		(int) $parts[5] +
+		(int) $parts[6] +
+		(int) $parts[7] +
+		(int) $parts[9]
+	);
+}
+
+/**
+ * Benchmark native XML import inventory summary.
+ *
+ * @return int Number of inventoried structure, content, and byte counts.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_import_inventory_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_payload_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_import_inventory();
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML import inventory benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 23 );
+	if ( 23 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML import inventory benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	if ( 0 === (int) $parts[1] || 0 === (int) $parts[11] || 0 === (int) $parts[14] || 0 === (int) $parts[15] || 0 === (int) $parts[16] || 0 === (int) $parts[17] || 0 === (int) $parts[18] || (int) $parts[22] < 20 ) {
+		throw new RuntimeException( 'Native XML import inventory benchmark returned unexpected counts.' );
+	}
+
+	return (
+		(int) $parts[0] +
+		(int) $parts[1] +
+		(int) $parts[2] +
+		(int) $parts[3] +
+		(int) $parts[11] +
+		(int) $parts[12] +
+		(int) $parts[14] +
+		(int) $parts[15] +
+		(int) $parts[16] +
+		(int) $parts[17] +
+		(int) $parts[18] +
+		(int) $parts[19] +
+		(int) $parts[21]
+	);
+}
+
+/**
+ * Benchmark native XML token summary batches.
+ *
+ * @return int Number of tokens visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_token_batch() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$count      = 0;
+
+	do {
+		$batch = $processor->next_token_compact_summary_batch( 256 );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			foreach ( explode( "\x1e", $batch ) as $row ) {
+				$parts = explode( "\x1f", $row, 6 );
+				if ( 6 !== count( $parts ) ) {
+					throw new RuntimeException( 'Native XML token batch benchmark returned an invalid summary row.' );
+				}
+
+				++$count;
+				if ( isset( $parts[5][0] ) && '1' === $parts[5][0] ) {
+					++$count;
+				}
+			}
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the native fused XML tag summary.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_tag_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_tag_stream( 'id' );
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML tag summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 3 );
+	if ( 3 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML tag summary benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return (int) $parts[1] + (int) $parts[2];
+}
+
+/**
+ * Benchmark native XML tag summary batches.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_tag_batch() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$count      = 0;
+
+	do {
+		$batch = $processor->next_tag_compact_summary_batch( 256, 'id' );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_xml_tag_batch( $batch );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark native XML matching tag summary batches.
+ *
+ * @return int Number of matching tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_matching_tag_batch() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$count      = 0;
+
+	do {
+		$batch = $processor->next_matching_tag_compact_summary_batch( 256, 'https://wordpress.org', 'item', 'id' );
+		if ( is_string( $batch ) && '' !== $batch ) {
+			$count += wp_toolkit_native_api_benchmark_count_xml_tag_batch( $batch );
+		}
+	} while ( is_string( $batch ) && '' !== $batch );
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark native XML matching tag count batches.
+ *
+ * @return int Number of matching tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_matching_tag_count_batch() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$count      = 0;
+
+	do {
+		$summary = $processor->next_matching_tag_count_batch( 256, 'https://wordpress.org', 'item', 'id' );
+		if ( is_string( $summary ) ) {
+			$parts = explode( "\x1f", $summary, 3 );
+			if ( 3 !== count( $parts ) ) {
+				throw new RuntimeException( 'Native XML matching tag count batch benchmark returned an invalid summary row.' );
+			}
+
+			$count += (int) $parts[1] + (int) $parts[2];
+		}
+	} while ( is_string( $summary ) );
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the native document-level XML matching tag summary.
+ *
+ * @return int Number of matching tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_matching_tag_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_matching_tag_stream( 'https://wordpress.org', 'item', 'id' );
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML matching tag summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 3 );
+	if ( 3 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML matching tag summary benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return (int) $parts[1] + (int) $parts[2];
+}
+
+/**
+ * Benchmark the native document-level XML matching tag multi-attribute summary.
+ *
+ * @return int Number of matching tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_matching_tag_attributes_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_matching_attribute_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_matching_tag_attributes_stream( 'https://wordpress.org', 'item', "id\x1fslug\x1fstatus" );
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML matching tag attributes summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 3 );
+	if ( 3 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML matching tag attributes summary benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return (int) $parts[1] + (int) $parts[2];
+}
+
+/**
+ * Benchmark native XML tag count batches.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_tag_count_batch() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$count      = 0;
+
+	do {
+		$summary = $processor->next_tag_count_batch( 256, 'id' );
+		if ( is_string( $summary ) ) {
+			$parts = explode( "\x1f", $summary, 3 );
+			if ( 3 !== count( $parts ) ) {
+				throw new RuntimeException( 'Native XML tag count batch benchmark returned an invalid summary row.' );
+			}
+
+			$count += (int) $parts[1] + (int) $parts[2];
+		}
+	} while ( is_string( $summary ) );
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return $count;
+}
+
+/**
+ * Counts compact XML tag batch rows without allocating per-row arrays.
+ *
+ * @param string $batch Compact tag summary batch.
+ * @return int Number of tags plus matching attributes.
+ */
+function wp_toolkit_native_api_benchmark_count_xml_tag_batch( $batch ) {
+	$count  = 0;
+	$offset = 0;
+	$length = strlen( $batch );
+
+	while ( $offset < $length ) {
+		$row_end = strpos( $batch, "\x1e", $offset );
+		if ( false === $row_end ) {
+			$row_end = $length;
+		}
+
+		$first = strpos( $batch, "\x1f", $offset );
+		if ( false === $first || $first >= $row_end ) {
+			throw new RuntimeException( 'XML tag batch benchmark returned an invalid summary row.' );
+		}
+
+		$second = strpos( $batch, "\x1f", $first + 1 );
+		if ( false === $second || $second >= $row_end ) {
+			throw new RuntimeException( 'XML tag batch benchmark returned an invalid summary row.' );
+		}
+
+		$third = strpos( $batch, "\x1f", $second + 1 );
+		if ( false === $third || $third >= $row_end ) {
+			throw new RuntimeException( 'XML tag batch benchmark returned an invalid summary row.' );
+		}
+
+		$fourth = strpos( $batch, "\x1f", $third + 1 );
+		if ( false === $fourth || $fourth >= $row_end ) {
+			throw new RuntimeException( 'XML tag batch benchmark returned an invalid summary row.' );
+		}
+
+		$fifth = strpos( $batch, "\x1f", $fourth + 1 );
+		if ( false === $fifth || $fifth >= $row_end ) {
+			throw new RuntimeException( 'XML tag batch benchmark returned an invalid summary row.' );
+		}
+
+		++$count;
+		if ( isset( $batch[ $fifth + 1 ] ) && '1' === $batch[ $fifth + 1 ] ) {
+			++$count;
+		}
+
+		$offset = $row_end + 1;
+	}
+
+	return $count;
+}
+
+/**
+ * Benchmark the native document-level XML attribute-prefix summary.
+ *
+ * @return int Number of tags visited plus matching attributes counted.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_prefix_summary() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_attribute_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->summarize_attribute_names_with_prefix( null, 'data-' );
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML prefix summary benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 3 );
+	if ( 3 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML prefix summary benchmark returned an invalid summary row.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return (int) $parts[1] + (int) $parts[2];
+}
+
+/**
+ * Benchmark native document-level XML prefixed-attribute removal.
+ *
+ * @return int Number of tags visited plus matching attributes removed.
+ */
+function wp_toolkit_native_api_benchmark_native_xml_prefix_sanitizer() {
+	$xml        = wp_toolkit_native_api_benchmark_xml_attribute_document();
+	$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+	$processor  = $class_name::create_from_string( $xml );
+	$summary    = $processor->remove_attributes_with_prefix_from_document( null, 'data-' );
+
+	if ( ! is_string( $summary ) ) {
+		throw new RuntimeException( 'Native XML prefix sanitizer benchmark returned an invalid summary.' );
+	}
+
+	$parts = explode( "\x1f", $summary, 3 );
+	if ( 3 !== count( $parts ) ) {
+		throw new RuntimeException( 'Native XML prefix sanitizer benchmark returned an invalid summary row.' );
+	}
+
+	if ( false !== strpos( $parts[2], ' data-' ) ) {
+		throw new RuntimeException( 'Native XML prefix sanitizer benchmark left data-* attributes in the output.' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		throw new RuntimeException( 'NativeXMLProcessor reported benchmark parse error: ' . $processor->get_last_error() );
+	}
+
+	return (int) $parts[0] + (int) $parts[1];
+}
+
+/**
+ * Build a representative HTML document.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_html_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<article data-id="%1$d" data-kind="post"><h2>Title %1$d</h2><p class="lede">Body <a href="/p/%1$d">link</a></p><img src="/%1$d.png" alt=""></article>',
+			$i
+		);
+	}
+
+	return '<main><section>' . implode( '', $items ) . '</section></main>';
+}
+
+/**
+ * Build a representative HTML document with ID attributes and duplicates.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_html_id_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<article id="post-%1$d"><h2 id="title-%1$d">Title %1$d</h2><p id="post-%1$d">Body <a id="link-%1$d" href="/p/%1$d">link</a></p><span id></span></article>',
+			$i
+		);
+	}
+
+	return '<main id="content"><section>' . implode( '', $items ) . '</section></main>';
+}
+
+/**
+ * Build a representative HTML document with link attributes for multi-attribute scans.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_html_link_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<article data-id="%1$d"><p><a href="/p/%1$d" title="Post %1$d &amp; archive" rel="bookmark">Post %1$d</a></p><p><a href="/feed/%1$d" rel="alternate">Feed %1$d</a></p></article>',
+			$i
+		);
+	}
+
+	return '<main><section>' . implode( '', $items ) . '</section></main>';
+}
+
+/**
+ * Build a representative HTML document with forms and named controls.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_html_form_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<form action="/search/%1$d"><input name="q%1$d" value="term"><input name="page" value="%1$d"><select name="sort"><option>New</option></select><button name="submit">Go</button><input></form>',
+			$i
+		);
+	}
+
+	return '<main><section>' . implode( '', $items ) . '</section></main>';
+}
+
+/**
+ * Build a representative HTML document with image attributes.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_html_image_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<figure><img src="/media/%1$d.jpg" alt="Image %1$d" width="800" height="600"><img src="/thumb/%1$d.jpg" alt=""><figcaption>Image %1$d</figcaption></figure>',
+			$i
+		);
+	}
+
+	return '<main><section>' . implode( '', $items ) . '</section></main>';
+}
+
+/**
+ * Build a representative HTML document with script attributes and inline scripts.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_html_script_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- Benchmark fixture markup.
+			'<article><script src="/assets/app-%1$d.js" type="module" async></script><script>window.wpData%1$d = {"id":%1$d};</script><script defer src="/assets/legacy-%1$d.js"></script></article>',
+			$i
+		);
+	}
+
+	return '<main><section>' . implode( '', $items ) . '</section></main>';
+}
+
+/**
+ * Build representative plain text containing URL references.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_url_in_text_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'Post %1$d: https://example.com/posts/%1$d?preview=1 references example.org/docs/%1$d and //cdn.example.org/assets/app-%1$d.js.',
+			$i
+		);
+	}
+
+	return implode( ' ', $items );
+}
+
+/**
+ * Build a representative XML document.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<wp:item xmlns:wp="https://wordpress.org" id="%1$d"><wp:title>Title %1$d</wp:title><wp:meta key="slug">post-%1$d</wp:meta></wp:item>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><wp:root xmlns:wp="https://wordpress.org">' . implode( '', $items ) . '</wp:root>';
+}
+
+/**
+ * Build a representative XML document for structure inventory scans.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_inventory_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<wp:item xmlns:wp="https://wordpress.org" id="%1$d"><wp:title>Title %1$d</wp:title><!-- item %1$d --><wp:meta key="slug"><![CDATA[post-%1$d]]></wp:meta><wp:empty /></wp:item>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><wp:root xmlns:wp="https://wordpress.org">' . implode( '', $items ) . '</wp:root>';
+}
+
+/**
+ * Build a representative XML document with repeated element names.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_element_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<wp:item id="%1$d"><wp:title>Title %1$d</wp:title><media:asset><media:file /><media:size /></media:asset><plain /></wp:item>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><wp:root xmlns:wp="https://wordpress.org" xmlns:media="https://example.com/media">' . implode( '', $items ) . '</wp:root>';
+}
+
+/**
+ * Build a representative XML document with nested importer elements.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_depth_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<section id="%1$d"><item><title>Title %1$d</title><meta><key name="slug" /><value>post-%1$d</value></meta></item><attachment><file /><sizes><size /></sizes></attachment></section>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><root><batch>' . implode( '', $items ) . '</batch><trailer /></root>';
+}
+
+/**
+ * Build a representative XML document with repeated matching tag attribute audits.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_matching_attribute_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<wp:item xmlns:wp="https://wordpress.org" id="%1$d" slug="post-%1$d" status="publish"><wp:title>Title %1$d</wp:title><wp:meta key="slug">post-%1$d</wp:meta></wp:item>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><wp:root xmlns:wp="https://wordpress.org">' . implode( '', $items ) . '</wp:root>';
+}
+
+/**
+ * Build a representative XML document with repeated prefixed attribute scans.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_attribute_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<wp:item xmlns:wp="https://wordpress.org" id="%1$d" wp:kind="post" data-id="%1$d" data-kind="post"><wp:title data-rank="%1$d">Title %1$d</wp:title><wp:meta key="slug" data-slug="post-%1$d">post-%1$d</wp:meta></wp:item>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><wp:root xmlns:wp="https://wordpress.org">' . implode( '', $items ) . '</wp:root>';
+}
+
+/**
+ * Build a representative XML document with ID-heavy importer data.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_id_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$duplicate_id = $i % 20;
+		$items[]      = sprintf(
+			'<wp:item xmlns:wp="https://wordpress.org" id="post-%1$d" wp:id="ignored-%1$d"><wp:title id="title-%1$d">Title %1$d</wp:title><wp:meta id="post-%2$d">post-%1$d</wp:meta><wp:empty id="empty-%1$d" /></wp:item>',
+			$i,
+			$duplicate_id
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><wp:root xmlns:wp="https://wordpress.org" id="root">' . implode( '', $items ) . '</wp:root>';
+}
+
+/**
+ * Build a representative XML document with namespace-heavy importer data.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_namespace_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<wp:item id="%1$d" wp:kind="post" media:type="image"><media:title data-rank="%1$d">Title %1$d</media:title><dc:creator dc:id="%1$d">author-%1$d</dc:creator><empty data-id="%1$d" /></wp:item>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><wp:root xmlns:wp="https://wordpress.org" xmlns:media="https://example.com/media" xmlns:dc="http://purl.org/dc/elements/1.1/">' . implode( '', $items ) . '</wp:root>';
+}
+
+/**
+ * Build a representative XML document with text-heavy importer data.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_text_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<item id="%1$d">Title %1$d<summary>Excerpt %1$d with &amp; entity text</summary><content><![CDATA[Long body %1$d with <markup> inside]]></content><blank>   </blank></item>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><root>' . implode( '', $items ) . '</root>';
+}
+
+/**
+ * Build a representative XML document with importer processing instructions.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_processing_instruction_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<?xml-import source="feed-%1$d" status="queued"?><item id="%1$d">Title %1$d</item><?xml-audit checksum="hash-%1$d"?>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><root>' . implode( '', $items ) . '</root><?xml-trailer processed="120"?>';
+}
+
+/**
+ * Build a representative XML document with importer comments.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_comment_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<!-- import item %1$d source feed with checksum hash-%1$d --><item id="%1$d">Title %1$d<!-- --><meta><!-- category post-%1$d --></meta></item>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><root><!-- batch import comments -->' . implode( '', $items ) . '<!--   --></root><!-- trailer comment -->';
+}
+
+/**
+ * Build a representative XML document with mixed payload-bearing tokens.
+ *
+ * @return string
+ */
+function wp_toolkit_native_api_benchmark_xml_payload_document() {
+	$items = array();
+	for ( $i = 0; $i < 120; $i++ ) {
+		$items[] = sprintf(
+			'<?xml-import source="feed-%1$d"?><!-- import payload %1$d with checksum hash-%1$d --><item id="%1$d">Title %1$d<summary>Excerpt %1$d with &amp; entity text</summary><content><![CDATA[Long body %1$d with <markup> inside]]></content><!-- --></item>',
+			$i
+		);
+	}
+
+	return '<?xml version="1.0" encoding="UTF-8"?><root><!-- mixed payload audit -->' . implode( '', $items ) . '</root><?xml-trailer processed="120"?>';
+}

--- a/bin/benchmark-native-apis.php
+++ b/bin/benchmark-native-apis.php
@@ -928,8 +928,18 @@ function wp_toolkit_native_api_benchmark_run( $name, $mode, $iterations, $class_
 	$start_cpu    = wp_toolkit_native_api_benchmark_cpu_time();
 	$operations   = 0;
 
-	for ( $i = 0; $i < $iterations; $i++ ) {
-		$operations += call_user_func( $callback );
+	try {
+		for ( $i = 0; $i < $iterations; $i++ ) {
+			$operations += call_user_func( $callback );
+		}
+	} catch ( Throwable $exception ) {
+		return array(
+			'name'           => $name,
+			'implementation' => $mode,
+			'class'          => $class_name,
+			'available'      => false,
+			'message'        => $exception->getMessage(),
+		);
 	}
 
 	$end_cpu = wp_toolkit_native_api_benchmark_cpu_time();

--- a/components/DataLiberation/Tests/DataLiberationHTMLProcessorTest.php
+++ b/components/DataLiberation/Tests/DataLiberationHTMLProcessorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WordPress\DataLiberation\DataLiberationHTMLProcessor;
+use WordPress\DataLiberation\Importer\ImportUtils;
+
+class NativeAwareDataLiberationHTMLProcessor extends DataLiberationHTMLProcessor {
+	public function is_native_processor_active() {
+		return $this->has_native_processor();
+	}
+}
+
+class DataLiberationHTMLProcessorTest extends TestCase {
+
+	public function test_native_processor_remains_available_for_inherited_html_cursor_methods() {
+		if ( ! class_exists( 'WP_HTML_Native_Processor', false ) ) {
+			$this->markTestSkipped( 'The native HTML processor is not loaded.' );
+		}
+
+		$processor = NativeAwareDataLiberationHTMLProcessor::create_fragment(
+			'<h1>Title</h1><p>Body</p>'
+		);
+
+		$this->assertTrue( $processor->is_native_processor_active() );
+		$this->assertTrue( $processor->next_tag( 'H1' ) );
+		$this->assertSame( 'Title', $processor->get_inner_html() );
+		$this->assertTrue( $processor->is_native_processor_active() );
+		$this->assertTrue( $processor->next_tag( 'P' ) );
+		$this->assertSame( 'P', $processor->get_tag() );
+	}
+
+	public function test_import_h1_removal_keeps_native_progressive_upgrade() {
+		if ( ! class_exists( 'WP_HTML_Native_Processor', false ) ) {
+			$this->markTestSkipped( 'The native HTML processor is not loaded.' );
+		}
+
+		$result = ImportUtils::remove_first_h1_block_from_block_markup(
+			'<h1>Native Title</h1><!-- wp:paragraph --><p>Body</p>'
+		);
+
+		$this->assertSame(
+			array(
+				'h1_content'     => 'Native Title',
+				'remaining_html' => '<p>Body</p>',
+			),
+			$result
+		);
+	}
+}

--- a/components/DataLiberation/Tests/URLInTextProcessorTest.php
+++ b/components/DataLiberation/Tests/URLInTextProcessorTest.php
@@ -5,6 +5,28 @@ use WordPress\DataLiberation\URL\URLInTextProcessor;
 
 class URLInTextProcessorTest extends TestCase {
 
+	public function test_direct_native_processor_finds_url_candidates_when_loaded() {
+		$native_class = 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor';
+		if ( ! class_exists( $native_class, false ) ) {
+			$this->markTestSkipped( 'Native URL-in-text processor is not loaded.' );
+		}
+
+		$p = new $native_class( 'Visit https://wordpress.org/plugins, then example.com/docs.' );
+		$this->assertTrue( $p->next_url() );
+		$this->assertSame( 'https://wordpress.org/plugins', $p->get_raw_url() );
+		$this->assertSame( 6, $p->get_url_starts_at() );
+		$this->assertTrue( $p->had_protocol() );
+
+		$this->assertTrue( $p->next_url() );
+		$this->assertSame( 'example.com/docs', $p->get_raw_url() );
+		$this->assertFalse( $p->had_protocol() );
+		$this->assertTrue( $p->set_raw_url( 'example.org/handbook' ) );
+		$this->assertSame(
+			'Visit https://wordpress.org/plugins, then example.org/handbook.',
+			$p->get_updated_text()
+		);
+	}
+
 	/**
 	 * @dataProvider provider_test_finds_next_url_when_base_url_is_used
 	 */

--- a/components/DataLiberation/URL/PHP/class-phpurlintextprocessor.php
+++ b/components/DataLiberation/URL/PHP/class-phpurlintextprocessor.php
@@ -106,7 +106,7 @@ use WP_HTML_Text_Replacement;
  *
  * This reflects how URLs actually appear in text blocks where whitespace often terminates a link.
  */
-class URLInTextProcessor {
+class PHPURLInTextProcessor {
 
 	private $text;
 	private $url_starts_at;

--- a/components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php
+++ b/components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace WordPress\DataLiberation\URL;
+
+class NativeURLInTextProcessorWrapper extends NativeURLInTextProcessor {}

--- a/components/DataLiberation/URL/class-urlintextprocessor.php
+++ b/components/DataLiberation/URL/class-urlintextprocessor.php
@@ -1,0 +1,21 @@
+<?php
+// phpcs:disable Generic.Classes.DuplicateClassName.Found,Generic.Files.OneObjectStructurePerFile.MultipleFound
+
+namespace WordPress\DataLiberation\URL;
+
+$wp_url_in_text_use_native =
+	class_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', false ) &&
+	method_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', 'supports_public_api' ) &&
+	( ! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) || ! WP_NATIVE_APIS_DISABLE_DEFAULTS );
+
+if ( $wp_url_in_text_use_native ) {
+	require_once __DIR__ . '/class-nativeurlintextprocessorwrapper.php';
+
+	class URLInTextProcessor extends NativeURLInTextProcessorWrapper {}
+} else {
+	require_once __DIR__ . '/PHP/class-phpurlintextprocessor.php';
+
+	class URLInTextProcessor extends PHPURLInTextProcessor {}
+}
+
+unset( $wp_url_in_text_use_native );

--- a/components/DataLiberation/class-dataliberationhtmlprocessor.php
+++ b/components/DataLiberation/class-dataliberationhtmlprocessor.php
@@ -5,9 +5,116 @@ namespace WordPress\DataLiberation;
 use WP_HTML_Processor;
 use WP_HTML_Tag_Processor;
 
+/**
+ * HTML Processor helpers used by the Data Liberation import pipeline.
+ *
+ * This class intentionally keeps the same no-burden progressive upgrade model
+ * as the public HTML API. When the native extension is loaded, inherited cursor
+ * operations such as `next_tag()`, `next_token()`, `get_attribute()`, and
+ * `get_modifiable_text()` use the native processor automatically. Consumers do
+ * not need to opt in or choose a separate class.
+ *
+ * The Data Liberation-only helpers below expose source-string offsets and
+ * substrings:
+ *
+ *     $p = DataLiberationHTMLProcessor::create_fragment( '<h1>Title</h1><p>Body</p>' );
+ *     $p->next_tag( 'H1' );
+ *     $inner_html = $p->get_inner_html(); // "Title".
+ *
+ *     $p->skip_to_closer();
+ *     $after_h1 = substr( $html, $p->get_string_index_after_current_token() );
+ *
+ * Those offsets are an implementation detail of the PHP parser; native HTML
+ * bookmarks are opaque and do not expose byte spans. To keep native processing
+ * available for normal scanning, these helpers replay the current cursor
+ * position on a PHP-backed mirror and read the offsets from that mirror.
+ */
 class DataLiberationHTMLProcessor extends WP_HTML_Processor {
 
+	/**
+	 * Number of public tokens consumed from this processor.
+	 *
+	 * This is enough to replay the cursor onto a PHP-backed mirror for the
+	 * Data Liberation helpers that need PHP bookmark spans.
+	 *
+	 * @var int
+	 */
+	private $tokens_parsed_for_php_replay = 0;
+
+	/**
+	 * Token counts captured for public bookmarks.
+	 *
+	 * Native bookmarks are intentionally opaque. This map lets a later `seek()`
+	 * restore the replay counter when the bookmark was created through this
+	 * class, so the PHP mirror can land on the same token.
+	 *
+	 * @var array<string,int>
+	 */
+	private $php_replay_bookmarks = array();
+
+	/**
+	 * Whether the current cursor can be replayed onto the PHP parser.
+	 *
+	 * @var bool
+	 */
+	private $can_replay_php_cursor = true;
+
+	/**
+	 * Whether this instance exists only as a PHP replay mirror.
+	 *
+	 * @var bool
+	 */
+	private $is_php_replay = false;
+
+	public function next_token(): bool {
+		$matched = parent::next_token();
+		if ( $matched ) {
+			++$this->tokens_parsed_for_php_replay;
+		}
+
+		return $matched;
+	}
+
+	public function set_bookmark( $name ): bool {
+		$set = parent::set_bookmark( $name );
+		if ( $set ) {
+			$this->php_replay_bookmarks[ $name ] = $this->tokens_parsed_for_php_replay;
+		}
+
+		return $set;
+	}
+
+	public function release_bookmark( $name ): bool {
+		$released = parent::release_bookmark( $name );
+		if ( $released ) {
+			unset( $this->php_replay_bookmarks[ $name ] );
+		}
+
+		return $released;
+	}
+
+	public function seek( $bookmark_name ): bool {
+		$found = parent::seek( $bookmark_name );
+		if ( ! $found ) {
+			return false;
+		}
+
+		if ( isset( $this->php_replay_bookmarks[ $bookmark_name ] ) ) {
+			$this->tokens_parsed_for_php_replay = $this->php_replay_bookmarks[ $bookmark_name ];
+		} else {
+			$this->can_replay_php_cursor = false;
+		}
+
+		return true;
+	}
+
 	public function get_inner_html() {
+		if ( $this->has_active_native_processor() ) {
+			$php_processor = $this->create_php_replay_at_current_token();
+
+			return $php_processor instanceof self ? $php_processor->get_inner_html() : false;
+		}
+
 		if ( '#tag' !== $this->get_token_type() ) {
 			return false;
 		}
@@ -16,24 +123,28 @@ class DataLiberationHTMLProcessor extends WP_HTML_Processor {
 			return false;
 		}
 
-		if ( false === WP_HTML_Tag_Processor::set_bookmark( 'tag-start' ) ) {
+		if ( false === $this->set_bookmark( 'tag-start' ) ) {
 			return false;
 		}
 
 		$this->skip_to_closer();
 
-		if ( false === WP_HTML_Tag_Processor::set_bookmark( 'tag-end' ) ) {
-			WP_HTML_Tag_Processor::release_bookmark( 'tag-start' );
+		if ( false === $this->set_bookmark( 'tag-end' ) ) {
+			$this->release_bookmark( 'tag-start' );
 
 			return false;
 		}
 
-		$inner_html_start = $this->bookmarks['tag-start']->start + $this->bookmarks['tag-start']->length;
-		$inner_html_end   = $this->bookmarks['tag-end']->start - $inner_html_start;
+		$tag_start        = $this->get_bookmark_span( 'tag-start' );
+		$tag_end          = $this->get_bookmark_span( 'tag-end' );
+		$inner_html_start = $tag_start->start + $tag_start->length;
+		$inner_html_end   = $tag_end->start - $inner_html_start;
 
-		WP_HTML_Tag_Processor::seek( 'tag-start' );
-		WP_HTML_Tag_Processor::release_bookmark( 'tag-start' );
-		WP_HTML_Tag_Processor::release_bookmark( 'tag-end' );
+		if ( ! $this->is_php_replay ) {
+			$this->seek( 'tag-start' );
+			$this->release_bookmark( 'tag-start' );
+			$this->release_bookmark( 'tag-end' );
+		}
 
 		return substr(
 			$this->html,
@@ -58,11 +169,97 @@ class DataLiberationHTMLProcessor extends WP_HTML_Processor {
 	}
 
 	public function get_string_index_after_current_token() {
+		if ( $this->has_active_native_processor() ) {
+			$php_processor = $this->create_php_replay_at_current_token();
+
+			return $php_processor instanceof self ? $php_processor->get_string_index_after_current_token() : false;
+		}
+
 		$name = 'current_token';
 		$this->set_bookmark( $name );
-		$bookmark = $this->bookmarks[ '_' . $name ];
+		$bookmark = $this->get_bookmark_span( '_' . $name );
 		$this->release_bookmark( $name );
 
 		return $bookmark->start + $bookmark->length;
+	}
+
+	/**
+	 * Returns a PHP bookmark span from this object or its PHP delegate.
+	 *
+	 * @param string $name Bookmark name.
+	 * @return WP_HTML_Span Bookmark span.
+	 */
+	private function get_bookmark_span( $name ) {
+		if ( isset( $this->bookmarks[ $name ] ) ) {
+			return $this->bookmarks[ $name ];
+		}
+		if ( isset( $this->bookmarks[ '_' . $name ] ) ) {
+			return $this->bookmarks[ '_' . $name ];
+		}
+
+		if ( property_exists( $this, 'php_processor' ) ) {
+			$property = new \ReflectionProperty( 'WP_HTML_PHP_Tag_Processor', 'bookmarks' );
+			$property->setAccessible( true );
+			$bookmarks = $property->getValue( $this->php_processor );
+			if ( isset( $bookmarks[ $name ] ) ) {
+				return $bookmarks[ $name ];
+			}
+			if ( isset( $bookmarks[ '_' . $name ] ) ) {
+				return $bookmarks[ '_' . $name ];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Checks whether this processor has a native delegate.
+	 *
+	 * The pure PHP HTML Processor loaded on older runtimes does not define the
+	 * native-wrapper helper method, so callers must guard the method before
+	 * invoking it.
+	 *
+	 * @return bool Whether a native processor is active.
+	 */
+	private function has_active_native_processor() {
+		return method_exists( $this, 'has_native_processor' ) && $this->has_native_processor();
+	}
+
+	/**
+	 * Creates a PHP-backed processor at the same public cursor token.
+	 *
+	 * Native cursor operations are faster for scanning, but native bookmarks do
+	 * not expose byte offsets. For offset-only helpers this method replays the
+	 * already-consumed public token count on a mirror with native delegation
+	 * disabled. Example:
+	 *
+	 *     $native = DataLiberationHTMLProcessor::create_fragment( '<h1>Title</h1><p>Body</p>' );
+	 *     $native->next_tag( 'H1' );
+	 *
+	 *     // The mirror runs the PHP parser through the same first token, so its
+	 *     // bookmark spans point to the original `<h1>` source bytes.
+	 *     $php = $native->create_php_replay_at_current_token();
+	 *
+	 * @return self|null PHP-backed processor at the current token, or null.
+	 */
+	private function create_php_replay_at_current_token() {
+		if ( ! $this->can_replay_php_cursor ) {
+			return null;
+		}
+
+		$processor = static::create_fragment( $this->html );
+		if ( ! $processor instanceof self ) {
+			return null;
+		}
+
+		$processor->set_native_processor( null );
+		$processor->is_php_replay = true;
+		for ( $i = 0; $i < $this->tokens_parsed_for_php_replay; ++$i ) {
+			if ( ! $processor->next_token() ) {
+				return null;
+			}
+		}
+
+		return $processor;
 	}
 }

--- a/components/HTML/PHP/class-wp-html-php-processor.php
+++ b/components/HTML/PHP/class-wp-html-php-processor.php
@@ -140,7 +140,7 @@
  * @see WP_HTML_Tag_Processor
  * @see https://html.spec.whatwg.org/
  */
-class WP_HTML_Processor extends WP_HTML_Tag_Processor {
+class WP_HTML_PHP_Processor extends WP_HTML_PHP_Tag_Processor {
 	/**
 	 * The maximum number of bookmarks allowed to exist at any given time.
 	 *

--- a/components/HTML/PHP/class-wp-html-php-tag-processor.php
+++ b/components/HTML/PHP/class-wp-html-php-tag-processor.php
@@ -408,7 +408,7 @@
  *              Introduces "special" elements which act like void elements, e.g. TITLE, STYLE.
  *              Allows scanning through all tokens and processing modifiable text, where applicable.
  */
-class WP_HTML_Tag_Processor {
+class WP_HTML_PHP_Tag_Processor {
 	/**
 	 * The maximum number of bookmarks allowed to exist at
 	 * any given time.

--- a/components/HTML/README.md
+++ b/components/HTML/README.md
@@ -14,7 +14,16 @@ see_also:
   - dataliberation | DataLiberation | Rewrite URLs and media references during import/export pipelines.
 ---
 
-A pure-PHP HTML parser and tag rewriter mirroring WordPress core's HTML API. Handle browser-style HTML fragments for supported markup — without <code>libxml2</code>, <code>DOMDocument</code>, or regex hacks — and rewrite attributes in a single linear pass.
+A pure-PHP HTML5 parser and tag rewriter mirroring WordPress core's HTML API. Treat HTML the way browsers do — without <code>libxml2</code>, <code>DOMDocument</code>, or regex hacks — and rewrite attributes in a single linear pass.
+
+When the native API extension is loaded, tag and fragment processors can use
+native delegates by default while preserving PHP fallback behavior. Define
+<code>WP_NATIVE_APIS_DISABLE_DEFAULTS</code> before loading the component to
+force the pure PHP fallback. Full-document parsing through
+<code>WP_HTML_Processor::create_full_parser()</code> remains PHP-backed for
+now. Fragment processors, including covered table, list, description-list,
+select/option/optgroup, omitted-paragraph, and ruby tree-builder cases, can use
+native delegates when the extension is loaded.
 
 ## Why this exists
 
@@ -23,8 +32,6 @@ A pure-PHP HTML parser and tag rewriter mirroring WordPress core's HTML API. Han
 <p>The HTML component gives WordPress-style code the same parsing model WordPress core uses: a browser-compatible tokenizer and tree-aware processor that run in pure PHP. Choose it for exact-byte rewrites, imperfect fragments, and post-content filters where a full DOM would do too much work.</p>
 
 <p>The component gives you two processors. <code>WP_HTML_Tag_Processor</code> is a forward-only cursor over tags and tokens — useful for attribute rewriting at scale. <code>WP_HTML_Processor</code> layers HTML5 tree construction on top so you can query by ancestry (breadcrumbs), serialize the parsed document, and trust that <code>&lt;p&gt;one&lt;p&gt;two</code> parses as two paragraphs the way a browser sees it.</p>
-
-<p>Scope: <code>WP_HTML_Processor</code> intentionally supports WordPress core's current subset of HTML5. It aborts on markup it cannot safely model, including table-internal content, foreign content such as SVG/MathML, and content outside the supported body parsing modes. Use <code>get_unsupported_exception()</code> when you need to explain why processing stopped.</p>
 
 <p>Footgun: <strong>Mutations are buffered.</strong> Nothing changes in the source string until you call <code>get_updated_html()</code>. If you read <code>get_attribute()</code> after a <code>set_attribute()</code> on the same tag, you see the new value — but downstream tooling reading the original string sees stale HTML until you serialize.</p>
 

--- a/components/HTML/Tests/NativeHTMLConformanceTest.php
+++ b/components/HTML/Tests/NativeHTMLConformanceTest.php
@@ -1,0 +1,4007 @@
+<?php
+/**
+ * Shared conformance tests for PHP and native HTML processors.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group html-api
+ * @group native-api
+ */
+class NativeHTMLConformanceTest extends TestCase {
+	/**
+	 * Verifies public HTML classes default to native delegates when available.
+	 */
+	public function test_public_html_classes_use_native_processors_when_available() {
+		if ( ! class_exists( 'WP_HTML_Native_Tag_Processor', false ) || ! method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) || ! class_exists( 'WP_HTML_Native_Processor', false ) || ! method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'Native HTML classes are not registered; load the native API extension to run this case.' );
+		}
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p data-id="1">Text</p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertTrue( $tag_processor->next_tag() );
+		$this->assertSame( 'P', $tag_processor->get_tag() );
+		$this->assertSame( '1', $tag_processor->get_attribute( 'data-id' ) );
+		$this->assertTrue( $tag_processor->remove_attribute( 'data-id' ) );
+		$this->assertNull( $tag_processor->get_attribute( 'data-id' ) );
+		$this->assertSame( '<p >Text</p>', $tag_processor->get_updated_html() );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p><br></p>' );
+		$this->assertTrue( $tag_processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
+		$this->assertSame( 'P', $tag_processor->get_tag() );
+		$this->assertFalse( $tag_processor->is_tag_closer() );
+		$this->assertTrue( $tag_processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
+		$this->assertSame( 'BR', $tag_processor->get_tag() );
+		$this->assertFalse( $tag_processor->is_tag_closer() );
+		$this->assertTrue( $tag_processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
+		$this->assertSame( 'P', $tag_processor->get_tag() );
+		$this->assertTrue( $tag_processor->is_tag_closer() );
+		$this->assertNull( $tag_processor->get_attribute_names_with_prefix( 'data-' ) );
+		$this->assertFalse( $tag_processor->has_class( 'anything' ) );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p>One</p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertTrue( $tag_processor->next_token() );
+		$this->assertTrue( $tag_processor->next_token() );
+		$this->assertSame( '#text', $tag_processor->get_token_type() );
+		$this->assertTrue( $tag_processor->set_modifiable_text( 'Two & Three' ) );
+		$this->assertSame( '<p>Two &amp; Three</p>', $tag_processor->get_updated_html() );
+
+		$tag_processor = new WP_HTML_Tag_Processor( "  \tMore" );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertTrue( $tag_processor->next_token() );
+		$this->assertTrue( $tag_processor->subdivide_text_appropriately() );
+		$this->assertSame( "  \t", $tag_processor->get_modifiable_text() );
+		$this->assertTrue( $tag_processor->next_token() );
+		$this->assertSame( 'More', $tag_processor->get_modifiable_text() );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p class="a b" data-kind="intro"><br></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertSame(
+			array(
+				array(
+					'tag_name'      => 'P',
+					'is_tag_closer' => false,
+				),
+			),
+			$tag_processor->next_tag_summary_batch( 1 )
+		);
+		$this->assertSame( array( 'a', 'b' ), iterator_to_array( $tag_processor->class_list() ) );
+		$this->assertSame( 'intro', $tag_processor->get_attribute( 'data-kind' ) );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p class="a b" data-kind="intro"><br></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertSame(
+			array(
+				array(
+					'tag_name'        => 'P',
+					'is_tag_closer'   => false,
+					'attribute_count' => 1,
+				),
+			),
+			$tag_processor->next_tag_prefix_summary_batch( 'data-', 1 )
+		);
+		$this->assertSame( array( 'a', 'b' ), iterator_to_array( $tag_processor->class_list() ) );
+		$this->assertSame( 'intro', $tag_processor->get_attribute( 'data-kind' ) );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p class="a b" data-kind="intro"><br></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertSame( "1\x1f1", $tag_processor->next_tag_prefix_count_compact_batch( 'data-', 1 ) );
+		$this->assertSame( array( 'a', 'b' ), iterator_to_array( $tag_processor->class_list() ) );
+		$this->assertSame( 'intro', $tag_processor->get_attribute( 'data-kind' ) );
+
+		$html_processor = WP_HTML_Processor::create_fragment( '<p>Text</p>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $html_processor ) ) );
+		$this->assertTrue( $html_processor->next_token() );
+		$this->assertSame( 'P', $html_processor->get_token_name() );
+		$this->assertSame( array( 'HTML', 'BODY', 'P' ), $html_processor->get_breadcrumbs() );
+
+		$list_processor = WP_HTML_Processor::create_fragment( '<ul><li>one<li>two</ul>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $list_processor ) ) );
+		$this->assertTrue( $list_processor->next_token() );
+		$this->assertSame( 'UL', $list_processor->get_token_name() );
+		$this->assertTrue( $list_processor->next_token() );
+		$this->assertSame( 'LI', $list_processor->get_token_name() );
+		$this->assertFalse( $list_processor->is_tag_closer() );
+		$this->assertTrue( $list_processor->next_token() );
+		$this->assertSame( 'one', $list_processor->get_modifiable_text() );
+		$this->assertTrue( $list_processor->next_token() );
+		$this->assertSame( 'LI', $list_processor->get_token_name() );
+		$this->assertTrue( $list_processor->is_tag_closer() );
+
+		$description_list_processor = WP_HTML_Processor::create_fragment( '<dl><dt>A<dd>B</dl>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $description_list_processor ) ) );
+		$this->assertTrue( $description_list_processor->next_token() );
+		$this->assertSame( 'DL', $description_list_processor->get_token_name() );
+		$this->assertTrue( $description_list_processor->next_token() );
+		$this->assertSame( 'DT', $description_list_processor->get_token_name() );
+		$this->assertFalse( $description_list_processor->is_tag_closer() );
+		$this->assertTrue( $description_list_processor->next_token() );
+		$this->assertSame( 'A', $description_list_processor->get_modifiable_text() );
+		$this->assertTrue( $description_list_processor->next_token() );
+		$this->assertSame( 'DT', $description_list_processor->get_token_name() );
+		$this->assertTrue( $description_list_processor->is_tag_closer() );
+
+		$select_processor = WP_HTML_Processor::create_fragment( '<select><option>A<option>B</select>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $select_processor ) ) );
+		$this->assertTrue( $select_processor->next_token() );
+		$this->assertSame( 'SELECT', $select_processor->get_token_name() );
+		$this->assertTrue( $select_processor->next_token() );
+		$this->assertSame( 'OPTION', $select_processor->get_token_name() );
+		$this->assertFalse( $select_processor->is_tag_closer() );
+		$this->assertTrue( $select_processor->next_token() );
+		$this->assertSame( 'A', $select_processor->get_modifiable_text() );
+		$this->assertTrue( $select_processor->next_token() );
+		$this->assertSame( 'OPTION', $select_processor->get_token_name() );
+		$this->assertTrue( $select_processor->is_tag_closer() );
+
+		$optgroup_processor = WP_HTML_Processor::create_fragment( '<select><optgroup label="a"><option>A<optgroup label="b"><option>B</select>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $optgroup_processor ) ) );
+		$this->assertTrue( $optgroup_processor->next_token() );
+		$this->assertSame( 'SELECT', $optgroup_processor->get_token_name() );
+		$this->assertTrue( $optgroup_processor->next_token() );
+		$this->assertSame( 'OPTGROUP', $optgroup_processor->get_token_name() );
+		$this->assertFalse( $optgroup_processor->is_tag_closer() );
+		$this->assertTrue( $optgroup_processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
+		$this->assertSame( 'OPTION', $optgroup_processor->get_token_name() );
+		$this->assertFalse( $optgroup_processor->is_tag_closer() );
+		$this->assertTrue( $optgroup_processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
+		$this->assertSame( 'OPTION', $optgroup_processor->get_token_name() );
+		$this->assertTrue( $optgroup_processor->is_tag_closer() );
+		$this->assertTrue( $optgroup_processor->next_token() );
+		$this->assertSame( 'OPTGROUP', $optgroup_processor->get_token_name() );
+		$this->assertTrue( $optgroup_processor->is_tag_closer() );
+
+		$ruby_processor = WP_HTML_Processor::create_fragment( '<ruby>a<rt>b<rp>(<rt>c</ruby>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $ruby_processor ) ) );
+		$this->assertTrue( $ruby_processor->next_token() );
+		$this->assertSame( 'RUBY', $ruby_processor->get_token_name() );
+		$this->assertTrue( $ruby_processor->next_token() );
+		$this->assertSame( 'a', $ruby_processor->get_modifiable_text() );
+		$this->assertTrue( $ruby_processor->next_token() );
+		$this->assertSame( 'RT', $ruby_processor->get_token_name() );
+		$this->assertFalse( $ruby_processor->is_tag_closer() );
+		$this->assertTrue( $ruby_processor->next_token() );
+		$this->assertSame( 'b', $ruby_processor->get_modifiable_text() );
+		$this->assertTrue( $ruby_processor->next_token() );
+		$this->assertSame( 'RT', $ruby_processor->get_token_name() );
+		$this->assertTrue( $ruby_processor->is_tag_closer() );
+
+		$paragraph_processor = WP_HTML_Processor::create_fragment( '<p>one<div>two</div>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $paragraph_processor ) ) );
+		$this->assertTrue( $paragraph_processor->next_token() );
+		$this->assertSame( 'P', $paragraph_processor->get_token_name() );
+		$this->assertFalse( $paragraph_processor->is_tag_closer() );
+		$this->assertTrue( $paragraph_processor->next_token() );
+		$this->assertSame( 'one', $paragraph_processor->get_modifiable_text() );
+		$this->assertTrue( $paragraph_processor->next_token() );
+		$this->assertSame( 'P', $paragraph_processor->get_token_name() );
+		$this->assertTrue( $paragraph_processor->is_tag_closer() );
+		$this->assertTrue( $paragraph_processor->next_token() );
+		$this->assertSame( 'DIV', $paragraph_processor->get_token_name() );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV' ), $paragraph_processor->get_breadcrumbs() );
+
+		$table_processor = WP_HTML_Processor::create_fragment( '<table><tr><td>A<td>B</tr></table>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $table_processor ) ) );
+		$this->assertTrue( $table_processor->next_token() );
+		$this->assertSame( 'TABLE', $table_processor->get_token_name() );
+		$this->assertTrue( $table_processor->next_token() );
+		$this->assertSame( 'TBODY', $table_processor->get_token_name() );
+		$this->assertFalse( $table_processor->is_tag_closer() );
+
+		$full_processor = WP_HTML_Processor::create_full_parser( '<html><body><main>Text</main></body></html>' );
+		$this->assertNull( $this->get_native_delegate( $full_processor ) );
+		$this->assertTrue( $full_processor->next_token() );
+		$this->assertSame( 'HTML', $full_processor->get_token_name() );
+	}
+
+	/**
+	 * Verifies public native-backed tag queries match PHP fallback match-offset parsing.
+	 */
+	public function test_public_html_native_defaults_ignore_non_integer_match_offsets() {
+		if ( ! class_exists( 'WP_HTML_Native_Tag_Processor', false ) || ! method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'Native HTML classes are not registered; load the native API extension to run this case.' );
+		}
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p id="one"></p><p id="two"></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertTrue( $tag_processor->next_tag( array( 'tag_name' => 'p', 'match_offset' => '2' ) ) );
+		$this->assertSame( 'one', $tag_processor->get_attribute( 'id' ) );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p id="one"></p><p id="two"></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertTrue( $tag_processor->next_tag( array( 'tag_name' => 'p', 'match_offset' => 2.0 ) ) );
+		$this->assertSame( 'one', $tag_processor->get_attribute( 'id' ) );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p id="one"></p><p id="two"></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertTrue( $tag_processor->next_tag( array( 'tag_name' => 'p', 'match_offset' => 2 ) ) );
+		$this->assertSame( 'two', $tag_processor->get_attribute( 'id' ) );
+	}
+
+	/**
+	 * Verifies public native-backed unrestricted closer fast paths do not swallow
+	 * tag-name queries that also visit closers.
+	 */
+	public function test_public_html_native_defaults_honor_tag_name_when_visiting_closers() {
+		if ( ! class_exists( 'WP_HTML_Native_Tag_Processor', false ) || ! method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'Native HTML classes are not registered; load the native API extension to run this case.' );
+		}
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<div></div><p id="target"></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertTrue(
+			$tag_processor->next_tag(
+				array(
+					'tag_name'    => 'p',
+					'tag_closers' => 'visit',
+				)
+			)
+		);
+		$this->assertSame( 'P', $tag_processor->get_tag() );
+		$this->assertFalse( $tag_processor->is_tag_closer() );
+		$this->assertSame( 'target', $tag_processor->get_attribute( 'id' ) );
+	}
+
+	/**
+	 * Verifies public native-backed tag processors handle invalid query types like PHP fallback.
+	 */
+	public function test_public_html_native_defaults_treat_invalid_query_types_as_unrestricted() {
+		if ( ! class_exists( 'WP_HTML_Native_Tag_Processor', false ) || ! method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'Native HTML classes are not registered; load the native API extension to run this case.' );
+		}
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p id="one"></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertTrue( $tag_processor->next_tag( 42 ) );
+		$this->assertSame( 'P', $tag_processor->get_tag() );
+		$this->assertSame( 'one', $tag_processor->get_attribute( 'id' ) );
+	}
+
+	/**
+	 * Verifies HTML native defaults can be disabled by constant.
+	 */
+	public function test_public_html_classes_can_disable_native_defaults_by_constant() {
+		if ( ! class_exists( 'WP_HTML_Native_Tag_Processor', false ) || ! method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) || ! class_exists( 'WP_HTML_Native_Processor', false ) || ! method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'Native HTML classes are not registered; load the native API extension to run this case.' );
+		}
+
+		$this->assertSame(
+			array(
+				'tag:php',
+				'tag-id:1',
+				'tree:php',
+				'tree-token:P',
+				'full:php',
+				'full-token:HTML',
+			),
+			$this->run_html_native_defaults_constant_probe( "define( 'WP_NATIVE_APIS_DISABLE_DEFAULTS', true );" )
+		);
+	}
+
+	/**
+	 * Verifies public native-backed HTML processors apply attribute and class updates.
+	 */
+	public function test_public_html_mutations_with_native_defaults() {
+		if ( ! class_exists( 'WP_HTML_Native_Tag_Processor', false ) || ! method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) || ! class_exists( 'WP_HTML_Native_Processor', false ) || ! method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'Native HTML classes are not registered; load the native API extension to run this case.' );
+		}
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p class="a">Text</p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertTrue( $tag_processor->next_tag( 'p' ) );
+		$this->assertTrue( $tag_processor->set_attribute( 'data-id', '7' ) );
+		$this->assertSame( '7', $tag_processor->get_attribute( 'data-id' ) );
+		$this->assertTrue( $tag_processor->add_class( 'b' ) );
+		$this->assertSame( 'a b', $tag_processor->get_attribute( 'class' ) );
+		$this->assertSame( '<p data-id="7" class="a b">Text</p>', $tag_processor->get_updated_html() );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<img>' );
+		$this->assertTrue( $tag_processor->next_tag( 'img' ) );
+		$this->assertTrue( $tag_processor->set_attribute( 'src', 'https://w.org/logo.png' ) );
+		$this->assertTrue( $tag_processor->set_attribute( 'alt', 'An image' ) );
+		$this->assertSame( 'https://w.org/logo.png', $tag_processor->get_attribute( 'src' ) );
+		$this->assertSame( 'An image', $tag_processor->get_attribute( 'alt' ) );
+		$this->assertSame( '<img alt="An image" src="https://w.org/logo.png">', $tag_processor->get_updated_html() );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p hidden>Text</p>' );
+		$this->assertTrue( $tag_processor->next_tag( 'p' ) );
+		$this->assertTrue( $tag_processor->get_attribute( 'hidden' ) );
+		$this->assertTrue( $tag_processor->set_attribute( 'hidden', true ) );
+		$this->assertTrue( $tag_processor->get_attribute( 'hidden' ) );
+		$this->assertSame( '<p hidden>Text</p>', $tag_processor->get_updated_html() );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p class="a b">Text</p>' );
+		$this->assertTrue( $tag_processor->next_tag( 'p' ) );
+		$this->assertTrue( $tag_processor->remove_class( 'a' ) );
+		$this->assertSame( 'b', $tag_processor->get_attribute( 'class' ) );
+		$this->assertSame( '<p class="b">Text</p>', $tag_processor->get_updated_html() );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p>Text</p>' );
+		$this->assertTrue( $tag_processor->next_tag( 'p' ) );
+		$this->assertTrue( $tag_processor->set_attribute( 'data-id', '7' ) );
+		$this->assertFalse( $tag_processor->remove_attribute( 'data-id' ) );
+		$this->assertNull( $tag_processor->get_attribute( 'data-id' ) );
+		$this->assertSame( '<p>Text</p>', $tag_processor->get_updated_html() );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p>Text</p>' );
+		$this->assertTrue( $tag_processor->next_tag( 'p' ) );
+		$this->assertTrue( $tag_processor->add_class( 'a' ) );
+		$this->assertTrue( $tag_processor->remove_class( 'a' ) );
+		$this->assertNull( $tag_processor->get_attribute( 'class' ) );
+		$this->assertSame( '<p>Text</p>', $tag_processor->get_updated_html() );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p class="a b">Text</p>' );
+		$this->assertTrue( $tag_processor->next_tag( 'p' ) );
+		$this->assertTrue( $tag_processor->remove_class( 'a' ) );
+		$this->assertTrue( $tag_processor->add_class( 'a' ) );
+		$this->assertSame( 'a b', $tag_processor->get_attribute( 'class' ) );
+		$this->assertSame( '<p class="a b">Text</p>', $tag_processor->get_updated_html() );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<p class="a">Text</p>' );
+		$this->assertTrue( $tag_processor->next_tag( 'p' ) );
+		$this->assertTrue( $tag_processor->remove_class( 'a' ) );
+		$this->assertTrue( $tag_processor->add_class( 'b' ) );
+		$this->assertSame( 'b', $tag_processor->get_attribute( 'class' ) );
+		$this->assertSame( '<p class="b">Text</p>', $tag_processor->get_updated_html() );
+
+		$html_processor = WP_HTML_Processor::create_fragment( '<section><p class="a">Text</p></section>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $html_processor ) ) );
+		$this->assertTrue( $html_processor->next_tag( 'P' ) );
+		$this->assertTrue( $html_processor->set_attribute( 'data-id', '7' ) );
+		$this->assertSame( '7', $html_processor->get_attribute( 'data-id' ) );
+		$this->assertTrue( $html_processor->add_class( 'b' ) );
+		$this->assertSame( 'a b', $html_processor->get_attribute( 'class' ) );
+		$this->assertSame( '<section><p data-id="7" class="a b">Text</p></section>', $html_processor->get_updated_html() );
+
+		$html_processor = WP_HTML_Processor::create_fragment( '<section><p hidden>Text</p></section>' );
+		$this->assertTrue( $html_processor->next_tag( 'P' ) );
+		$this->assertTrue( $html_processor->get_attribute( 'hidden' ) );
+		$this->assertTrue( $html_processor->set_attribute( 'hidden', true ) );
+		$this->assertTrue( $html_processor->get_attribute( 'hidden' ) );
+		$this->assertSame( '<section><p hidden>Text</p></section>', $html_processor->get_updated_html() );
+
+		$html_processor = WP_HTML_Processor::create_fragment( '<section><p>Text</p></section>' );
+		$this->assertTrue( $html_processor->next_tag( 'P' ) );
+		$this->assertTrue( $html_processor->set_attribute( 'data-id', '7' ) );
+		$this->assertFalse( $html_processor->remove_attribute( 'data-id' ) );
+		$this->assertNull( $html_processor->get_attribute( 'data-id' ) );
+		$this->assertSame( '<section><p>Text</p></section>', $html_processor->get_updated_html() );
+	}
+
+	/**
+	 * Verifies public native-backed tag processors preserve bookmark lifecycle behavior.
+	 */
+	public function test_public_html_tag_processor_bookmarks_with_native_defaults() {
+		if ( ! class_exists( 'WP_HTML_Native_Tag_Processor', false ) || ! method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'Native HTML classes are not registered; load the native API extension to run this case.' );
+		}
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<div id="one"><span id="two"></span><p id="three"></p></div>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+
+		$this->assertTrue( $tag_processor->next_tag( 'span' ) );
+		$this->assertSame( 'SPAN', $tag_processor->get_tag() );
+		$this->assertSame( 'two', $tag_processor->get_attribute( 'id' ) );
+		$this->assertTrue( $tag_processor->set_bookmark( 'saved-span' ) );
+		$this->assertTrue( $tag_processor->has_bookmark( 'saved-span' ) );
+
+		$this->assertTrue( $tag_processor->next_tag( 'p' ) );
+		$this->assertSame( 'P', $tag_processor->get_tag() );
+		$this->assertSame( 'three', $tag_processor->get_attribute( 'id' ) );
+
+		$this->assertTrue( $tag_processor->seek( 'saved-span' ) );
+		$this->assertSame( 'SPAN', $tag_processor->get_tag() );
+		$this->assertSame( 'two', $tag_processor->get_attribute( 'id' ) );
+		$this->assertTrue( $tag_processor->remove_attribute( 'id' ) );
+		$this->assertSame( '<div id="one"><span ></span><p id="three"></p></div>', $tag_processor->get_updated_html() );
+		$this->assertTrue( $tag_processor->release_bookmark( 'saved-span' ) );
+		$this->assertFalse( $tag_processor->has_bookmark( 'saved-span' ) );
+
+		$tag_processor = new WP_HTML_Tag_Processor( '<div><span class="b">Text</span><p>More</p></div>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $tag_processor ) ) );
+		$this->assertTrue( $tag_processor->next_tag( 'span' ) );
+		$this->assertTrue( $tag_processor->set_bookmark( 'saved-class' ) );
+		$this->assertTrue( $tag_processor->next_tag( 'p' ) );
+		$this->assertTrue( $tag_processor->seek( 'saved-class' ) );
+		$this->assertTrue( $tag_processor->remove_class( 'b' ) );
+		$this->assertTrue( $tag_processor->add_class( 'c' ) );
+		$this->assertSame( 'c', $tag_processor->get_attribute( 'class' ) );
+		$this->assertSame( '<div><span class="c">Text</span><p>More</p></div>', $tag_processor->get_updated_html() );
+	}
+
+	/**
+	 * Verifies public native-backed HTML processors preserve bookmark lifecycle behavior.
+	 */
+	public function test_public_html_processor_bookmarks_with_native_defaults() {
+		if ( ! class_exists( 'WP_HTML_Native_Processor', false ) || ! method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Native_Processor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = WP_HTML_Processor::create_fragment( '<section><p id="one">One</p><p id="two">Two</p></section>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+
+		$this->assertTrue( $processor->next_tag( 'P' ) );
+		$this->assertSame( 'P', $processor->get_tag() );
+		$this->assertSame( 'one', $processor->get_attribute( 'id' ) );
+		$this->assertTrue( $processor->set_bookmark( 'saved-paragraph' ) );
+		$this->assertTrue( $processor->has_bookmark( 'saved-paragraph' ) );
+
+		$this->assertTrue( $processor->next_tag( 'P' ) );
+		$this->assertSame( 'P', $processor->get_tag() );
+		$this->assertSame( 'two', $processor->get_attribute( 'id' ) );
+
+		$this->assertTrue( $processor->seek( 'saved-paragraph' ) );
+		$this->assertSame( 'P', $processor->get_tag() );
+		$this->assertSame( 'one', $processor->get_attribute( 'id' ) );
+		$this->assertSame( array( 'HTML', 'BODY', 'SECTION', 'P' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->release_bookmark( 'saved-paragraph' ) );
+		$this->assertFalse( $processor->has_bookmark( 'saved-paragraph' ) );
+	}
+
+	/**
+	 * Verifies public HTML normalization keeps PHP serializer semantics with native defaults.
+	 */
+	public function test_public_html_normalize_uses_php_serializer_with_native_defaults() {
+		if ( ! class_exists( 'WP_HTML_Native_Processor', false ) || ! method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Native_Processor is not registered; load the native API extension to run this case.' );
+		}
+
+		$html      = '<a href=#anchor v=5 href="/" enabled>One</a another v=5><!--';
+		$expected  = '<a href="#anchor" v="5" enabled>One</a>';
+		$processor = WP_HTML_Processor::create_fragment( $html );
+
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertSame( $expected, $processor->serialize() );
+		$this->assertSame( $expected, WP_HTML_Processor::normalize( $html ) );
+	}
+
+	/**
+	 * Verifies public HTML serialization rejects already-started native defaults.
+	 */
+	public function test_public_html_serialize_rejects_started_processor_with_native_defaults() {
+		if ( ! class_exists( 'WP_HTML_Native_Processor', false ) || ! method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Native_Processor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = WP_HTML_Processor::create_fragment( '<p>Text</p>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_token() );
+		$this->assert_serialize_rejects_started_processor( $processor );
+
+		$processor = WP_HTML_Processor::create_fragment( '<p>Text</p>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, $processor->next_token_summary_batch( 1 ) );
+		$this->assert_serialize_rejects_started_processor( $processor );
+	}
+
+	/**
+	 * Verifies remaining-document native aggregates leave public tag processors complete.
+	 */
+	public function test_public_html_tag_aggregates_complete_native_default_processors() {
+		if ( ! class_exists( 'WP_HTML_Native_Tag_Processor', false ) || ! method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Native_Tag_Processor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = $this->create_tag_processor_state_probe( '<p class="a" data-kind="intro"><a href="/x" rel="next">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertSame(
+			array(
+				'tag_count'       => 2,
+				'attribute_count' => 1,
+			),
+			$processor->summarize_attribute_names_with_prefix( 'data-' )
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $processor->get_parser_state() );
+
+		$processor = $this->create_tag_processor_state_probe( '<p class="a" data-kind="intro"><a href="/x" rel="next">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'tag_count'       => 1,
+				'attribute_count' => 0,
+			),
+			$processor->summarize_attribute_names_with_prefix( 'data-' )
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $processor->get_parser_state() );
+
+		$processor = $this->create_tag_processor_state_probe( '<p class="a" data-kind="intro"><a href="/x" rel="next">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertSame(
+			array(
+				'tag_count'             => 2,
+				'open_tag_count'        => 2,
+				'closing_tag_count'     => 0,
+				'attribute_count'       => 4,
+				'unique_tag_name_count' => 2,
+			),
+			$processor->summarize_tag_inventory()
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $processor->get_parser_state() );
+
+		$processor = $this->create_tag_processor_state_probe( '<p class="a" data-kind="intro"><a href="/x" rel="next">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'tag_count'             => 1,
+				'open_tag_count'        => 1,
+				'closing_tag_count'     => 0,
+				'attribute_count'       => 2,
+				'unique_tag_name_count' => 1,
+			),
+			$processor->summarize_tag_inventory()
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $processor->get_parser_state() );
+
+		$processor = $this->create_tag_processor_state_probe( '<p><a href="/x" rel="next">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertSame(
+			array(
+				'tag_count'             => 1,
+				'attribute_count'       => 2,
+				'attribute_value_bytes' => 6,
+			),
+			$processor->summarize_matching_tag_attributes( 'a', array( 'href', 'rel' ) )
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $processor->get_parser_state() );
+
+		$processor = $this->create_tag_processor_state_probe( '<p><a href="/x" rel="next">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'tag_count'             => 1,
+				'attribute_count'       => 2,
+				'attribute_value_bytes' => 6,
+			),
+			$processor->summarize_matching_tag_attributes( 'a', array( 'href', 'rel' ) )
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $processor->get_parser_state() );
+
+		$processor = $this->create_tag_processor_state_probe( '<p data-kind="intro"><a href="/x" data-kind="link">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertSame(
+			array(
+				'tag_count'     => 2,
+				'removed_count' => 2,
+				'html'          => '<p ><a href="/x" >Link</a></p>',
+			),
+			$processor->remove_attributes_with_prefix_from_document( 'data-' )
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $processor->get_parser_state() );
+
+		$processor = $this->create_tag_processor_state_probe( '<p data-kind="intro"><a href="/x" data-kind="link">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'tag_count'     => 1,
+				'removed_count' => 1,
+				'html'          => '<p data-kind="intro"><a href="/x" >Link</a></p>',
+			),
+			$processor->remove_attributes_with_prefix_from_document( 'data-' )
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $processor->get_parser_state() );
+	}
+
+	/**
+	 * Verifies short native tag batches complete public tag processors.
+	 */
+	public function test_public_html_tag_batches_complete_native_default_processors() {
+		if ( ! class_exists( 'WP_HTML_Native_Tag_Processor', false ) || ! method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Native_Tag_Processor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a href="/one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 2, $processor->next_tag_summary_batch( 2 ) );
+		$this->assertCount( 1, $processor->next_tag_summary_batch( 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a data-id="one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 2, $processor->next_tag_prefix_summary_batch( 'data-', 2 ) );
+		$this->assertCount( 1, $processor->next_tag_prefix_summary_batch( 'data-', 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a data-id="one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertSame( "2\x1f1", $processor->next_tag_prefix_count_compact_batch( 'data-', 2 ) );
+		$this->assertSame( "1\x1f0", $processor->next_tag_prefix_count_compact_batch( 'data-', 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a href="/one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, $processor->next_matching_tag_summary_batch( 'A', 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a href="/one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, $processor->next_matching_tag_attribute_summary_batch( 'A', 'href', 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a href="/one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, $processor->next_matching_tag_attributes_summary_batch( 'A', array( 'href', 'data-id' ), 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+	}
+
+	/**
+	 * Verifies short native compact tag batches complete public tag processors.
+	 */
+	public function test_public_html_compact_tag_batches_complete_native_default_processors() {
+		if ( ! class_exists( 'WP_HTML_Native_Tag_Processor', false ) || ! method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Native_Tag_Processor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a href="/one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 2, explode( "\x1e", $processor->next_tag_compact_summary_batch( 2 ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_tag_compact_summary_batch( 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a data-id="one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 2, explode( "\x1e", $processor->next_tag_prefix_compact_summary_batch( 'data-', 2 ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_tag_prefix_compact_summary_batch( 'data-', 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a href="/one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_matching_tag_compact_summary_batch( 'A', 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a href="/one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_matching_tag_attribute_compact_summary_batch( 'A', 'href', 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = new WP_HTML_Tag_Processor( '<main><a href="/one">One</a><img src="/x"></main>' );
+		$this->assertSame( 'WP_HTML_Native_Tag_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_matching_tag_attributes_compact_summary_batch( 'A', array( 'href', 'data-id' ), 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+	}
+
+	/**
+	 * Verifies inherited aggregate scans complete public HTML processors too.
+	 */
+	public function test_public_html_processor_aggregates_complete_native_default_processors() {
+		if ( ! class_exists( 'WP_HTML_Native_Processor', false ) || ! method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Native_Processor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = WP_HTML_Processor::create_fragment( '<p data-kind="intro"><a href="/x" data-kind="link">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertSame(
+			array(
+				'tag_count'       => 2,
+				'attribute_count' => 2,
+			),
+			$processor->summarize_attribute_names_with_prefix( 'data-' )
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+
+		$processor = WP_HTML_Processor::create_fragment( '<p class="a" data-kind="intro"><a href="/x" rel="next">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'tag_count'       => 1,
+				'attribute_count' => 0,
+			),
+			$processor->summarize_attribute_names_with_prefix( 'data-' )
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+
+		$processor = WP_HTML_Processor::create_fragment( '<p class="a" data-kind="intro"><a href="/x" rel="next">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'tag_count'             => 1,
+				'open_tag_count'        => 1,
+				'closing_tag_count'     => 0,
+				'attribute_count'       => 2,
+				'unique_tag_name_count' => 1,
+			),
+			$processor->summarize_tag_inventory()
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+
+		$processor = WP_HTML_Processor::create_fragment( '<p><a href="/x" rel="next">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'tag_count'             => 1,
+				'attribute_count'       => 2,
+				'attribute_value_bytes' => 6,
+			),
+			$processor->summarize_matching_tag_attributes( 'a', array( 'href', 'rel' ) )
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+
+		$processor = WP_HTML_Processor::create_fragment( '<p data-kind="intro"><a href="/x" data-kind="link">Link</a></p>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'tag_count'     => 1,
+				'removed_count' => 1,
+				'html'          => '<p data-kind="intro"><a href="/x" >Link</a></p>',
+			),
+			$processor->remove_attributes_with_prefix_from_document( 'data-' )
+		);
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+	}
+
+	/**
+	 * Verifies native token summary batches complete public HTML processors.
+	 */
+	public function test_public_html_processor_token_batches_complete_native_default_processors() {
+		if ( ! class_exists( 'WP_HTML_Native_Processor', false ) || ! method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Native_Processor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = WP_HTML_Processor::create_fragment( '<section><p>Text</p></section>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 5, $processor->next_token_summary_batch( 64 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_token_type() );
+
+		$processor = WP_HTML_Processor::create_fragment( '<section><p>Text</p></section>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 2, $processor->next_token_summary_batch( 2 ) );
+		$this->assertCount( 2, $processor->next_token_summary_batch( 2 ) );
+		$this->assertCount( 1, $processor->next_token_summary_batch( 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_token_type() );
+
+		$processor = WP_HTML_Processor::create_fragment( '<section><p>Text</p></section>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$batch = $processor->next_token_compact_summary_batch( 64 );
+		$this->assertIsString( $batch );
+		$this->assertCount( 5, explode( "\x1e", $batch ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_token_type() );
+
+		$processor = WP_HTML_Processor::create_fragment( '<section><p>Text</p></section>' );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 2, explode( "\x1e", $processor->next_token_compact_summary_batch( 2 ) ) );
+		$this->assertCount( 2, explode( "\x1e", $processor->next_token_compact_summary_batch( 2 ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_token_compact_summary_batch( 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_token_type() );
+	}
+
+	/**
+	 * Verifies inherited native tag batches complete public HTML processors.
+	 */
+	public function test_public_html_processor_tag_batches_complete_native_default_processors() {
+		if ( ! class_exists( 'WP_HTML_Native_Processor', false ) || ! method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Native_Processor is not registered; load the native API extension to run this case.' );
+		}
+
+		$html = '<main><a href="/one" data-id="one">One</a><img src="/x"></main>';
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 2, $processor->next_tag_summary_batch( 2 ) );
+		$this->assertCount( 1, $processor->next_tag_summary_batch( 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 2, $processor->next_tag_prefix_summary_batch( 'data-', 2 ) );
+		$this->assertCount( 1, $processor->next_tag_prefix_summary_batch( 'data-', 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertSame( "2\x1f1", $processor->next_tag_prefix_count_compact_batch( 'data-', 2 ) );
+		$this->assertSame( "1\x1f0", $processor->next_tag_prefix_count_compact_batch( 'data-', 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, $processor->next_matching_tag_summary_batch( 'A', 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, $processor->next_matching_tag_attribute_summary_batch( 'A', 'href', 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, $processor->next_matching_tag_attributes_summary_batch( 'A', array( 'href', 'data-id' ), 2 ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+	}
+
+	/**
+	 * Verifies inherited native compact tag batches complete public HTML processors.
+	 */
+	public function test_public_html_processor_compact_tag_batches_complete_native_default_processors() {
+		if ( ! class_exists( 'WP_HTML_Native_Processor', false ) || ! method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) ) {
+			$this->markTestSkipped( 'WP_HTML_Native_Processor is not registered; load the native API extension to run this case.' );
+		}
+
+		$html = '<main><a href="/one" data-id="one">One</a><img src="/x"></main>';
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 2, explode( "\x1e", $processor->next_tag_compact_summary_batch( 2 ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_tag_compact_summary_batch( 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 2, explode( "\x1e", $processor->next_tag_prefix_compact_summary_batch( 'data-', 2 ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_tag_prefix_compact_summary_batch( 'data-', 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_matching_tag_compact_summary_batch( 'A', 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_matching_tag_attribute_compact_summary_batch( 'A', 'href', 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertSame( 'WP_HTML_Native_Processor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertCount( 1, explode( "\x1e", $processor->next_matching_tag_attributes_compact_summary_batch( 'A', array( 'href', 'data-id' ), 2 ) ) );
+		$this->assertSame( WP_HTML_Tag_Processor::STATE_COMPLETE, $this->get_parser_state( $processor ) );
+		$this->assertNull( $processor->get_tag() );
+	}
+
+	/**
+	 * Asserts that a started public HTML processor rejects serialization.
+	 *
+	 * @param WP_HTML_Processor $processor Started processor.
+	 */
+	private function assert_serialize_rejects_started_processor( $processor ) {
+		$warning = null;
+		set_error_handler(
+			function ( $error_number, $error_string ) use ( &$warning ) {
+				if ( E_USER_WARNING !== $error_number ) {
+					return false;
+				}
+
+				$warning = $error_string;
+
+				return true;
+			},
+			E_USER_WARNING
+		);
+
+		try {
+			$this->assertNull( $processor->serialize() );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertStringContainsString( 'already started processing cannot serialize', $warning );
+	}
+
+	/**
+	 * Creates a public tag processor exposing its parser state for conformance checks.
+	 *
+	 * @param string $html HTML to parse.
+	 * @return WP_HTML_Tag_Processor Tag processor with `get_parser_state()`.
+	 */
+	private function create_tag_processor_state_probe( $html ) {
+		return new class( $html ) extends WP_HTML_Tag_Processor {
+			public function get_parser_state() {
+				return $this->parser_state;
+			}
+		};
+	}
+
+	/**
+	 * Verifies the first native slice matches the PHP tag processor behavior.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_tags_and_attributes( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<!--comment--><MAIN data-z="7" DATA-a="post"><a href="/x?one=1&amp;two=2" title="A&#x2F;B&#47;C" data-label="A&nbsp;B&copy;&reg;&hellip;&mdash;&notin;">Link</a></MAIN>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the first HTML tag.' );
+		$this->assertSame( 'MAIN', $processor->get_tag() );
+		$this->assertSame( '7', $processor->get_attribute( 'data-z' ) );
+		$this->assertSame( 'post', $processor->get_attribute( 'data-a' ) );
+		$this->assertSame(
+			array( 'data-z', 'data-a' ),
+			$processor->get_attribute_names_with_prefix( 'data-' )
+		);
+		$this->skip_if_html_method_is_unavailable( $processor, 'count_attribute_names_with_prefix' );
+		$this->assertSame( 2, $processor->count_attribute_names_with_prefix( 'data-' ) );
+		$this->assertSame( 0, $processor->count_attribute_names_with_prefix( 'aria-' ) );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the nested anchor tag.' );
+		$this->assertSame( 'A', $processor->get_tag() );
+		$this->assertSame( '/x?one=1&two=2', $processor->get_attribute( 'href' ) );
+		$this->assertSame( 'A/B/C', $processor->get_attribute( 'title' ) );
+		$this->assertSame( "A\u{00a0}B\u{00a9}\u{00ae}\u{2026}\u{2014}\u{2209}", $processor->get_attribute( 'data-label' ) );
+		$this->assertFalse( $processor->next_tag(), 'next_tag() should skip closing tags by default.' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<p .x="dot" @x="at" data-x="ok">Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the paragraph tag with unusual attributes.' );
+		$this->assertSame( array( '.x', '@x', 'data-x' ), $processor->get_attribute_names_with_prefix( '' ) );
+		$this->assertSame( 'dot', $processor->get_attribute( '.x' ) );
+		$this->assertSame( 'at', $processor->get_attribute( '@x' ) );
+		$this->assertNull( $processor->get_attribute( 'x' ) );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<p =b a/=c data-x="ok">Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the paragraph tag with equals-start attributes.' );
+		$this->assertSame( array( '=b', 'a', '=c', 'data-x' ), $processor->get_attribute_names_with_prefix( '' ) );
+		$this->assertTrue( $processor->get_attribute( '=b' ) );
+		$this->assertTrue( $processor->get_attribute( '=c' ) );
+		$this->assertNull( $processor->get_attribute( 'b' ) );
+		$this->assertSame( array( '=b', '=c' ), $processor->get_attribute_names_with_prefix( '=' ) );
+		$this->assertSame( 2, $processor->count_attribute_names_with_prefix( '=' ) );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<div data-id="1"></div>'
+		);
+
+		$this->assertTrue( $this->next_tag_visiting_closers( $processor ), 'Expected the opening tag.' );
+		$this->assertSame( array( 'data-id' ), $processor->get_attribute_names_with_prefix( 'data-' ) );
+		$this->assertSame( 1, $processor->count_attribute_names_with_prefix( 'data-' ) );
+		$this->assertTrue( $this->next_tag_visiting_closers( $processor ), 'Expected the closing tag.' );
+		$this->assertTrue( $processor->is_tag_closer() );
+		$this->assertNull( $processor->get_attribute_names_with_prefix( 'data-' ) );
+		$this->assertNull( $processor->count_attribute_names_with_prefix( 'data-' ) );
+	}
+
+	/**
+	 * Verifies attribute removal works for the shared sanitization workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_removes_attributes( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main data-id="7" DATA-id="duplicate" class="entry"><a DATA-kind="nav" data-track="1" href="/x">Link</a></main>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the main tag.' );
+		$this->assertSame( array( 'data-id' ), $processor->get_attribute_names_with_prefix( 'data-' ) );
+		$this->assertTrue( $processor->remove_attribute( 'data-id' ) );
+		$this->assertNull( $processor->get_attribute( 'data-id' ) );
+		$this->assertSame(
+			'<main   class="entry"><a DATA-kind="nav" data-track="1" href="/x">Link</a></main>',
+			$processor->get_updated_html()
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the anchor tag after removing from the main tag.' );
+		$this->skip_if_html_method_is_unavailable( $processor, 'remove_attributes_with_prefix' );
+		$this->assertSame( 2, $processor->remove_attributes_with_prefix( 'data-' ) );
+		$this->assertNull( $processor->get_attribute( 'data-kind' ) );
+		$this->assertSame( 0, $processor->remove_attributes_with_prefix( 'data-' ) );
+		$this->assertSame(
+			'<main   class="entry"><a   href="/x">Link</a></main>',
+			$processor->get_updated_html()
+		);
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<p data-x disabled data-y="1">Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the paragraph tag with boolean attributes.' );
+		$this->assertTrue( $processor->remove_attribute( 'disabled' ) );
+		$this->assertSame( '<p data-x  data-y="1">Text</p>', $processor->get_updated_html() );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<p data-x disabled data-y="1">Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the paragraph tag with boolean attributes.' );
+		$this->assertSame( 3, $processor->remove_attributes_with_prefix( 'd' ) );
+		$this->assertSame( '<p   >Text</p>', $processor->get_updated_html() );
+	}
+
+	/**
+	 * Verifies document-level prefix removals match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_removes_prefixed_attributes_from_document( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main data-id="7" class="entry"><a DATA-kind="nav" data-track="1" href="/x">Link</a><img data-src="/x"></main>'
+		);
+
+		$this->assertSame(
+			array(
+				'tag_count'     => 5,
+				'removed_count' => 4,
+				'html'          => '<main  class="entry"><a   href="/x">Link</a><img ></main>',
+			),
+			$this->remove_attributes_with_prefix_from_document( $processor, 'data-', true )
+		);
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main data-id="7"><a data-kind="nav"></a></main>'
+		);
+
+		$this->assertTrue( $this->next_tag_visiting_closers( $processor ), 'Expected the opening main tag.' );
+		$this->assertSame(
+			array(
+				'tag_count'     => 1,
+				'removed_count' => 1,
+				'html'          => '<main data-id="7"><a ></a></main>',
+			),
+			$this->remove_attributes_with_prefix_from_document( $processor, 'data-', false )
+		);
+	}
+
+	/**
+	 * Verifies document-level prefix summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_prefixed_attributes( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main data-id="7"><a data-kind="nav" href="/x">Link</a><img data-src="/x"></main>'
+		);
+
+		$this->assertSame(
+			array(
+				'tag_count'       => 5,
+				'attribute_count' => 3,
+			),
+			$this->summarize_attribute_names_with_prefix( $processor, 'data-', true )
+		);
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main data-id="7"><a data-kind="nav" href="/x">Link</a><img data-src="/x"></main>'
+		);
+
+		$this->assertSame(
+			array(
+				'tag_count'       => 3,
+				'attribute_count' => 3,
+			),
+			$this->summarize_attribute_names_with_prefix( $processor, 'data-', false )
+		);
+	}
+
+	/**
+	 * Verifies document-level tag inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_tag_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main data-id="7"><a data-kind="nav" href="/x">Link</a><img data-src="/x"></main>'
+		);
+
+		$this->assertSame(
+			array(
+				'tag_count'             => 5,
+				'open_tag_count'        => 3,
+				'closing_tag_count'     => 2,
+				'attribute_count'       => 4,
+				'unique_tag_name_count' => 3,
+			),
+			$this->summarize_tag_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main data-id="7"><a data-kind="nav" href="/x">Link</a><img data-src="/x"></main>'
+		);
+
+		$this->assertSame(
+			array(
+				'tag_count'             => 3,
+				'open_tag_count'        => 3,
+				'closing_tag_count'     => 0,
+				'attribute_count'       => 4,
+				'unique_tag_name_count' => 3,
+			),
+			$this->summarize_tag_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies heading inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_heading_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$html = '<main><h1>A</h1><section><h2>B</h2><h3>C</h3></section></main>';
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'     => 10,
+				'heading_count' => 3,
+				'h1_count'      => 1,
+				'h2_count'      => 1,
+				'h3_count'      => 1,
+				'h4_count'      => 0,
+				'h5_count'      => 0,
+				'h6_count'      => 0,
+			),
+			$this->summarize_heading_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'     => 5,
+				'heading_count' => 3,
+				'h1_count'      => 1,
+				'h2_count'      => 1,
+				'h3_count'      => 1,
+				'h4_count'      => 0,
+				'h5_count'      => 0,
+				'h6_count'      => 0,
+			),
+			$this->summarize_heading_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies ID inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_id_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$html = '<main id="root"><p id="intro">One</p><section id="intro"><span id></span></section></main>';
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'          => 8,
+				'id_tag_count'       => 4,
+				'unique_id_count'    => 2,
+				'duplicate_id_count' => 1,
+				'id_value_bytes'     => 14,
+			),
+			$this->summarize_id_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'          => 4,
+				'id_tag_count'       => 4,
+				'unique_id_count'    => 2,
+				'duplicate_id_count' => 1,
+				'id_value_bytes'     => 14,
+			),
+			$this->summarize_id_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies attribute inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_attribute_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$html = '<main data-id="7" hidden><p class="x" title="A &amp; B">Text</p></main>';
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'                   => 4,
+				'attribute_count'             => 4,
+				'unique_attribute_name_count' => 4,
+				'attribute_value_bytes'       => 7,
+			),
+			$this->summarize_attribute_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'                   => 2,
+				'attribute_count'             => 4,
+				'unique_attribute_name_count' => 4,
+				'attribute_value_bytes'       => 7,
+			),
+			$this->summarize_attribute_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies data-attribute inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_data_attribute_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$html = '<div data-id="1" data-kind="hero" data-empty data-value="A &amp; B"></div><p data-kind="copy"></p>';
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'                        => 4,
+				'data_attribute_tag_count'         => 2,
+				'data_attribute_count'             => 5,
+				'unique_data_attribute_name_count' => 4,
+				'data_attribute_value_bytes'       => 14,
+			),
+			$this->summarize_data_attribute_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'                        => 2,
+				'data_attribute_tag_count'         => 2,
+				'data_attribute_count'             => 5,
+				'unique_data_attribute_name_count' => 4,
+				'data_attribute_value_bytes'       => 14,
+			),
+			$this->summarize_data_attribute_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies ARIA attribute inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_aria_attribute_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$html = '<button aria-label="Close" aria-expanded="false"></button><div aria-hidden aria-label="Panel" data-id="1"></div>';
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'                        => 4,
+				'aria_attribute_tag_count'         => 2,
+				'aria_attribute_count'             => 4,
+				'unique_aria_attribute_name_count' => 3,
+				'aria_attribute_value_bytes'       => 15,
+			),
+			$this->summarize_aria_attribute_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'                        => 2,
+				'aria_attribute_tag_count'         => 2,
+				'aria_attribute_count'             => 4,
+				'unique_aria_attribute_name_count' => 3,
+				'aria_attribute_value_bytes'       => 15,
+			),
+			$this->summarize_aria_attribute_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies class inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_class_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$html = '<main class="wrap entry"><p class="lede entry">Text</p><span class>Bool</span><div class="card primary primary"></div></main>';
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'               => 8,
+				'class_attribute_count'   => 4,
+				'class_name_count'        => 6,
+				'unique_class_name_count' => 5,
+				'class_value_bytes'       => 40,
+			),
+			$this->summarize_class_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'               => 4,
+				'class_attribute_count'   => 4,
+				'class_name_count'        => 6,
+				'unique_class_name_count' => 5,
+				'class_value_bytes'       => 40,
+			),
+			$this->summarize_class_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies resource inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_resource_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$html = '<main><a href="/one">One</a><img src="/one.png" alt=""><script src="/app.js"></script><link href="/main.css" rel="stylesheet"><source src="/clip.webm"><a>No href</a></main>';
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'                      => 10,
+				'resource_tag_count'             => 5,
+				'resource_attribute_count'       => 5,
+				'unique_resource_tag_name_count' => 5,
+				'resource_value_bytes'           => 38,
+			),
+			$this->summarize_resource_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'                      => 7,
+				'resource_tag_count'             => 5,
+				'resource_attribute_count'       => 5,
+				'unique_resource_tag_name_count' => 5,
+				'resource_value_bytes'           => 38,
+			),
+			$this->summarize_resource_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies image inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_image_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$html = '<img src="/a.png" alt=""><img src="/b.png" alt="Bee" width="10" height="20"><img alt><p></p>';
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'       => 5,
+				'image_count'     => 3,
+				'src_count'       => 2,
+				'alt_count'       => 3,
+				'empty_alt_count' => 2,
+				'dimension_count' => 1,
+				'src_value_bytes' => 12,
+				'alt_value_bytes' => 3,
+			),
+			$this->summarize_image_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'       => 4,
+				'image_count'     => 3,
+				'src_count'       => 2,
+				'alt_count'       => 3,
+				'empty_alt_count' => 2,
+				'dimension_count' => 1,
+				'src_value_bytes' => 12,
+				'alt_value_bytes' => 3,
+			),
+			$this->summarize_image_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies script inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_script_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$html = '<main><script src="/app.js" type="module" async></script><script>let a = 1;</script><script defer src="/legacy.js"></script></main>';
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'           => 5,
+				'script_count'        => 3,
+				'src_count'           => 2,
+				'module_count'        => 1,
+				'async_count'         => 1,
+				'defer_count'         => 1,
+				'inline_script_bytes' => 10,
+				'src_value_bytes'     => 17,
+			),
+			$this->summarize_script_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'           => 4,
+				'script_count'        => 3,
+				'src_count'           => 2,
+				'module_count'        => 1,
+				'async_count'         => 1,
+				'defer_count'         => 1,
+				'inline_script_bytes' => 10,
+				'src_value_bytes'     => 17,
+			),
+			$this->summarize_script_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies form inventory summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_form_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$html = '<form><input name="q"><input name="page"><input><button name="go"></button></form>';
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'                 => 7,
+				'form_count'                => 1,
+				'control_count'             => 4,
+				'named_control_count'       => 3,
+				'unique_control_name_count' => 3,
+				'control_name_value_bytes'  => 7,
+			),
+			$this->summarize_form_inventory( $processor, true )
+		);
+
+		$processor = $this->create_tag_processor( $implementation, $html );
+		$this->assertSame(
+			array(
+				'tag_count'                 => 5,
+				'form_count'                => 1,
+				'control_count'             => 4,
+				'named_control_count'       => 3,
+				'unique_control_name_count' => 3,
+				'control_name_value_bytes'  => 7,
+			),
+			$this->summarize_form_inventory( $processor, false )
+		);
+	}
+
+	/**
+	 * Verifies chunked prefix summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_prefix_summary_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main data-id="7"><a data-kind="nav" href="/x">Link</a><img data-src="/x"></main>'
+		);
+		$rows      = array();
+
+		do {
+			$batch = $this->next_tag_prefix_summary_batch( $processor, $implementation, 'data-', 2, true );
+			$rows  = array_merge( $rows, $batch );
+		} while ( ! empty( $batch ) );
+
+		$this->assertSame(
+			array( 'MAIN', 'A', 'A', 'IMG', 'MAIN' ),
+			array_column( $rows, 'tag_name' )
+		);
+		$this->assertSame(
+			array( false, false, true, false, true ),
+			array_column( $rows, 'is_tag_closer' )
+		);
+		$this->assertSame(
+			array( 1, 1, 0, 1, 0 ),
+			array_column( $rows, 'attribute_count' )
+		);
+		$this->assertSame( 5, count( $rows ) );
+
+		if ( 'tag-processor' === $implementation ) {
+			$processor = $this->create_tag_processor(
+				$implementation,
+				'<main data-id="7"><a data-kind="nav" href="/x">Link</a><img data-src="/x"></main>'
+			);
+			$this->assertSame(
+				"MAIN\x1f0\x1f1\x1eA\x1f0\x1f1",
+				$processor->next_tag_prefix_compact_summary_batch( 'data-', 2, true )
+			);
+		}
+	}
+
+	/**
+	 * Verifies chunked prefix count summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_prefix_count_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main data-id="7"><a data-kind="nav" href="/x">Link</a><img data-src="/x"></main>'
+		);
+		$summary   = array(
+			'tag_count'       => 0,
+			'attribute_count' => 0,
+		);
+
+		do {
+			$batch = $this->next_tag_prefix_count_batch( $processor, 'data-', 2, true );
+			if ( ! empty( $batch ) ) {
+				$summary['tag_count']       += $batch['tag_count'];
+				$summary['attribute_count'] += $batch['attribute_count'];
+			}
+		} while ( ! empty( $batch ) );
+
+		$this->assertSame(
+			array(
+				'tag_count'       => 5,
+				'attribute_count' => 3,
+			),
+			$summary
+		);
+	}
+
+	/**
+	 * Verifies chunked tag summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_tag_summary_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main data-id="7"><a href="/x">Link</a><img src="/x"></main>'
+		);
+		$rows      = array();
+
+		do {
+			$batch = $this->next_tag_summary_batch( $processor, $implementation, 2, true );
+			$rows  = array_merge( $rows, $batch );
+		} while ( ! empty( $batch ) );
+
+		$this->assertSame(
+			array( 'MAIN', 'A', 'A', 'IMG', 'MAIN' ),
+			array_column( $rows, 'tag_name' )
+		);
+		$this->assertSame(
+			array( false, false, true, false, true ),
+			array_column( $rows, 'is_tag_closer' )
+		);
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main><a>Link</a></main>'
+		);
+
+		$this->assertSame(
+			"MAIN\x1f0\x1eA\x1f0",
+			$processor->next_tag_compact_summary_batch( 2, true )
+		);
+	}
+
+	/**
+	 * Verifies chunked tag-name summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_matching_tag_summary_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main><a href="/one">One</a><span><a href="/two">Two</a></span><img src="/x"></main>'
+		);
+		$rows      = array();
+
+		do {
+			$batch = $this->next_matching_tag_summary_batch( $processor, $implementation, 'a', 2, true );
+			$rows  = array_merge( $rows, $batch );
+		} while ( ! empty( $batch ) );
+
+		$this->assertSame(
+			array( 'A', 'A', 'A', 'A' ),
+			array_column( $rows, 'tag_name' )
+		);
+		$this->assertSame(
+			array( false, true, false, true ),
+			array_column( $rows, 'is_tag_closer' )
+		);
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main><a>One</a><a>Two</a></main>'
+		);
+
+		$this->assertSame(
+			"A\x1f0\x1eA\x1f1",
+			$processor->next_matching_tag_compact_summary_batch( 'A', 2, true )
+		);
+	}
+
+	/**
+	 * Verifies chunked tag-name and attribute summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_matching_tag_attribute_summary_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main><a href="/one">One</a><span><a href="/two?x=1&amp;y=2">Two</a></span><a>No href</a></main>'
+		);
+		$rows      = array();
+
+		do {
+			$batch = $this->next_matching_tag_attribute_summary_batch( $processor, $implementation, 'a', 'href', 2, true );
+			$rows  = array_merge( $rows, $batch );
+		} while ( ! empty( $batch ) );
+
+		$this->assertSame(
+			array( 'A', 'A', 'A', 'A', 'A', 'A' ),
+			array_column( $rows, 'tag_name' )
+		);
+		$this->assertSame(
+			array( false, true, false, true, false, true ),
+			array_column( $rows, 'is_tag_closer' )
+		);
+		$this->assertSame(
+			array( '/one', null, '/two?x=1&y=2', null, null, null ),
+			array_column( $rows, 'attribute_value' )
+		);
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main><a href="/one">One</a><a>Two</a></main>'
+		);
+
+		$this->assertSame(
+			"A\x1f0\x1f1/one\x1eA\x1f1\x1f0",
+			$processor->next_matching_tag_attribute_compact_summary_batch( 'A', 'href', 2, true )
+		);
+	}
+
+	/**
+	 * Verifies chunked tag-name and multi-attribute summaries match the per-tag workflow.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_matching_tag_attributes_summary_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main><a href="/one" title="One &amp; two">One</a><span><a href="/two" rel>Two</a></span><a title="Three">Three</a></main>'
+		);
+		$rows      = array();
+
+		do {
+			$batch = $this->next_matching_tag_attributes_summary_batch( $processor, $implementation, 'a', array( 'href', 'title', 'rel' ), 2, true );
+			$rows  = array_merge( $rows, $batch );
+		} while ( ! empty( $batch ) );
+
+		$this->assertSame(
+			array( 'A', 'A', 'A', 'A', 'A', 'A' ),
+			array_column( $rows, 'tag_name' )
+		);
+		$this->assertSame(
+			array( false, true, false, true, false, true ),
+			array_column( $rows, 'is_tag_closer' )
+		);
+		$this->assertSame(
+			array(
+				array(
+					'href'  => '/one',
+					'title' => 'One & two',
+					'rel'   => null,
+				),
+				array(
+					'href'  => null,
+					'title' => null,
+					'rel'   => null,
+				),
+				array(
+					'href'  => '/two',
+					'title' => null,
+					'rel'   => '',
+				),
+				array(
+					'href'  => null,
+					'title' => null,
+					'rel'   => null,
+				),
+				array(
+					'href'  => null,
+					'title' => 'Three',
+					'rel'   => null,
+				),
+				array(
+					'href'  => null,
+					'title' => null,
+					'rel'   => null,
+				),
+			),
+			array_column( $rows, 'attribute_values' )
+		);
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main><a href="/one" title="One">One</a><a rel>Two</a></main>'
+		);
+
+		$this->assertSame(
+			"A\x1f0\x1f1/one\x1f1One\x1f0\x1eA\x1f1\x1f0\x1f0\x1f0",
+			$this->next_matching_tag_attributes_compact_summary_batch( $processor, $implementation, 'A', array( 'href', 'title', 'rel' ), 2, true )
+		);
+	}
+
+	/**
+	 * Verifies document-level tag-name and multi-attribute summaries.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_summarizes_matching_tag_attributes( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main><a href="/one" title="One &amp; two">One</a><span><a href="/two" rel>Two</a></span><a title="Three">Three</a></main>'
+		);
+
+		$this->assertSame(
+			array(
+				'tag_count'             => 6,
+				'attribute_count'       => 5,
+				'attribute_value_bytes' => 22,
+			),
+			$this->summarize_matching_tag_attributes( $processor, $implementation, 'a', array( 'href', 'title', 'rel' ), true )
+		);
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main><a href="/one" title="One &amp; two">One</a><span><a href="/two" rel>Two</a></span><a title="Three">Three</a></main>'
+		);
+
+		$this->assertSame(
+			array(
+				'tag_count'             => 3,
+				'attribute_count'       => 5,
+				'attribute_value_bytes' => 22,
+			),
+			$this->summarize_matching_tag_attributes( $processor, $implementation, 'A', array( 'href', 'title', 'rel' ), false )
+		);
+	}
+
+	/**
+	 * Verifies numeric and legacy character-reference decoding parity.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_decodes_numeric_and_legacy_character_references( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<a title="&#0 &#xD800 &#128 &#x85 &#x41 &copy &notin &ampx &notit;"></a><title>&notin &ampx &copyx &#x110000</title>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the anchor tag.' );
+		$this->assertSame( "\u{fffd} \u{fffd} \u{20ac} \u{2026} A \u{00a9} &notin &ampx &notit;", $processor->get_attribute( 'title' ) );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the title tag.' );
+		$this->assertSame( 'TITLE', $processor->get_token_name() );
+		$this->assertSame( "\u{00ac}in &x \u{00a9}x \u{fffd}", $processor->get_modifiable_text() );
+	}
+
+	/**
+	 * Verifies the native tag processor exposes DOCTYPE tokens like PHP userland.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_doctype_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		foreach (
+			array(
+				'<!DOCTYPE html>'    => ' html',
+				'<!DOCTYPE>'         => '',
+				'<!DOCTYPE svg>'     => ' svg',
+				'<!DOCTYPE 123>'     => ' 123',
+				'<!DOCTYPE html<p>'  => ' html<p',
+				'<!DOCTYPE html<!--x-->' => ' html<!--x--',
+			) as $doctype_html => $modifiable_text
+		) {
+			$processor = $this->create_tag_processor(
+				$implementation,
+				$doctype_html . '<p>Text</p>'
+			);
+
+			$this->assertTrue( $processor->next_token(), 'Expected the DOCTYPE token.' );
+			$this->assertSame( '#doctype', $processor->get_token_type() );
+			$this->assertSame( 'html', $processor->get_token_name() );
+			$this->assertSame( $modifiable_text, $processor->get_modifiable_text() );
+
+			$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip DOCTYPE and find the paragraph tag.' );
+			$this->assertSame( 'P', $processor->get_tag() );
+		}
+	}
+
+	/**
+	 * Verifies complete native tag-processor inputs do not report incomplete-token pauses.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reports_complete_input_status( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<main><p>Text</p></main>'
+		);
+
+		$this->assertFalse( $processor->paused_at_incomplete_token() );
+		$this->assertTrue( $processor->next_tag(), 'Expected the main tag.' );
+		$this->assertTrue( $processor->next_tag(), 'Expected the paragraph tag.' );
+		$this->assertFalse( $processor->next_tag(), 'Expected complete input to be exhausted.' );
+		$this->assertFalse( $processor->paused_at_incomplete_token() );
+	}
+
+	/**
+	 * Verifies comment metadata is exposed through the tag processor.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_comment_metadata( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<!--note--><p>Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the comment token.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertSame( 'note', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_HTML_COMMENT', $processor->get_comment_type() );
+		$this->assertSame( 'note', $processor->get_full_comment_text() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip the comment and find the paragraph tag.' );
+		$this->assertSame( 'P', $processor->get_tag() );
+		$this->assertNull( $processor->get_comment_type() );
+		$this->assertNull( $processor->get_full_comment_text() );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<!--note--!><p>Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the comment token with a --!> close.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( 'note', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_HTML_COMMENT', $processor->get_comment_type() );
+		$this->assertSame( 'note', $processor->get_full_comment_text() );
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to find the paragraph after the --!> comment.' );
+		$this->assertSame( 'P', $processor->get_tag() );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<!--note-- <p>Text</p>'
+		);
+
+		$this->assertFalse( $processor->next_token(), 'Unclosed comments should not expose a token.' );
+	}
+
+	/**
+	 * Verifies non-standard comment-like tokens expose PHP userland metadata.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_funky_comment_metadata( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<?pi.name data?><?1 data?><?pi data><![CDATA[x]]><!notdoctype><p>Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the processing-instruction-looking comment.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertSame( 'pi.name', $processor->get_tag() );
+		$this->assertSame( ' data', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_PI_NODE_LOOKALIKE', $processor->get_comment_type() );
+		$this->assertSame( '?pi.name data?', $processor->get_full_comment_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the invalid processing-instruction-looking comment with a numeric target.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertNull( $processor->get_tag() );
+		$this->assertSame( '1 data?', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_INVALID_HTML', $processor->get_comment_type() );
+		$this->assertSame( '?1 data?', $processor->get_full_comment_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the invalid processing-instruction-looking comment without XML-style close.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertNull( $processor->get_tag() );
+		$this->assertSame( 'pi data', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_INVALID_HTML', $processor->get_comment_type() );
+		$this->assertSame( '?pi data', $processor->get_full_comment_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the CDATA-looking comment.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertNull( $processor->get_tag() );
+		$this->assertSame( 'x', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_CDATA_LOOKALIKE', $processor->get_comment_type() );
+		$this->assertSame( '[CDATA[x]]', $processor->get_full_comment_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the invalid-HTML comment.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertNull( $processor->get_tag() );
+		$this->assertSame( 'notdoctype', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_INVALID_HTML', $processor->get_comment_type() );
+		$this->assertSame( 'notdoctype', $processor->get_full_comment_text() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip funky comments and find the paragraph tag.' );
+		$this->assertSame( 'P', $processor->get_tag() );
+	}
+
+	/**
+	 * Verifies presumptuous tags, funky closers, and abruptly closed comments match PHP userland.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_invalid_closing_and_abrupt_comment_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'</></1></%bad><//></ p></_x></:x><!--><!---><p>Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the presumptuous tag token.' );
+		$this->assertSame( '#presumptuous-tag', $processor->get_token_type() );
+		$this->assertSame( '#presumptuous-tag', $processor->get_token_name() );
+		$this->assertSame( '', $processor->get_modifiable_text() );
+		$this->assertNull( $processor->get_full_comment_text() );
+
+		foreach ( array( '1', '%bad', '/', ' p', '_x', ':x' ) as $expected_text ) {
+			$this->assertTrue( $processor->next_token(), 'Expected a funky closing comment token.' );
+			$this->assertSame( '#funky-comment', $processor->get_token_type() );
+			$this->assertSame( '#funky-comment', $processor->get_token_name() );
+			$this->assertSame( $expected_text, $processor->get_modifiable_text() );
+			$this->assertSame( $expected_text, $processor->get_full_comment_text() );
+		}
+
+		$this->assertTrue( $processor->next_token(), 'Expected the abruptly closed HTML comment.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertSame( '', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_ABRUPTLY_CLOSED_COMMENT', $processor->get_comment_type() );
+		$this->assertSame( '', $processor->get_full_comment_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the dash-abruptly closed HTML comment.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertSame( '', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_ABRUPTLY_CLOSED_COMMENT', $processor->get_comment_type() );
+		$this->assertSame( '', $processor->get_full_comment_text() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip invalid tokens and find the paragraph tag.' );
+		$this->assertSame( 'P', $processor->get_tag() );
+	}
+
+	/**
+	 * Verifies invalid opening tags remain text tokens like PHP userland.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_invalid_opening_tag_text_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'before &amp; <1><%bad><_x><:x><.x><-x>< p><p>Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected an invalid opening-tag text token.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( '#text', $processor->get_token_name() );
+		$this->assertSame( 'before & <1><%bad><_x><:x><.x><-x>< p>', $processor->get_modifiable_text() );
+		$this->assertNull( $processor->get_comment_type() );
+		$this->assertNull( $processor->get_full_comment_text() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip invalid text and find the paragraph tag.' );
+		$this->assertSame( 'P', $processor->get_tag() );
+
+		$processor = $this->create_tag_processor( $implementation, '<<p>Text</p><' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected adjacent invalid opening text.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( '<', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected valid paragraph after adjacent invalid opening text.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'P', $processor->get_tag() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected paragraph text.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( 'Text', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected paragraph closer.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'P', $processor->get_tag() );
+		$this->assertTrue( $processor->is_tag_closer() );
+
+		$this->assertFalse( $processor->next_token(), 'Expected a trailing lone < not to expose a token.' );
+
+		$processor = $this->create_tag_processor( $implementation, 'x<y <' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected text before an incomplete tag-like sequence.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( 'x', $processor->get_modifiable_text() );
+		$this->assertFalse( $processor->next_token(), 'Expected incomplete tag-like sequences not to expose tokens.' );
+
+		$processor = $this->create_tag_processor( $implementation, '<< <<p>Text</p>' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected consecutive invalid openings to coalesce.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( '<< <', $processor->get_modifiable_text() );
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to find the valid tag after consecutive invalid openings.' );
+		$this->assertSame( 'P', $processor->get_tag() );
+	}
+
+	/**
+	 * Verifies raw-text contents are attached to the opening tag like PHP userland.
+	 *
+	 * @dataProvider data_tag_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_tag_processor_reads_raw_text_element_contents( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Tag_Processor' );
+
+		$processor = $this->create_tag_processor(
+			$implementation,
+			'<script>if (a < b) { c(); }</script><iframe>A&amp;<b>C</b></iframe><noembed>D&amp;<i>E</i></noembed><noframes>F&amp;<u>G</u></noframes><xmp>H&amp;<q>I</q></xmp><title>A&amp;B&nbsp;&copy;</title><textarea>C&lt;D&hellip;</textarea><p>x</p>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the script token.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'SCRIPT', $processor->get_token_name() );
+		$this->assertSame( 'if (a < b) { c(); }', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the iframe token after the script contents.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'IFRAME', $processor->get_token_name() );
+		$this->assertSame( 'A&amp;<b>C</b>', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the noembed token after the iframe contents.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'NOEMBED', $processor->get_token_name() );
+		$this->assertSame( 'D&amp;<i>E</i>', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the noframes token after the noembed contents.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'NOFRAMES', $processor->get_token_name() );
+		$this->assertSame( 'F&amp;<u>G</u>', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the xmp token after the noframes contents.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'XMP', $processor->get_token_name() );
+		$this->assertSame( 'H&amp;<q>I</q>', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the title token after the script contents.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'TITLE', $processor->get_token_name() );
+		$this->assertSame( "A&B\u{00a0}\u{00a9}", $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the textarea token after the title contents.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'TEXTAREA', $processor->get_token_name() );
+		$this->assertSame( "C<D\u{2026}", $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the paragraph token after the script contents.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'P', $processor->get_token_name() );
+		$this->assertFalse( $processor->is_tag_closer(), 'The script closer should not be exposed as the next token.' );
+	}
+
+	/**
+	 * Verifies the first native slice matches the PHP HTML processor token stream.
+	 *
+	 * @dataProvider data_html_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_html_processor_reads_tag_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Processor' );
+
+		$processor = $this->create_html_processor(
+			$implementation,
+			'<section><p data-id="7">Text</p></section>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the section token.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'SECTION', $processor->get_token_name() );
+		$this->assertFalse( $processor->is_tag_closer() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the paragraph token.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'P', $processor->get_token_name() );
+		$this->assertFalse( $processor->is_tag_closer() );
+		$this->assertSame( '7', $processor->get_attribute( 'data-id' ) );
+
+		while ( $processor->next_token() && ! $processor->is_tag_closer() ) {
+			continue;
+		}
+
+		$this->assertTrue( $processor->is_tag_closer(), 'next_token() should expose closing tag tokens.' );
+		$this->assertSame( 'P', $processor->get_token_name() );
+	}
+
+	/**
+	 * Verifies the first native slice matches PHP HTML processor ancestry APIs.
+	 *
+	 * @dataProvider data_html_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_html_processor_reports_breadcrumbs_and_current_depth( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Processor' );
+
+		$processor = $this->create_html_processor(
+			$implementation,
+			'<section><p><img></p></section>'
+		);
+
+		$this->assertSame( 2, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the section token.' );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', 'SECTION' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the paragraph token.' );
+		$this->assertSame( 4, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', 'SECTION', 'P' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the image token.' );
+		$this->assertSame( 5, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', 'SECTION', 'P', 'IMG' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the paragraph closer.' );
+		$this->assertTrue( $processor->is_tag_closer(), 'Expected a closing paragraph token.' );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', 'SECTION' ), $processor->get_breadcrumbs() );
+	}
+
+	/**
+	 * Verifies text and comment tokens are visible through next_token().
+	 *
+	 * @dataProvider data_html_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_html_processor_reads_text_and_comment_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Processor' );
+
+		$processor = $this->create_html_processor(
+			$implementation,
+			'<p>Hello<!--note--><em>World</em></p>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the paragraph token.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'P', $processor->get_token_name() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the text token.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( '#text', $processor->get_token_name() );
+		$this->assertSame( 'Hello', $processor->get_modifiable_text() );
+		$this->assertSame( 4, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', 'P', '#text' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the comment token.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertSame( 'note', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_HTML_COMMENT', $processor->get_comment_type() );
+		$this->assertSame( 'note', $processor->get_full_comment_text() );
+		$this->assertSame( 4, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', 'P', '#comment' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the emphasis token.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'EM', $processor->get_token_name() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the nested text token.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( 'World', $processor->get_modifiable_text() );
+		$this->assertSame( 5, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', 'P', 'EM', '#text' ), $processor->get_breadcrumbs() );
+	}
+
+	/**
+	 * Verifies chunked HTML processor token summaries match next_token() metadata.
+	 *
+	 * @dataProvider data_html_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_html_processor_reads_token_summary_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Processor' );
+
+		$processor = $this->create_html_processor(
+			$implementation,
+			'<section><p data-id="7">Text</p><!--note--></section>'
+		);
+		$rows      = array();
+
+		do {
+			$batch = $this->next_html_token_summary_batch( $processor, $implementation, 2 );
+			$rows  = array_merge( $rows, $batch );
+		} while ( ! empty( $batch ) );
+
+		$this->assertSame(
+			array( '#tag', '#tag', '#text', '#tag', '#comment', '#tag' ),
+			array_column( $rows, 'token_type' )
+		);
+		$this->assertSame(
+			array( 'SECTION', 'P', '#text', 'P', '#comment', 'SECTION' ),
+			array_column( $rows, 'token_name' )
+		);
+		$this->assertSame(
+			array( false, false, false, true, false, true ),
+			array_column( $rows, 'is_tag_closer' )
+		);
+		$this->assertSame(
+			array( 3, 4, 5, 3, 4, 2 ),
+			array_column( $rows, 'current_depth' )
+		);
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'SECTION', 'P', '#text' ),
+			$rows[2]['breadcrumbs']
+		);
+
+		$processor = $this->create_html_processor(
+			$implementation,
+			'<section><p>Text</p></section>'
+		);
+
+		$this->assertSame(
+			"t\x1fSECTION\x1f0\x1f3\x1fHTML\x1dBODY\x1dSECTION\x1et\x1fP\x1f0\x1f4\x1fHTML\x1dBODY\x1dSECTION\x1dP",
+			$processor->next_token_compact_summary_batch( 2 )
+		);
+	}
+
+	/**
+	 * Verifies non-standard comment-like tokens stay visible in fragment parsing.
+	 *
+	 * @dataProvider data_html_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_html_processor_reads_funky_comment_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Processor' );
+
+		$processor = $this->create_html_processor(
+			$implementation,
+			'<?pi.name data?><?1 data?><?pi data><![CDATA[x]]><!notdoctype><p>Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the processing-instruction-looking comment.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertSame( 'pi.name', $processor->get_tag() );
+		$this->assertSame( ' data', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_PI_NODE_LOOKALIKE', $processor->get_comment_type() );
+		$this->assertSame( '?pi.name data?', $processor->get_full_comment_text() );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', '#comment' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the invalid processing-instruction-looking comment with a numeric target.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertNull( $processor->get_tag() );
+		$this->assertSame( '1 data?', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_INVALID_HTML', $processor->get_comment_type() );
+		$this->assertSame( '?1 data?', $processor->get_full_comment_text() );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', '#comment' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the invalid processing-instruction-looking comment without XML-style close.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertNull( $processor->get_tag() );
+		$this->assertSame( 'pi data', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_INVALID_HTML', $processor->get_comment_type() );
+		$this->assertSame( '?pi data', $processor->get_full_comment_text() );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', '#comment' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the CDATA-looking comment.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertNull( $processor->get_tag() );
+		$this->assertSame( 'x', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_CDATA_LOOKALIKE', $processor->get_comment_type() );
+		$this->assertSame( '[CDATA[x]]', $processor->get_full_comment_text() );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', '#comment' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the invalid-HTML comment.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertNull( $processor->get_tag() );
+		$this->assertSame( 'notdoctype', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_INVALID_HTML', $processor->get_comment_type() );
+		$this->assertSame( 'notdoctype', $processor->get_full_comment_text() );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', '#comment' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip funky comments and find the paragraph tag.' );
+		$this->assertSame( 'P', $processor->get_token_name() );
+	}
+
+	/**
+	 * Verifies processor handling of invalid closing and abruptly closed comment tokens.
+	 *
+	 * @dataProvider data_html_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_html_processor_reads_invalid_closing_and_abrupt_comment_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Processor' );
+
+		$processor = $this->create_html_processor(
+			$implementation,
+			'</></1></%bad><//></ p></_x></:x><!--><!---><p>Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the presumptuous tag token.' );
+		$this->assertSame( '#presumptuous-tag', $processor->get_token_type() );
+		$this->assertSame( '#presumptuous-tag', $processor->get_token_name() );
+		$this->assertSame( '', $processor->get_modifiable_text() );
+		$this->assertNull( $processor->get_full_comment_text() );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', '#presumptuous-tag' ), $processor->get_breadcrumbs() );
+
+		foreach ( array( '1', '%bad', '/', ' p', '_x', ':x' ) as $expected_text ) {
+			$this->assertTrue( $processor->next_token(), 'Expected a funky closing comment token.' );
+			$this->assertSame( '#funky-comment', $processor->get_token_type() );
+			$this->assertSame( '#funky-comment', $processor->get_token_name() );
+			$this->assertSame( $expected_text, $processor->get_modifiable_text() );
+			$this->assertSame( $expected_text, $processor->get_full_comment_text() );
+			$this->assertSame( 3, $processor->get_current_depth() );
+			$this->assertSame( array( 'HTML', 'BODY', '#funky-comment' ), $processor->get_breadcrumbs() );
+		}
+
+		$this->assertTrue( $processor->next_token(), 'Expected the abruptly closed HTML comment.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertSame( '', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_ABRUPTLY_CLOSED_COMMENT', $processor->get_comment_type() );
+		$this->assertSame( '', $processor->get_full_comment_text() );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', '#comment' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the dash-abruptly closed HTML comment.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertSame( '', $processor->get_modifiable_text() );
+		$this->assertSame( 'COMMENT_AS_ABRUPTLY_CLOSED_COMMENT', $processor->get_comment_type() );
+		$this->assertSame( '', $processor->get_full_comment_text() );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', '#comment' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip invalid tokens and find the paragraph tag.' );
+		$this->assertSame( 'P', $processor->get_token_name() );
+	}
+
+	/**
+	 * Verifies invalid opening tags stay visible as text in fragment parsing.
+	 *
+	 * @dataProvider data_html_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_html_processor_reads_invalid_opening_tag_text_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Processor' );
+
+		$processor = $this->create_html_processor(
+			$implementation,
+			'before &amp; <1><%bad><_x><:x><.x><-x>< p><p>Text</p>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected an invalid opening-tag text token.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( '#text', $processor->get_token_name() );
+		$this->assertSame( 'before & <1><%bad><_x><:x><.x><-x>< p>', $processor->get_modifiable_text() );
+		$this->assertNull( $processor->get_comment_type() );
+		$this->assertNull( $processor->get_full_comment_text() );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame( array( 'HTML', 'BODY', '#text' ), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip invalid text and find the paragraph tag.' );
+		$this->assertSame( 'P', $processor->get_token_name() );
+
+		$processor = $this->create_html_processor( $implementation, '<<p>Text</p><' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected adjacent invalid opening text.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( '<', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected valid paragraph after adjacent invalid opening text.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'P', $processor->get_token_name() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected paragraph text.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( 'Text', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected paragraph closer.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'P', $processor->get_token_name() );
+		$this->assertTrue( $processor->is_tag_closer() );
+
+		$this->assertFalse( $processor->next_token(), 'Expected a trailing lone < not to expose a token.' );
+
+		$processor = $this->create_html_processor( $implementation, 'x<y <' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected text before an incomplete tag-like sequence.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( 'x', $processor->get_modifiable_text() );
+		$this->assertFalse( $processor->next_token(), 'Expected incomplete tag-like sequences not to expose tokens.' );
+
+		$processor = $this->create_html_processor( $implementation, '<< <<p>Text</p>' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected consecutive invalid openings to coalesce.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( '<< <', $processor->get_modifiable_text() );
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to find the valid tag after consecutive invalid openings.' );
+		$this->assertSame( 'P', $processor->get_token_name() );
+	}
+
+	/**
+	 * Verifies table, list, option, and paragraph fragments synthesize implied tokens.
+	 *
+	 * @dataProvider data_html_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_html_processor_synthesizes_selected_implied_closers( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Processor' );
+
+		$cases = array(
+			'table-cells' => array(
+				'<table><tr><td>A<td>B</tr></table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-bare-cells' => array(
+				'<table><td>A<td>B</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-explicit-sections' => array(
+				'<table><thead><tr><th>A<th>B</thead><tbody><tr><td>C</tbody></table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'THEAD', false, array( 'HTML', 'BODY', 'TABLE', 'THEAD' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'THEAD', 'TR' ) ),
+					array( 'TH', false, array( 'HTML', 'BODY', 'TABLE', 'THEAD', 'TR', 'TH' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'THEAD', 'TR', 'TH', '#text' ) ),
+					array( 'TH', true, array( 'HTML', 'BODY', 'TABLE', 'THEAD', 'TR' ) ),
+					array( 'TH', false, array( 'HTML', 'BODY', 'TABLE', 'THEAD', 'TR', 'TH' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'THEAD', 'TR', 'TH', '#text' ) ),
+					array( 'TH', true, array( 'HTML', 'BODY', 'TABLE', 'THEAD', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'THEAD' ) ),
+					array( 'THEAD', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-repeated-body-sections' => array(
+				'<table><tbody><tr><td>a<tbody><tr><td>b</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-colgroup' => array(
+				'<table><col><tr><td>A</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'COLGROUP', false, array( 'HTML', 'BODY', 'TABLE', 'COLGROUP' ) ),
+					array( 'COL', false, array( 'HTML', 'BODY', 'TABLE', 'COLGROUP', 'COL' ) ),
+					array( 'COLGROUP', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-caption' => array(
+				'<table><caption>A<tr><td>B</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'CAPTION', false, array( 'HTML', 'BODY', 'TABLE', 'CAPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'CAPTION', '#text' ) ),
+					array( 'CAPTION', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-caption-after-row' => array(
+				'<table><tr><td>x<caption>c</caption></table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'CAPTION', false, array( 'HTML', 'BODY', 'TABLE', 'CAPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'CAPTION', '#text' ) ),
+					array( 'CAPTION', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-caption-after-colgroup' => array(
+				'<table><colgroup><col><caption>c</caption></table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'COLGROUP', false, array( 'HTML', 'BODY', 'TABLE', 'COLGROUP' ) ),
+					array( 'COL', false, array( 'HTML', 'BODY', 'TABLE', 'COLGROUP', 'COL' ) ),
+					array( 'COLGROUP', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'CAPTION', false, array( 'HTML', 'BODY', 'TABLE', 'CAPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'CAPTION', '#text' ) ),
+					array( 'CAPTION', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-stray-row-closer-ignored' => array(
+				'<table></tr><tr><td>x</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-stray-caption-closer-ignored' => array(
+				'<table><tr><td>x</caption><tr><td>y</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-unsupported-stray-closer-aborts-table' => array(
+				'<table></p><tr><td>x</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+				),
+			),
+			'table-template-stray-closer-ignored' => array(
+				'<table></template><tr><td>x</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-form-before-row' => array(
+				'<table><form><tr><td>x</td></tr></table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'FORM', false, array( 'HTML', 'BODY', 'TABLE', 'FORM' ) ),
+					array( 'FORM', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-explicit-form-before-row' => array(
+				'<table><form></form><tr><td>x</td></tr></table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'FORM', false, array( 'HTML', 'BODY', 'TABLE', 'FORM' ) ),
+					array( 'FORM', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+				),
+			),
+			'table-form-whitespace-before-row' => array(
+				'<table><form> <tr><td>x</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'FORM', false, array( 'HTML', 'BODY', 'TABLE', 'FORM' ) ),
+					array( 'FORM', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', '#text' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-form-text-aborts-table' => array(
+				'<table><form>x<tr><td>y</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'FORM', false, array( 'HTML', 'BODY', 'TABLE', 'FORM' ) ),
+					array( 'FORM', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+				),
+			),
+			'table-form-comment-before-row' => array(
+				'<table><form><!--x--><tr><td>y</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'FORM', false, array( 'HTML', 'BODY', 'TABLE', 'FORM' ) ),
+					array( 'FORM', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( '#comment', false, array( 'HTML', 'BODY', 'TABLE', '#comment' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-form-script-before-row' => array(
+				'<table><form><script>x</script><tr><td>y</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'FORM', false, array( 'HTML', 'BODY', 'TABLE', 'FORM' ) ),
+					array( 'FORM', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'SCRIPT', false, array( 'HTML', 'BODY', 'TABLE', 'SCRIPT' ) ),
+					array( 'TBODY', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TR', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TD', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR', 'TD', '#text' ) ),
+					array( 'TD', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY', 'TR' ) ),
+					array( 'TR', true, array( 'HTML', 'BODY', 'TABLE', 'TBODY' ) ),
+					array( 'TBODY', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'TABLE', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-form-flow-start-aborts-table' => array(
+				'<table><form><div>x</div><tr><td>y</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( 'FORM', false, array( 'HTML', 'BODY', 'TABLE', 'FORM' ) ),
+					array( 'FORM', true, array( 'HTML', 'BODY', 'TABLE' ) ),
+				),
+			),
+			'table-flow-start-aborts-table' => array(
+				'<table><select>x</select><tr><td>y</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+				),
+			),
+			'table-inline-start-aborts-table' => array(
+				'<table><span>x</span><tr><td>y</table>',
+				array(
+					array( 'TABLE', false, array( 'HTML', 'BODY', 'TABLE' ) ),
+				),
+			),
+			'list-items' => array(
+				'<ul><li>One<li>Two</ul>',
+				array(
+					array( 'UL', false, array( 'HTML', 'BODY', 'UL' ) ),
+					array( 'LI', false, array( 'HTML', 'BODY', 'UL', 'LI' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'UL', 'LI', '#text' ) ),
+					array( 'LI', true, array( 'HTML', 'BODY', 'UL' ) ),
+					array( 'LI', false, array( 'HTML', 'BODY', 'UL', 'LI' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'UL', 'LI', '#text' ) ),
+					array( 'LI', true, array( 'HTML', 'BODY', 'UL' ) ),
+					array( 'UL', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'ordinary-eof-closers' => array(
+				'<div><span>Text',
+				array(
+					array( 'DIV', false, array( 'HTML', 'BODY', 'DIV' ) ),
+					array( 'SPAN', false, array( 'HTML', 'BODY', 'DIV', 'SPAN' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'DIV', 'SPAN', '#text' ) ),
+					array( 'SPAN', true, array( 'HTML', 'BODY', 'DIV' ) ),
+					array( 'DIV', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'void-child-eof-closer' => array(
+				'<a><img>',
+				array(
+					array( 'A', false, array( 'HTML', 'BODY', 'A' ) ),
+					array( 'IMG', false, array( 'HTML', 'BODY', 'A', 'IMG' ) ),
+					array( 'A', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'options'    => array(
+				'<select><option>A<option>B</select>',
+				array(
+					array( 'SELECT', false, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'OPTION', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION', '#text' ) ),
+					array( 'OPTION', true, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'OPTION', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION', '#text' ) ),
+					array( 'OPTION', true, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'SELECT', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'paragraphs' => array(
+				'<p>One<p>Two',
+				array(
+					array( 'P', false, array( 'HTML', 'BODY', 'P' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( 'P', true, array( 'HTML', 'BODY' ) ),
+					array( 'P', false, array( 'HTML', 'BODY', 'P' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( 'P', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'paragraph-before-block' => array(
+				'<p>Text<div>Block</div>',
+				array(
+					array( 'P', false, array( 'HTML', 'BODY', 'P' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( 'P', true, array( 'HTML', 'BODY' ) ),
+					array( 'DIV', false, array( 'HTML', 'BODY', 'DIV' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'DIV', '#text' ) ),
+					array( 'DIV', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'paragraph-before-heading' => array(
+				'<p>Text<h1>Heading</h1>',
+				array(
+					array( 'P', false, array( 'HTML', 'BODY', 'P' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( 'P', true, array( 'HTML', 'BODY' ) ),
+					array( 'H1', false, array( 'HTML', 'BODY', 'H1' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'H1', '#text' ) ),
+					array( 'H1', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'paragraph-before-inline' => array(
+				'<p>Text<span>Inline</span>',
+				array(
+					array( 'P', false, array( 'HTML', 'BODY', 'P' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( 'SPAN', false, array( 'HTML', 'BODY', 'P', 'SPAN' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'P', 'SPAN', '#text' ) ),
+					array( 'SPAN', true, array( 'HTML', 'BODY', 'P' ) ),
+					array( 'P', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'heading-before-heading' => array(
+				'<h1>One<h2>Two</h2>',
+				array(
+					array( 'H1', false, array( 'HTML', 'BODY', 'H1' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'H1', '#text' ) ),
+					array( 'H1', true, array( 'HTML', 'BODY' ) ),
+					array( 'H2', false, array( 'HTML', 'BODY', 'H2' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'H2', '#text' ) ),
+					array( 'H2', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'heading-before-inline' => array(
+				'<h1>One<span>Span</span>',
+				array(
+					array( 'H1', false, array( 'HTML', 'BODY', 'H1' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'H1', '#text' ) ),
+					array( 'SPAN', false, array( 'HTML', 'BODY', 'H1', 'SPAN' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'H1', 'SPAN', '#text' ) ),
+					array( 'SPAN', true, array( 'HTML', 'BODY', 'H1' ) ),
+					array( 'H1', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'button-before-button' => array(
+				'<button><span>One<button>Two</button>',
+				array(
+					array( 'BUTTON', false, array( 'HTML', 'BODY', 'BUTTON' ) ),
+					array( 'SPAN', false, array( 'HTML', 'BODY', 'BUTTON', 'SPAN' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'BUTTON', 'SPAN', '#text' ) ),
+					array( 'SPAN', true, array( 'HTML', 'BODY', 'BUTTON' ) ),
+					array( 'BUTTON', true, array( 'HTML', 'BODY' ) ),
+					array( 'BUTTON', false, array( 'HTML', 'BODY', 'BUTTON' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'BUTTON', '#text' ) ),
+					array( 'BUTTON', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'button-explicit-closer' => array(
+				'<button><span>One</button>',
+				array(
+					array( 'BUTTON', false, array( 'HTML', 'BODY', 'BUTTON' ) ),
+					array( 'SPAN', false, array( 'HTML', 'BODY', 'BUTTON', 'SPAN' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'BUTTON', 'SPAN', '#text' ) ),
+					array( 'SPAN', true, array( 'HTML', 'BODY', 'BUTTON' ) ),
+					array( 'BUTTON', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'summary-before-details-closer' => array(
+				'<details><summary>One<summary>Two</summary></details>',
+				array(
+					array( 'DETAILS', false, array( 'HTML', 'BODY', 'DETAILS' ) ),
+					array( 'SUMMARY', false, array( 'HTML', 'BODY', 'DETAILS', 'SUMMARY' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'DETAILS', 'SUMMARY', '#text' ) ),
+					array( 'SUMMARY', false, array( 'HTML', 'BODY', 'DETAILS', 'SUMMARY', 'SUMMARY' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'DETAILS', 'SUMMARY', 'SUMMARY', '#text' ) ),
+					array( 'SUMMARY', true, array( 'HTML', 'BODY', 'DETAILS', 'SUMMARY' ) ),
+					array( 'SUMMARY', true, array( 'HTML', 'BODY', 'DETAILS' ) ),
+					array( 'DETAILS', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'nested-form-start-ignored' => array(
+				'<form>One<form>Two</form>',
+				array(
+					array( 'FORM', false, array( 'HTML', 'BODY', 'FORM' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'FORM', '#text' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'FORM', '#text' ) ),
+					array( 'FORM', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'nobr-before-nobr' => array(
+				'<nobr>One<nobr>Two</nobr>',
+				array(
+					array( 'NOBR', false, array( 'HTML', 'BODY', 'NOBR' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'NOBR', '#text' ) ),
+					array( 'NOBR', true, array( 'HTML', 'BODY' ) ),
+					array( 'NOBR', false, array( 'HTML', 'BODY', 'NOBR' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'NOBR', '#text' ) ),
+					array( 'NOBR', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'nobr-explicit-closer' => array(
+				'<nobr><span>One</nobr>',
+				array(
+					array( 'NOBR', false, array( 'HTML', 'BODY', 'NOBR' ) ),
+					array( 'SPAN', false, array( 'HTML', 'BODY', 'NOBR', 'SPAN' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'NOBR', 'SPAN', '#text' ) ),
+					array( 'SPAN', true, array( 'HTML', 'BODY', 'NOBR' ) ),
+					array( 'NOBR', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'select-before-input' => array(
+				'<select><option>A<input>B</select>',
+				array(
+					array( 'SELECT', false, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'OPTION', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION', '#text' ) ),
+					array( 'OPTION', true, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'SELECT', true, array( 'HTML', 'BODY' ) ),
+					array( 'INPUT', false, array( 'HTML', 'BODY', 'INPUT' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', '#text' ) ),
+				),
+			),
+			'select-option-before-hr' => array(
+				'<select><option>A<hr>B</select>',
+				array(
+					array( 'SELECT', false, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'OPTION', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION', '#text' ) ),
+					array( 'OPTION', true, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'HR', false, array( 'HTML', 'BODY', 'SELECT', 'HR' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'SELECT', '#text' ) ),
+					array( 'SELECT', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'select-before-textarea' => array(
+				'<select><option>A<textarea>B</textarea></select>',
+				array(
+					array( 'SELECT', false, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'OPTION', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION', '#text' ) ),
+					array( 'OPTION', true, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'SELECT', true, array( 'HTML', 'BODY' ) ),
+					array( 'TEXTAREA', false, array( 'HTML', 'BODY', 'TEXTAREA' ) ),
+				),
+			),
+			'html-and-body-starts-ignored' => array(
+				'<html><body><body><p>x',
+				array(
+					array( 'P', false, array( 'HTML', 'BODY', 'P' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( 'P', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'description-list' => array(
+				'<dl><dt>A<dd>B<dt>C</dl>',
+				array(
+					array( 'DL', false, array( 'HTML', 'BODY', 'DL' ) ),
+					array( 'DT', false, array( 'HTML', 'BODY', 'DL', 'DT' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'DL', 'DT', '#text' ) ),
+					array( 'DT', true, array( 'HTML', 'BODY', 'DL' ) ),
+					array( 'DD', false, array( 'HTML', 'BODY', 'DL', 'DD' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'DL', 'DD', '#text' ) ),
+					array( 'DD', true, array( 'HTML', 'BODY', 'DL' ) ),
+					array( 'DT', false, array( 'HTML', 'BODY', 'DL', 'DT' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'DL', 'DT', '#text' ) ),
+					array( 'DT', true, array( 'HTML', 'BODY', 'DL' ) ),
+					array( 'DL', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'ruby-text' => array(
+				'<ruby>a<rt>b<rp>(<rt>c</ruby>',
+				array(
+					array( 'RUBY', false, array( 'HTML', 'BODY', 'RUBY' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'RUBY', '#text' ) ),
+					array( 'RT', false, array( 'HTML', 'BODY', 'RUBY', 'RT' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'RUBY', 'RT', '#text' ) ),
+					array( 'RT', true, array( 'HTML', 'BODY', 'RUBY' ) ),
+					array( 'RP', false, array( 'HTML', 'BODY', 'RUBY', 'RP' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'RUBY', 'RP', '#text' ) ),
+					array( 'RP', true, array( 'HTML', 'BODY', 'RUBY' ) ),
+					array( 'RT', false, array( 'HTML', 'BODY', 'RUBY', 'RT' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'RUBY', 'RT', '#text' ) ),
+					array( 'RT', true, array( 'HTML', 'BODY', 'RUBY' ) ),
+					array( 'RUBY', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'optgroups' => array(
+				'<select><option>A<optgroup label=b><option>B<optgroup label=c><option>C</select>',
+				array(
+					array( 'SELECT', false, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'OPTION', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'SELECT', 'OPTION', '#text' ) ),
+					array( 'OPTION', true, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'OPTGROUP', false, array( 'HTML', 'BODY', 'SELECT', 'OPTGROUP' ) ),
+					array( 'OPTION', false, array( 'HTML', 'BODY', 'SELECT', 'OPTGROUP', 'OPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'SELECT', 'OPTGROUP', 'OPTION', '#text' ) ),
+					array( 'OPTION', true, array( 'HTML', 'BODY', 'SELECT', 'OPTGROUP' ) ),
+					array( 'OPTGROUP', true, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'OPTGROUP', false, array( 'HTML', 'BODY', 'SELECT', 'OPTGROUP' ) ),
+					array( 'OPTION', false, array( 'HTML', 'BODY', 'SELECT', 'OPTGROUP', 'OPTION' ) ),
+					array( '#text', false, array( 'HTML', 'BODY', 'SELECT', 'OPTGROUP', 'OPTION', '#text' ) ),
+					array( 'OPTION', true, array( 'HTML', 'BODY', 'SELECT', 'OPTGROUP' ) ),
+					array( 'OPTGROUP', true, array( 'HTML', 'BODY', 'SELECT' ) ),
+					array( 'SELECT', true, array( 'HTML', 'BODY' ) ),
+				),
+			),
+		);
+
+		foreach ( $cases as $label => $case ) {
+			$processor = $this->create_html_processor( $implementation, $case[0] );
+
+			foreach ( $case[1] as $expected ) {
+				$this->assertTrue( $processor->next_token(), "Expected {$label} token." );
+				$this->assertSame( $expected[0], $processor->get_token_name(), "Unexpected {$label} token name." );
+				$this->assertSame( $expected[1], $processor->is_tag_closer(), "Unexpected {$label} closer flag." );
+				$this->assertSame( $expected[2], $processor->get_breadcrumbs(), "Unexpected {$label} breadcrumbs." );
+			}
+
+			$this->assertFalse( $processor->next_token(), "Expected {$label} to be exhausted." );
+		}
+	}
+
+	/**
+	 * Verifies HTML processor text-token subdivision and table-text boundaries.
+	 *
+	 * @dataProvider data_html_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_html_processor_subdivides_selected_text_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation, 'WP_HTML_Native_Processor' );
+
+		$cases = array(
+			'body-text-leading-whitespace' => array(
+				'<p> A <b>B</b></p>',
+				array(
+					array( 'P', '', array( 'HTML', 'BODY', 'P' ) ),
+					array( '#text', ' ', array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( '#text', 'A ', array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( 'B', '', array( 'HTML', 'BODY', 'P', 'B' ) ),
+					array( '#text', 'B', array( 'HTML', 'BODY', 'P', 'B', '#text' ) ),
+					array( 'B', '', array( 'HTML', 'BODY', 'P' ) ),
+					array( 'P', '', array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'body-text-reference-leading-whitespace' => array(
+				'<p> &#10;&#x20;A</p>',
+				array(
+					array( 'P', '', array( 'HTML', 'BODY', 'P' ) ),
+					array( '#text', " \n ", array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( '#text', 'A', array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( 'P', '', array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'body-text-raw-null' => array(
+				"<p>\0 A\0B</p>",
+				array(
+					array( 'P', '', array( 'HTML', 'BODY', 'P' ) ),
+					array( '#text', ' ', array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( '#text', 'AB', array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( 'P', '', array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'body-text-newlines' => array(
+				"<p>\r\n\tA\rB</p>",
+				array(
+					array( 'P', '', array( 'HTML', 'BODY', 'P' ) ),
+					array( '#text', "\n\t", array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( '#text', "A\nB", array( 'HTML', 'BODY', 'P', '#text' ) ),
+					array( 'P', '', array( 'HTML', 'BODY' ) ),
+				),
+			),
+			'table-text-leading-whitespace' => array(
+				'<table> A <tr><td>B</table>',
+				array(
+					array( 'TABLE', '', array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( '#text', ' ', array( 'HTML', 'BODY', 'TABLE', '#text' ) ),
+				),
+			),
+			'table-text-reference-leading-whitespace' => array(
+				'<table>&#x20;A<tr><td>B</table>',
+				array(
+					array( 'TABLE', '', array( 'HTML', 'BODY', 'TABLE' ) ),
+					array( '#text', ' ', array( 'HTML', 'BODY', 'TABLE', '#text' ) ),
+				),
+			),
+			'table-text-no-leading-whitespace' => array(
+				'<table>A<tr><td>B</table>',
+				array(
+					array( 'TABLE', '', array( 'HTML', 'BODY', 'TABLE' ) ),
+				),
+			),
+		);
+
+		foreach ( $cases as $label => $case ) {
+			$processor = $this->create_html_processor( $implementation, $case[0] );
+
+			foreach ( $case[1] as $expected ) {
+				$this->assertTrue( $processor->next_token(), "Expected {$label} token." );
+				$this->assertSame( $expected[0], $processor->get_token_name(), "Unexpected {$label} token name." );
+				$this->assertSame( $expected[1], $processor->get_modifiable_text(), "Unexpected {$label} text." );
+				$this->assertSame( $expected[2], $processor->get_breadcrumbs(), "Unexpected {$label} breadcrumbs." );
+			}
+
+			$this->assertFalse( $processor->next_token(), "Expected {$label} to be exhausted." );
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_tag_processor_implementations() {
+		return array(
+			'php-tag-processor'    => array( 'php-tag-processor' ),
+			'native-tag-processor' => array( 'native-tag-processor' ),
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_html_processor_implementations() {
+		return array(
+			'php-html-processor'    => array( 'php-html-processor' ),
+			'native-html-processor' => array( 'native-html-processor' ),
+		);
+	}
+
+	/**
+	 * Creates a tag processor for a specific implementation.
+	 *
+	 * @param string $implementation Implementation identifier.
+	 * @param string $html           HTML input.
+	 * @return object Processor instance.
+	 */
+	private function create_tag_processor( $implementation, $html ) {
+		if ( 'native-tag-processor' === $implementation ) {
+			return new WP_HTML_Native_Tag_Processor( $html );
+		}
+
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$this->disable_native_delegate( $processor );
+
+		return $processor;
+	}
+
+	/**
+	 * Creates an HTML processor for a specific implementation.
+	 *
+	 * @param string $implementation Implementation identifier.
+	 * @param string $html           HTML input.
+	 * @return object Processor instance.
+	 */
+	private function create_html_processor( $implementation, $html ) {
+		if ( 'native-html-processor' === $implementation ) {
+			return WP_HTML_Native_Processor::create_fragment( $html );
+		}
+
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->disable_native_delegate( $processor );
+
+		return $processor;
+	}
+
+	/**
+	 * Disables the native delegate so PHP implementation rows still cover PHP.
+	 *
+	 * @param object $processor Processor instance.
+	 */
+	private function disable_native_delegate( $processor ) {
+		if ( ! property_exists( 'WP_HTML_Tag_Processor', 'native_processor' ) ) {
+			return;
+		}
+
+		$property = new ReflectionProperty( 'WP_HTML_Tag_Processor', 'native_processor' );
+		$property->setAccessible( true );
+		$property->setValue( $processor, null );
+	}
+
+	/**
+	 * Returns the native delegate for public-class default checks.
+	 *
+	 * @param object $processor Processor instance.
+	 * @return object|null Native delegate.
+	 */
+	private function get_native_delegate( $processor ) {
+		if ( ! property_exists( 'WP_HTML_Tag_Processor', 'native_processor' ) ) {
+			return null;
+		}
+
+		$property = new ReflectionProperty( 'WP_HTML_Tag_Processor', 'native_processor' );
+		$property->setAccessible( true );
+
+		return $property->getValue( $processor );
+	}
+
+	/**
+	 * Runs a fresh PHP process that defines native-default constants before bootstrap.
+	 *
+	 * @param string $constant_definitions PHP source defining constants.
+	 * @return string[] Probe output lines.
+	 */
+	private function run_html_native_defaults_constant_probe( $constant_definitions ) {
+		$root      = dirname( __DIR__, 3 );
+		$extension = $root . '/extensions/native-apis/target/release/libwp_native_apis.so';
+
+		if ( ! file_exists( $extension ) ) {
+			$this->markTestSkipped( 'Native API extension binary is not built.' );
+		}
+
+		$code = $constant_definitions . "\n" .
+			'require ' . var_export( $root . '/bootstrap.php', true ) . ";\n" .
+			'$property = new ReflectionProperty( \'WP_HTML_Tag_Processor\', \'native_processor\' );' . "\n" .
+			'$property->setAccessible( true );' . "\n" .
+			'$tag_processor = new WP_HTML_Tag_Processor( \'<p data-id="1">Text</p>\' );' . "\n" .
+			'$tag_delegate = $property->getValue( $tag_processor );' . "\n" .
+			'echo \'tag:\' . ( null === $tag_delegate ? \'php\' : get_class( $tag_delegate ) ) . "\n";' . "\n" .
+			'$tag_processor->next_tag( \'p\' );' . "\n" .
+			'echo \'tag-id:\' . $tag_processor->get_attribute( \'data-id\' ) . "\n";' . "\n" .
+			'$html_processor = WP_HTML_Processor::create_fragment( \'<p>Text</p>\' );' . "\n" .
+			'$tree_delegate = $property->getValue( $html_processor );' . "\n" .
+			'echo \'tree:\' . ( null === $tree_delegate ? \'php\' : get_class( $tree_delegate ) ) . "\n";' . "\n" .
+			'$html_processor->next_token();' . "\n" .
+			'echo \'tree-token:\' . $html_processor->get_token_name() . "\n";' . "\n" .
+			'$full_processor = WP_HTML_Processor::create_full_parser( \'<html><body><main>Text</main></body></html>\' );' . "\n" .
+			'$full_delegate = $property->getValue( $full_processor );' . "\n" .
+			'echo \'full:\' . ( null === $full_delegate ? \'php\' : get_class( $full_delegate ) ) . "\n";' . "\n" .
+			'$full_processor->next_token();' . "\n" .
+			'echo \'full-token:\' . $full_processor->get_token_name() . "\n";';
+
+		$command = escapeshellarg( PHP_BINARY ) . ' -d extension=' . escapeshellarg( $extension ) . ' -r ' . escapeshellarg( $code );
+		$output  = array();
+		$status  = 0;
+		exec( $command . ' 2>&1', $output, $status );
+
+		$this->assertSame( 0, $status, implode( "\n", $output ) );
+
+		return $output;
+	}
+
+	/**
+	 * Returns the public parser state for lifecycle conformance checks.
+	 *
+	 * @param object $processor Processor instance.
+	 * @return string Parser state.
+	 */
+	private function get_parser_state( $processor ) {
+		$property = new ReflectionProperty( 'WP_HTML_Tag_Processor', 'parser_state' );
+		$property->setAccessible( true );
+
+		return $property->getValue( $processor );
+	}
+
+	/**
+	 * Advances either tag-processor implementation while visiting closers.
+	 *
+	 * @param object $processor Processor instance.
+	 * @return bool Whether a tag was matched.
+	 */
+	private function next_tag_visiting_closers( $processor ) {
+		if ( method_exists( $processor, 'next_tag_any' ) ) {
+			return $processor->next_tag_any( true, 1 );
+		}
+
+		return $processor->next_tag( array( 'tag_closers' => 'visit' ) );
+	}
+
+	/**
+	 * Skips implementation rows when an API is provided only by the native class.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param string $method    Method name.
+	 */
+	private function skip_if_html_method_is_unavailable( $processor, $method ) {
+		if ( ! method_exists( $processor, $method ) ) {
+			$this->markTestSkipped( "{$method} is not exposed by this HTML processor implementation." );
+		}
+	}
+
+	/**
+	 * Summarizes prefixed attributes for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param string $prefix    Attribute-name prefix.
+	 * @param bool   $closers   Whether to include closing tags in the tag count.
+	 * @return array Summary with `tag_count` and `attribute_count`.
+	 */
+	private function summarize_attribute_names_with_prefix( $processor, $prefix, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_attribute_names_with_prefix' );
+
+		$summary = $processor->summarize_attribute_names_with_prefix( $prefix, $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 2 );
+
+		return array(
+			'tag_count'       => (int) $parts[0],
+			'attribute_count' => (int) $parts[1],
+		);
+	}
+
+	/**
+	 * Summarizes tag inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with tag inventory counts.
+	 */
+	private function summarize_tag_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_tag_inventory' );
+
+		$summary = $processor->summarize_tag_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 5 );
+
+		return array(
+			'tag_count'             => (int) $parts[0],
+			'open_tag_count'        => (int) $parts[1],
+			'closing_tag_count'     => (int) $parts[2],
+			'attribute_count'       => (int) $parts[3],
+			'unique_tag_name_count' => (int) $parts[4],
+		);
+	}
+
+	/**
+	 * Summarizes heading inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with heading inventory counts.
+	 */
+	private function summarize_heading_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_heading_inventory' );
+
+		$summary = $processor->summarize_heading_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 8 );
+
+		return array(
+			'tag_count'     => (int) $parts[0],
+			'heading_count' => (int) $parts[1],
+			'h1_count'      => (int) $parts[2],
+			'h2_count'      => (int) $parts[3],
+			'h3_count'      => (int) $parts[4],
+			'h4_count'      => (int) $parts[5],
+			'h5_count'      => (int) $parts[6],
+			'h6_count'      => (int) $parts[7],
+		);
+	}
+
+	/**
+	 * Summarizes ID inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with ID inventory counts.
+	 */
+	private function summarize_id_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_id_inventory' );
+
+		$summary = $processor->summarize_id_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 5 );
+
+		return array(
+			'tag_count'          => (int) $parts[0],
+			'id_tag_count'       => (int) $parts[1],
+			'unique_id_count'    => (int) $parts[2],
+			'duplicate_id_count' => (int) $parts[3],
+			'id_value_bytes'     => (int) $parts[4],
+		);
+	}
+
+	/**
+	 * Summarizes attribute inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with attribute inventory counts.
+	 */
+	private function summarize_attribute_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_attribute_inventory' );
+
+		$summary = $processor->summarize_attribute_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 4 );
+
+		return array(
+			'tag_count'                   => (int) $parts[0],
+			'attribute_count'             => (int) $parts[1],
+			'unique_attribute_name_count' => (int) $parts[2],
+			'attribute_value_bytes'       => (int) $parts[3],
+		);
+	}
+
+	/**
+	 * Summarizes data-attribute inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with data-attribute inventory counts.
+	 */
+	private function summarize_data_attribute_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_data_attribute_inventory' );
+
+		$summary = $processor->summarize_data_attribute_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 5 );
+
+		return array(
+			'tag_count'                        => (int) $parts[0],
+			'data_attribute_tag_count'         => (int) $parts[1],
+			'data_attribute_count'             => (int) $parts[2],
+			'unique_data_attribute_name_count' => (int) $parts[3],
+			'data_attribute_value_bytes'       => (int) $parts[4],
+		);
+	}
+
+	/**
+	 * Summarizes ARIA attribute inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with ARIA attribute inventory counts.
+	 */
+	private function summarize_aria_attribute_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_aria_attribute_inventory' );
+
+		$summary = $processor->summarize_aria_attribute_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 5 );
+
+		return array(
+			'tag_count'                        => (int) $parts[0],
+			'aria_attribute_tag_count'         => (int) $parts[1],
+			'aria_attribute_count'             => (int) $parts[2],
+			'unique_aria_attribute_name_count' => (int) $parts[3],
+			'aria_attribute_value_bytes'       => (int) $parts[4],
+		);
+	}
+
+	/**
+	 * Summarizes class inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with class inventory counts.
+	 */
+	private function summarize_class_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_class_inventory' );
+
+		$summary = $processor->summarize_class_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 5 );
+
+		return array(
+			'tag_count'               => (int) $parts[0],
+			'class_attribute_count'   => (int) $parts[1],
+			'class_name_count'        => (int) $parts[2],
+			'unique_class_name_count' => (int) $parts[3],
+			'class_value_bytes'       => (int) $parts[4],
+		);
+	}
+
+	/**
+	 * Summarizes resource inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with resource inventory counts.
+	 */
+	private function summarize_resource_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_resource_inventory' );
+
+		$summary = $processor->summarize_resource_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 5 );
+
+		return array(
+			'tag_count'                      => (int) $parts[0],
+			'resource_tag_count'             => (int) $parts[1],
+			'resource_attribute_count'       => (int) $parts[2],
+			'unique_resource_tag_name_count' => (int) $parts[3],
+			'resource_value_bytes'           => (int) $parts[4],
+		);
+	}
+
+	/**
+	 * Summarizes image inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with image inventory counts.
+	 */
+	private function summarize_image_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_image_inventory' );
+
+		$summary = $processor->summarize_image_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 8 );
+
+		return array(
+			'tag_count'       => (int) $parts[0],
+			'image_count'     => (int) $parts[1],
+			'src_count'       => (int) $parts[2],
+			'alt_count'       => (int) $parts[3],
+			'empty_alt_count' => (int) $parts[4],
+			'dimension_count' => (int) $parts[5],
+			'src_value_bytes' => (int) $parts[6],
+			'alt_value_bytes' => (int) $parts[7],
+		);
+	}
+
+	/**
+	 * Summarizes script inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with script inventory counts.
+	 */
+	private function summarize_script_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_script_inventory' );
+
+		$summary = $processor->summarize_script_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 8 );
+
+		return array(
+			'tag_count'           => (int) $parts[0],
+			'script_count'        => (int) $parts[1],
+			'src_count'           => (int) $parts[2],
+			'module_count'        => (int) $parts[3],
+			'async_count'         => (int) $parts[4],
+			'defer_count'         => (int) $parts[5],
+			'inline_script_bytes' => (int) $parts[6],
+			'src_value_bytes'     => (int) $parts[7],
+		);
+	}
+
+	/**
+	 * Summarizes form inventory for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array Summary with form inventory counts.
+	 */
+	private function summarize_form_inventory( $processor, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_form_inventory' );
+
+		$summary = $processor->summarize_form_inventory( $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 6 );
+
+		return array(
+			'tag_count'                 => (int) $parts[0],
+			'form_count'                => (int) $parts[1],
+			'control_count'             => (int) $parts[2],
+			'named_control_count'       => (int) $parts[3],
+			'unique_control_name_count' => (int) $parts[4],
+			'control_name_value_bytes'  => (int) $parts[5],
+		);
+	}
+
+	/**
+	 * Summarizes matching tag attributes for either public or native processors.
+	 *
+	 * @param object $processor       Processor instance.
+	 * @param string $implementation  Implementation identifier.
+	 * @param string $tag_name        Tag name to match.
+	 * @param array  $attribute_names Attribute names to read.
+	 * @param bool   $closers         Whether to include closing tags in the tag count.
+	 * @return array Summary with `tag_count`, `attribute_count`, and `attribute_value_bytes`.
+	 */
+	private function summarize_matching_tag_attributes( $processor, $implementation, $tag_name, $attribute_names, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'summarize_matching_tag_attributes' );
+
+		if ( 'native-tag-processor' === $implementation ) {
+			$summary = $processor->summarize_matching_tag_attributes( $tag_name, implode( "\x1f", $attribute_names ), $closers );
+		} else {
+			$summary = $processor->summarize_matching_tag_attributes( $tag_name, $attribute_names, $closers );
+		}
+
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 3 );
+
+		return array(
+			'tag_count'             => (int) $parts[0],
+			'attribute_count'       => (int) $parts[1],
+			'attribute_value_bytes' => (int) $parts[2],
+		);
+	}
+
+	/**
+	 * Removes prefixed attributes for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param string $prefix    Attribute-name prefix.
+	 * @param bool   $closers   Whether to include closing tags in the tag count.
+	 * @return array Summary with `tag_count`, `removed_count`, and `html`.
+	 */
+	private function remove_attributes_with_prefix_from_document( $processor, $prefix, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'remove_attributes_with_prefix_from_document' );
+
+		$summary = $processor->remove_attributes_with_prefix_from_document( $prefix, $closers );
+		if ( is_array( $summary ) ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 3 );
+
+		return array(
+			'tag_count'     => (int) $parts[0],
+			'removed_count' => (int) $parts[1],
+			'html'          => $parts[2],
+		);
+	}
+
+	/**
+	 * Reads a chunked tag-prefix summary for either public or native processors.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param string $prefix         Attribute-name prefix.
+	 * @param int    $max_tags       Maximum number of tag rows.
+	 * @param bool   $closers        Whether to include closing tags.
+	 * @return array[] Tag summary rows.
+	 */
+	private function next_tag_prefix_summary_batch( $processor, $implementation, $prefix, $max_tags, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'next_tag_prefix_summary_batch' );
+
+		$batch = $processor->next_tag_prefix_summary_batch( $prefix, $max_tags, $closers );
+		if ( 'native-tag-processor' !== $implementation ) {
+			return $batch;
+		}
+
+		if ( ! is_string( $batch ) || '' === $batch ) {
+			return array();
+		}
+
+		$rows = array();
+		foreach ( explode( "\x1e", $batch ) as $metadata ) {
+			$parts = explode( "\x1f", $metadata, 3 );
+			$this->assertCount( 3, $parts, 'Expected compact HTML tag summary row.' );
+
+			$rows[] = array(
+				'tag_name'        => $parts[0],
+				'is_tag_closer'   => '1' === $parts[1],
+				'attribute_count' => (int) $parts[2],
+			);
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Reads a chunked tag-prefix count summary for either public or native processors.
+	 *
+	 * @param object $processor Processor instance.
+	 * @param string $prefix    Attribute-name prefix.
+	 * @param int    $max_tags  Maximum number of tags to consume.
+	 * @param bool   $closers   Whether to include closing tags.
+	 * @return array|null Summary with `tag_count` and `attribute_count`, or null when exhausted.
+	 */
+	private function next_tag_prefix_count_batch( $processor, $prefix, $max_tags, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'next_tag_prefix_count_compact_batch' );
+
+		$summary = $processor->next_tag_prefix_count_compact_batch( $prefix, $max_tags, $closers );
+		if ( ! is_string( $summary ) || '' === $summary ) {
+			return null;
+		}
+
+		$parts = explode( "\x1f", $summary, 2 );
+		$this->assertCount( 2, $parts, 'Expected compact HTML tag prefix count batch.' );
+
+		return array(
+			'tag_count'       => (int) $parts[0],
+			'attribute_count' => (int) $parts[1],
+		);
+	}
+
+	/**
+	 * Reads a chunked tag summary for either public or native processors.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param int    $max_tags       Maximum number of tag rows.
+	 * @param bool   $closers        Whether to include closing tags.
+	 * @return array[] Tag summary rows.
+	 */
+	private function next_tag_summary_batch( $processor, $implementation, $max_tags, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'next_tag_summary_batch' );
+
+		return $processor->next_tag_summary_batch( $max_tags, $closers );
+	}
+
+	/**
+	 * Reads a chunked matching-tag summary for either public or native processors.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param string $tag_name       Tag name to match.
+	 * @param int    $max_tags       Maximum number of tag rows.
+	 * @param bool   $closers        Whether to include closing tags.
+	 * @return array[] Tag summary rows.
+	 */
+	private function next_matching_tag_summary_batch( $processor, $implementation, $tag_name, $max_tags, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'next_matching_tag_summary_batch' );
+
+		return $processor->next_matching_tag_summary_batch( $tag_name, $max_tags, $closers );
+	}
+
+	/**
+	 * Reads a chunked matching-tag attribute summary for either public or native processors.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param string $tag_name       Tag name to match.
+	 * @param string $attribute_name Attribute name to read.
+	 * @param int    $max_tags       Maximum number of tag rows.
+	 * @param bool   $closers        Whether to include closing tags.
+	 * @return array[] Tag summary rows.
+	 */
+	private function next_matching_tag_attribute_summary_batch( $processor, $implementation, $tag_name, $attribute_name, $max_tags, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'next_matching_tag_attribute_summary_batch' );
+
+		return $processor->next_matching_tag_attribute_summary_batch( $tag_name, $attribute_name, $max_tags, $closers );
+	}
+
+	/**
+	 * Reads a chunked matching-tag multi-attribute summary for either public or native processors.
+	 *
+	 * @param object $processor       Processor instance.
+	 * @param string $implementation  Implementation identifier.
+	 * @param string $tag_name        Tag name to match.
+	 * @param array  $attribute_names Attribute names to read.
+	 * @param int    $max_tags        Maximum number of tag rows.
+	 * @param bool   $closers         Whether to include closing tags.
+	 * @return array[] Tag summary rows.
+	 */
+	private function next_matching_tag_attributes_summary_batch( $processor, $implementation, $tag_name, $attribute_names, $max_tags, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'next_matching_tag_attributes_summary_batch' );
+
+		return $processor->next_matching_tag_attributes_summary_batch( $tag_name, $attribute_names, $max_tags, $closers );
+	}
+
+	/**
+	 * Reads a compact chunked matching-tag multi-attribute summary.
+	 *
+	 * @param object $processor       Processor instance.
+	 * @param string $implementation  Implementation identifier.
+	 * @param string $tag_name        Tag name to match.
+	 * @param array  $attribute_names Attribute names to read.
+	 * @param int    $max_tags        Maximum number of tag rows.
+	 * @param bool   $closers         Whether to include closing tags.
+	 * @return string|null Compact tag summary batch, or null when exhausted.
+	 */
+	private function next_matching_tag_attributes_compact_summary_batch( $processor, $implementation, $tag_name, $attribute_names, $max_tags, $closers ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'next_matching_tag_attributes_compact_summary_batch' );
+
+		if ( 'native-tag-processor' === $implementation ) {
+			return $processor->next_matching_tag_attributes_compact_summary_batch( $tag_name, implode( "\x1f", $attribute_names ), $max_tags, $closers );
+		}
+
+		return $processor->next_matching_tag_attributes_compact_summary_batch( $tag_name, $attribute_names, $max_tags, $closers );
+	}
+
+	/**
+	 * Reads a chunked HTML token summary for either public or native processors.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param int    $max_tokens     Maximum number of token rows.
+	 * @return array[] Token summary rows.
+	 */
+	private function next_html_token_summary_batch( $processor, $implementation, $max_tokens ) {
+		$this->skip_if_html_method_is_unavailable( $processor, 'next_token_summary_batch' );
+
+		return $processor->next_token_summary_batch( $max_tokens );
+	}
+
+	/**
+	 * Skips native implementation cases when the extension is unavailable.
+	 *
+	 * @param string $implementation Implementation identifier.
+	 * @param string $class_name     Native class name.
+	 */
+	private function skip_if_native_is_unavailable( $implementation, $class_name ) {
+		if ( 0 === strpos( $implementation, 'native-' ) && ! class_exists( $class_name, false ) ) {
+			$this->markTestSkipped( $class_name . ' is not registered; load the native API extension to run this case.' );
+		}
+	}
+}

--- a/components/HTML/class-wp-html-native-processor-wrapper.php
+++ b/components/HTML/class-wp-html-native-processor-wrapper.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Public HTML Processor native adapter.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ */
+
+class WP_HTML_Native_Processor_Wrapper extends WP_HTML_Native_Processor {}

--- a/components/HTML/class-wp-html-native-tag-processor-wrapper.php
+++ b/components/HTML/class-wp-html-native-tag-processor-wrapper.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Public HTML Tag Processor native adapter.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ */
+
+class WP_HTML_Native_Tag_Processor_Wrapper extends WP_HTML_Native_Tag_Processor {}

--- a/components/HTML/class-wp-html-processor.php
+++ b/components/HTML/class-wp-html-processor.php
@@ -1,0 +1,31 @@
+<?php
+// phpcs:disable Generic.Classes.DuplicateClassName.Found,Generic.Files.OneObjectStructurePerFile.MultipleFound
+/**
+ * Public HTML processor loader.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ */
+
+if ( ! class_exists( 'WP_HTML_Tag_Processor', false ) ) {
+	require_once __DIR__ . '/class-wp-html-tag-processor.php';
+}
+
+$wp_html_use_native_processor =
+	class_exists( 'WP_HTML_Native_Processor', false ) &&
+	class_exists( 'WP_HTML_Native_Tag_Processor', false ) &&
+	method_exists( 'WP_HTML_Native_Processor', 'supports_public_api' ) &&
+	method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) &&
+	( ! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) || ! WP_NATIVE_APIS_DISABLE_DEFAULTS );
+
+if ( $wp_html_use_native_processor ) {
+	require_once __DIR__ . '/class-wp-html-native-processor-wrapper.php';
+
+	class WP_HTML_Processor extends WP_HTML_Native_Processor_Wrapper {}
+} else {
+	require_once __DIR__ . '/PHP/class-wp-html-php-processor.php';
+
+	class WP_HTML_Processor extends WP_HTML_PHP_Processor {}
+}
+
+unset( $wp_html_use_native_processor );

--- a/components/HTML/class-wp-html-tag-processor.php
+++ b/components/HTML/class-wp-html-tag-processor.php
@@ -1,0 +1,25 @@
+<?php
+// phpcs:disable Generic.Classes.DuplicateClassName.Found,Generic.Files.OneObjectStructurePerFile.MultipleFound
+/**
+ * Public HTML tag processor loader.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ */
+
+$wp_html_use_native_tag_processor =
+	class_exists( 'WP_HTML_Native_Tag_Processor', false ) &&
+	method_exists( 'WP_HTML_Native_Tag_Processor', 'supports_public_api' ) &&
+	( ! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) || ! WP_NATIVE_APIS_DISABLE_DEFAULTS );
+
+if ( $wp_html_use_native_tag_processor ) {
+	require_once __DIR__ . '/class-wp-html-native-tag-processor-wrapper.php';
+
+	class WP_HTML_Tag_Processor extends WP_HTML_Native_Tag_Processor_Wrapper {}
+} else {
+	require_once __DIR__ . '/PHP/class-wp-html-php-tag-processor.php';
+
+	class WP_HTML_Tag_Processor extends WP_HTML_PHP_Tag_Processor {}
+}
+
+unset( $wp_html_use_native_tag_processor );

--- a/components/Markdown/class-markdownproducer.php
+++ b/components/Markdown/class-markdownproducer.php
@@ -158,7 +158,6 @@ class MarkdownProducer implements DataFormatProducer {
 					} elseif ( ( 'TH' === $tag || 'TD' === $tag ) && ! $is_closer ) {
 						$cell_content  = $processor->get_inner_html();
 						$current_row[] = $this->html_to_markdown( $cell_content );
-						$processor->skip_to_closer();
 					}
 				}
 

--- a/components/XML/PHP/class-phpxmlprocessor.php
+++ b/components/XML/PHP/class-phpxmlprocessor.php
@@ -341,7 +341,7 @@ use function WordPress\Encoding\utf8_ord;
  *
  * @since WP_VERSION
  */
-class XMLProcessor {
+class PHPXMLProcessor {
 	/**
 	 * The maximum number of bookmarks allowed to exist at
 	 * any given time.

--- a/components/XML/README.md
+++ b/components/XML/README.md
@@ -9,11 +9,16 @@ see_also:
   - bytestream | ByteStream | Keep large XML reads incremental.
 ---
 
-A streaming, namespace-aware XML processor in pure PHP. Read huge feeds, WXR exports, ePub manifests, and Office Open XML parts incrementally, then emit edited XML without depending on <code>libxml2</code>.
+A streaming, namespace-aware XML processor in pure PHP. Read and modify huge feeds, WXR exports, ePub manifests, and Office Open XML parts without ever loading the document into memory and without depending on <code>libxml2</code>.
+
+When the native API extension is loaded, <code>XMLProcessor</code> can use a
+native delegate by default while preserving PHP fallback behavior. Define
+<code>WP_NATIVE_APIS_DISABLE_DEFAULTS</code> before loading the component to
+force the pure PHP fallback.
 
 ## Why this exists
 
-<p><code>SimpleXMLElement</code> and <code>DOMDocument</code> both need <code>libxml2</code> and both build a complete in-memory tree. <code>XMLProcessor</code> walks the document forward as a cursor, keeps modifications in a side buffer, and emits the full updated XML with <code>get_updated_xml()</code> only when you ask for it. Reading stays incremental; materializing the updated XML still allocates the resulting document.</p>
+<p><code>SimpleXMLElement</code> and <code>DOMDocument</code> both need <code>libxml2</code> and both build a complete in-memory tree. <code>XMLProcessor</code> walks the document forward as a cursor, keeps modifications in a side buffer, and emits the full updated XML with <code>get_updated_xml()</code> only when you ask for it.</p>
 
 <p>This design came from WordPress-scale documents such as WXR exports. A migration may only need to rewrite <code>wp:attachment_url</code> values or bump a feed attribute, so the processor optimizes for targeted cursor edits instead of a full validating XML stack.</p>
 
@@ -113,7 +118,7 @@ wp/status: publish
 
 ## Rewrite URLs across an entire WXR export
 
-<p>Large WXR exports can hold many URLs in <code>&lt;link&gt;</code>, <code>&lt;guid&gt;</code>, and post content. The cursor can find and rewrite matching text nodes incrementally; calling <code>get_updated_xml()</code> returns the complete rewritten document.</p>
+<p>Large WXR exports can hold many URLs in <code>&lt;link&gt;</code>, <code>&lt;guid&gt;</code>, and post content. Streaming the file lets you rewrite large exports without loading the whole XML document into memory.</p>
 
 <!-- snippet:
 filename: rewrite-wxr-urls.php

--- a/components/XML/Tests/NativeXMLConformanceTest.php
+++ b/components/XML/Tests/NativeXMLConformanceTest.php
@@ -1,0 +1,3223 @@
+<?php
+/**
+ * Shared conformance tests for PHP and native XML processors.
+ *
+ * @package WordPress
+ * @subpackage XML-API
+ */
+
+use PHPUnit\Framework\TestCase;
+use WordPress\XML\XMLProcessor;
+
+/**
+ * @group xml-api
+ * @group native-api
+ */
+class NativeXMLConformanceTest extends TestCase {
+	/**
+	 * Verifies public XML classes can opt in to native delegates when available.
+	 */
+	public function test_public_xml_class_uses_native_processor_when_enabled() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = XMLProcessor::create_from_string( '<root><item id="1" /></root>' );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag( 'item' ) );
+		$this->assertSame( 'item', $processor->get_token_name() );
+		$this->assertSame( '1', $processor->get_attribute( '', 'id' ) );
+		$this->assertTrue( $processor->is_empty_element() );
+		$this->assertFalse( $processor->expects_closer() );
+		$this->assertFalse( $processor->is_tag_opener() );
+		$this->assertSame(
+			array( array( '', 'root' ), array( '', 'item' ) ),
+			$processor->get_breadcrumbs()
+		);
+	}
+
+	/**
+	 * Verifies public read-only native XML scans expose the final complete token.
+	 */
+	public function test_public_xml_class_exposes_complete_token_with_native_defaults() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = XMLProcessor::create_from_string( '<root><item></item></root>' );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+
+		$token_types = array();
+		while ( $processor->next_token() ) {
+			$token_types[] = $processor->get_token_type();
+		}
+
+		$this->assertSame( array( '#tag', '#tag', '#tag', '#tag', '#complete' ), $token_types );
+		$this->assertTrue( $processor->is_finished() );
+		$this->assertSame( '#complete', $processor->get_token_name() );
+		$this->assertNull( $processor->get_last_error() );
+	}
+
+	/**
+	 * Verifies public native-backed XML processors expose native parse exceptions.
+	 */
+	public function test_public_xml_class_exposes_native_parse_exceptions_when_enabled() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = XMLProcessor::create_from_string( '<root attr></root>' );
+		while ( $processor->next_token() ) {
+			continue;
+		}
+
+		$this->assertSame( XMLProcessor::ERROR_SYNTAX, $processor->get_last_error() );
+		$this->assertInstanceOf( 'WordPress\\XML\\XMLUnsupportedException', $processor->get_exception() );
+		$this->assertStringContainsString( 'Unquoted attribute value encountered.', $processor->get_exception()->getMessage() );
+
+		$processor = XMLProcessor::create_from_string( '<root xmlns:a=""></root>' );
+		$this->assertFalse( $processor->next_token(), 'Expected invalid namespace declarations to stop before exposing a token.' );
+		$this->assertSame( XMLProcessor::ERROR_SYNTAX, $processor->get_last_error() );
+		$this->assertInstanceOf( 'WordPress\\XML\\XMLUnsupportedException', $processor->get_exception() );
+		$this->assertSame( 'Attribute "xmlns:a" has an invalid namespace prefix "xmlns".', $processor->get_exception()->getMessage() );
+	}
+
+	/**
+	 * Verifies XML native defaults can be disabled by constant.
+	 */
+	public function test_public_xml_class_can_disable_native_defaults_by_constant() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$this->assertSame(
+			array(
+				'delegate:php',
+				'token:item',
+				'id:1',
+			),
+			$this->run_xml_native_defaults_constant_probe( "define( 'WP_NATIVE_APIS_DISABLE_DEFAULTS', true );" )
+		);
+	}
+
+	/**
+	 * Verifies public native-backed XML processors preserve tag-token modifiable text after next_tag().
+	 */
+	public function test_public_xml_tag_modifiable_text_after_next_tag_with_native_defaults() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = XMLProcessor::create_from_string( '<root><!--c--><![CDATA[data]]><item id="1">Text &amp; More</item></root>' );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag( '', 'item' ) );
+		$this->assertSame( 'Text & More</', $processor->get_modifiable_text() );
+		$this->assertNull( $this->get_native_delegate( $processor ) );
+	}
+
+	/**
+	 * Verifies public native-backed XML processors preserve bookmark lifecycle behavior.
+	 */
+	public function test_public_xml_bookmarks_with_native_defaults() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = XMLProcessor::create_from_string( '<root><item id="one" /><item id="two" /></root>' );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+
+		$this->assertTrue( $processor->next_tag( 'item' ) );
+		$this->assertSame( 'item', $processor->get_token_name() );
+		$this->assertSame( 'one', $processor->get_attribute( '', 'id' ) );
+		$this->assertTrue( $processor->set_bookmark( 'saved-item' ) );
+		$this->assertTrue( $processor->has_bookmark( 'saved-item' ) );
+
+		$this->assertTrue( $processor->next_tag( 'item' ) );
+		$this->assertSame( 'item', $processor->get_token_name() );
+		$this->assertSame( 'two', $processor->get_attribute( '', 'id' ) );
+
+		$this->assertTrue( $processor->seek( 'saved-item' ) );
+		$this->assertSame( 'item', $processor->get_token_name() );
+		$this->assertSame( 'one', $processor->get_attribute( '', 'id' ) );
+		$this->assertSame(
+			array( array( '', 'root' ), array( '', 'item' ) ),
+			$processor->get_breadcrumbs()
+		);
+
+		$this->assertTrue( $processor->release_bookmark( 'saved-item' ) );
+		$this->assertFalse( $processor->has_bookmark( 'saved-item' ) );
+	}
+
+	/**
+	 * Verifies native-backed XML bookmark seeks preserve PHP mutation handoff state.
+	 */
+	public function test_public_xml_bookmark_seek_then_mutation_with_native_defaults() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$processor = XMLProcessor::create_from_string( '<root xmlns:x="urn:x"><item id="1" data-one="a">One</item><x:item x:id="2">Two</x:item></root>' );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+
+		$this->assertTrue( $processor->next_tag( '', 'item' ) );
+		$this->assertTrue( $processor->set_bookmark( 'first-item' ) );
+		$this->assertTrue( $processor->next_tag( 'urn:x', 'item' ) );
+		$this->assertTrue( $processor->seek( 'first-item' ) );
+		$this->assertSame( '1', $processor->get_attribute( '', 'id' ) );
+		$this->assertNull( $processor->get_attribute( 'urn:x', 'id' ) );
+
+		$this->assertTrue( $processor->set_attribute( '', 'data-two', 'b' ) );
+		$this->assertTrue( $processor->remove_attribute( '', 'data-one' ) );
+		$this->assertSame(
+			'<root xmlns:x="urn:x"><item data-two="b" id="1" >One</item><x:item x:id="2">Two</x:item></root>',
+			$processor->get_updated_xml()
+		);
+
+		$processor = XMLProcessor::create_from_string( '<root><item>One</item><item>Two</item></root>' );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag( 'item' ) );
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( 'One', $processor->get_modifiable_text() );
+		$this->assertTrue( $processor->set_bookmark( 'first-text' ) );
+		$this->assertTrue( $processor->next_tag( 'item' ) );
+		$this->assertTrue( $processor->seek( 'first-text' ) );
+		$this->assertTrue( $processor->set_modifiable_text( 'Changed & <ok>' ) );
+		$this->assertSame(
+			'<root><item>Changed &amp; &lt;ok&gt;</item><item>Two</item></root>',
+			$processor->get_updated_xml()
+		);
+
+		$processor = XMLProcessor::create_from_string( '<root><item id="1">One</item><item id="2">Two</item></root>' );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag( 'root' ) );
+		$this->assertTrue( $processor->set_bookmark( 'root' ) );
+		$this->assertTrue( $processor->next_tag( array( 'breadcrumbs' => array( 'root', 'item' ), 'match_offset' => 2 ) ) );
+		$this->assertSame( '2', $processor->get_attribute( '', 'id' ) );
+		$this->assertTrue( $processor->set_bookmark( 'second-item' ) );
+		$this->assertTrue( $processor->seek( 'root' ) );
+		$this->assertTrue( $processor->set_attribute( '', 'class', 'top' ) );
+		$this->assertNull( $this->get_native_delegate( $processor ) );
+		$this->assertTrue( $processor->seek( 'second-item' ) );
+		$this->assertSame( 'item', $processor->get_token_name() );
+		$this->assertSame( '2', $processor->get_attribute( '', 'id' ) );
+		$this->assertSame(
+			'<root class="top"><item id="1">One</item><item id="2">Two</item></root>',
+			$processor->get_updated_xml()
+		);
+	}
+
+	/**
+	 * Verifies public XML inventory summaries complete native-default processors.
+	 */
+	public function test_public_xml_metadata_inventory_summaries_complete_native_default_processors() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$methods = array(
+			'summarize_attribute_inventory',
+			'summarize_id_inventory',
+			'summarize_namespace_inventory',
+			'summarize_text_inventory',
+			'summarize_processing_instruction_inventory',
+			'summarize_comment_inventory',
+			'summarize_payload_inventory',
+		);
+		$xml     = '<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org" id="r"><wp:item wp:slug="first">Text<!-- note --><![CDATA[x]]><?xml audit data?></wp:item></wp:root>';
+
+		foreach ( $methods as $method ) {
+			$processor = XMLProcessor::create_from_string( $xml );
+			$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+
+			$processor->$method();
+			$this->assertTrue( $processor->is_finished(), $method . ' should finish a fresh native-default processor.' );
+
+			$processor = XMLProcessor::create_from_string( $xml );
+			$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+			$this->assertTrue( $processor->next_tag() );
+
+			$processor->$method();
+			$this->assertTrue( $processor->is_finished(), $method . ' should finish a partially advanced native-default processor.' );
+		}
+	}
+
+	/**
+	 * Verifies public XML aggregate summaries complete native-default processors.
+	 */
+	public function test_public_xml_aggregate_summaries_complete_native_default_processors() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$cases = array(
+			array( 'summarize_attribute_names_with_prefix', array( null, 'data-' ) ),
+			array( 'summarize_token_stream', array( 'id' ) ),
+			array( 'summarize_matching_tag_stream', array( 'https://wordpress.org', 'item', 'id' ) ),
+			array( 'summarize_matching_tag_attributes_stream', array( 'https://wordpress.org', 'item', array( 'id', 'data-kind' ) ) ),
+			array( 'summarize_tag_stream', array( 'id' ) ),
+		);
+		$xml   = '<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org" id="r"><wp:item id="1" data-kind="post">Text</wp:item><item data-kind="plain" /></wp:root>';
+
+		foreach ( $cases as $case ) {
+			$processor = XMLProcessor::create_from_string( $xml );
+			$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+
+			call_user_func_array( array( $processor, $case[0] ), $case[1] );
+			$this->assertTrue( $processor->is_finished(), $case[0] . ' should finish a fresh native-default processor.' );
+
+			$processor = XMLProcessor::create_from_string( $xml );
+			$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+			$this->assertTrue( $processor->next_tag() );
+
+			call_user_func_array( array( $processor, $case[0] ), $case[1] );
+			$this->assertTrue( $processor->is_finished(), $case[0] . ' should finish a partially advanced native-default processor.' );
+		}
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+
+		$summary = $processor->remove_attributes_with_prefix_from_document( null, 'data-' );
+		$this->assertSame( 2, $summary['removed_count'] );
+		$this->assertTrue( $processor->is_finished(), 'remove_attributes_with_prefix_from_document should finish a fresh native-default processor.' );
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		$this->assertTrue( $processor->next_tag() );
+
+		$summary = $processor->remove_attributes_with_prefix_from_document( null, 'data-' );
+		$this->assertSame( 2, $summary['removed_count'] );
+		$this->assertTrue( $processor->is_finished(), 'remove_attributes_with_prefix_from_document should finish a partially advanced native-default processor.' );
+	}
+
+	/**
+	 * Verifies public XML batch scans complete native-default processors.
+	 */
+	public function test_public_xml_batches_complete_native_default_processors() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$xml = '<?xml version="1.0"?><root id="root"><item id="1">Text</item><empty id="2" /></root>';
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		do {
+			$batch = $processor->next_token_summary_batch( 2 );
+		} while ( ! empty( $batch ) );
+		$this->assertTrue( $processor->is_finished(), 'next_token_summary_batch should finish after exhaustion.' );
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		do {
+			$batch = $processor->next_tag_summary_batch( 2, 'id' );
+		} while ( ! empty( $batch ) );
+		$this->assertTrue( $processor->is_finished(), 'next_tag_summary_batch should finish after exhaustion.' );
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		do {
+			$summary = $processor->next_tag_count_batch( 2, 'id' );
+		} while ( $summary['token_count'] > 0 );
+		$this->assertTrue( $processor->is_finished(), 'next_tag_count_batch should finish after exhaustion.' );
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		do {
+			$batch = $processor->next_matching_tag_summary_batch( 1, '', 'item', 'id' );
+		} while ( ! empty( $batch ) );
+		$this->assertTrue( $processor->is_finished(), 'next_matching_tag_summary_batch should finish after exhaustion.' );
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		do {
+			$summary = $processor->next_matching_tag_count_batch( 1, '', 'item', 'id' );
+		} while ( $summary['token_count'] > 0 );
+		$this->assertTrue( $processor->is_finished(), 'next_matching_tag_count_batch should finish after exhaustion.' );
+	}
+
+	/**
+	 * Verifies public XML compact batch scans complete native-default processors.
+	 */
+	public function test_public_xml_compact_batches_complete_native_default_processors() {
+		if ( ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+
+		$xml = '<?xml version="1.0"?><root id="root"><item id="1">Text</item><empty id="2" /></root>';
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		do {
+			$batch = $processor->next_token_compact_summary_batch( 2 );
+		} while ( is_string( $batch ) && '' !== $batch );
+		$this->assertTrue( $processor->is_finished(), 'next_token_compact_summary_batch should finish after exhaustion.' );
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		do {
+			$batch = $processor->next_tag_compact_summary_batch( 2, 'id' );
+		} while ( is_string( $batch ) && '' !== $batch );
+		$this->assertTrue( $processor->is_finished(), 'next_tag_compact_summary_batch should finish after exhaustion.' );
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		do {
+			$summary = $processor->next_tag_count_compact_batch( 2, 'id' );
+			$parts   = explode( "\x1f", is_string( $summary ) ? $summary : '' );
+		} while ( isset( $parts[0] ) && (int) $parts[0] > 0 );
+		$this->assertTrue( $processor->is_finished(), 'next_tag_count_compact_batch should finish after exhaustion.' );
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		do {
+			$batch = $processor->next_matching_tag_compact_summary_batch( 1, '', 'item', 'id' );
+		} while ( is_string( $batch ) && '' !== $batch );
+		$this->assertTrue( $processor->is_finished(), 'next_matching_tag_compact_summary_batch should finish after exhaustion.' );
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->assertSame( 'WordPress\\XML\\NativeXMLProcessor', get_class( $this->get_native_delegate( $processor ) ) );
+		do {
+			$summary = $processor->next_matching_tag_count_compact_batch( 1, '', 'item', 'id' );
+			$parts   = explode( "\x1f", is_string( $summary ) ? $summary : '' );
+		} while ( isset( $parts[0] ) && (int) $parts[0] > 0 );
+		$this->assertTrue( $processor->is_finished(), 'next_matching_tag_count_compact_batch should finish after exhaustion.' );
+	}
+
+	/**
+	 * Verifies complete-input processors reject appended bytes.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_rejects_append_bytes_for_complete_input( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root><item /></root>'
+		);
+
+		$this->assertFalse( $processor->append_bytes( '<extra />' ) );
+		$this->assertFalse( $processor->is_expecting_more_input() );
+		$this->assertFalse( $processor->is_paused_at_incomplete_input() );
+	}
+
+	/**
+	 * Verifies streaming processors can resume after incomplete input.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_streaming_appends_after_incomplete_input( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_streaming_processor( $implementation, '<root' );
+
+		$this->assertFalse( $processor->next_token(), 'Expected incomplete opening tag to pause token scanning.' );
+		$this->assertNull( $processor->get_last_error() );
+		$this->assertTrue( $processor->is_paused_at_incomplete_input() );
+		$this->assertTrue( $processor->is_expecting_more_input() );
+		$this->assertTrue( $processor->append_bytes( '><item id="1" /></root>' ) );
+
+		$this->assertTrue( $processor->next_token(), 'Expected root tag after appending bytes.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'root', $processor->get_token_name() );
+		$this->assertTrue( $processor->next_token(), 'Expected item tag after appending bytes.' );
+		$this->assertSame( 'item', $processor->get_token_name() );
+		$this->assertSame( '1', $this->get_xml_attribute( $processor, $implementation, 'id' ) );
+		$this->assertTrue( $processor->next_token(), 'Expected root closer after appending bytes.' );
+		$this->assertSame( 'root', $processor->get_token_name() );
+		$this->assertTrue( $processor->is_tag_closer() );
+	}
+
+	/**
+	 * Verifies streaming processors resume after an incomplete token following prior tokens.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_streaming_appends_after_prior_token_incomplete_input( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_streaming_processor( $implementation, '<root><item' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected root tag before incomplete child.' );
+		$this->assertSame( 'root', $processor->get_token_name() );
+		$this->assertFalse( $processor->next_token(), 'Expected incomplete child tag to pause token scanning.' );
+		$this->assertNull( $processor->get_last_error() );
+		$this->assertTrue( $processor->is_paused_at_incomplete_input() );
+		$this->assertTrue( $processor->is_expecting_more_input() );
+		$this->assertTrue( $processor->append_bytes( ' id="1" /></root>' ) );
+
+		$this->assertTrue( $processor->next_token(), 'Expected child tag after appending bytes.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'item', $processor->get_token_name() );
+		$this->assertSame( '1', $this->get_xml_attribute( $processor, $implementation, 'id' ) );
+		$this->assertTrue( $processor->next_token(), 'Expected root closer after appended child.' );
+		$this->assertSame( 'root', $processor->get_token_name() );
+		$this->assertTrue( $processor->is_tag_closer() );
+	}
+
+	/**
+	 * Verifies streaming cursors preserve context for siblings but not parent closers.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_streaming_cursor_preserves_sibling_context( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<wp:root xmlns:wp="https://wordpress.org"><wp:item id="7">Text</wp:item><wp:tail /></wp:root>';
+		$processor = $this->create_xml_streaming_processor( $implementation, $xml );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected root tag before cursor capture.' );
+		$this->assertTrue( $processor->next_tag(), 'Expected item tag before cursor capture.' );
+		$this->assertSame( 'item', $processor->get_tag_local_name() );
+		$this->assertSame( 'https://wordpress.org', $processor->get_tag_namespace() );
+
+		$offset  = $processor->get_token_byte_offset_in_the_input_stream();
+		$cursor  = $processor->get_reentrancy_cursor();
+		$resumed = $this->create_xml_streaming_processor_from_cursor( $implementation, substr( $xml, $offset ), $cursor );
+
+		$this->assertTrue( $resumed->next_tag(), 'Expected resumed processor to expose the item tag.' );
+		$this->assertSame( 'item', $resumed->get_tag_local_name() );
+		$this->assertSame( 'https://wordpress.org', $resumed->get_tag_namespace() );
+		$this->assertSame( '7', $this->get_xml_attribute( $resumed, $implementation, 'id' ) );
+		$this->assertTrue( $resumed->next_token(), 'Expected resumed processor to expose item text.' );
+		$this->assertSame( 'Text', $resumed->get_modifiable_text() );
+		$this->assertTrue( $resumed->next_token(), 'Expected resumed processor to expose item closer.' );
+		$this->assertSame( 'item', $resumed->get_tag_local_name() );
+		$this->assertTrue( $resumed->is_tag_closer() );
+		$this->assertTrue( $resumed->next_token(), 'Expected resumed processor to expose sibling tail tag.' );
+		$this->assertSame( 'tail', $resumed->get_tag_local_name() );
+		$this->assertSame( 'https://wordpress.org', $resumed->get_tag_namespace() );
+		$this->assertTrue( $resumed->is_empty_element() );
+		$this->assertFalse( $resumed->next_token(), 'Expected resumed processor to reject the pre-cursor parent closer.' );
+		$this->assertNotNull( $resumed->get_last_error() );
+	}
+
+	/**
+	 * Verifies streaming batch scans pause at incomplete input and resume after append.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_streaming_batches_pause_at_incomplete_input( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$cases = array(
+			'token_compact',
+			'tag_compact',
+			'tag_count',
+			'matching_tag_compact',
+			'matching_tag_count',
+		);
+
+		foreach ( $cases as $case ) {
+			$processor = $this->create_xml_streaming_processor( $implementation, '<root><item' );
+			$result    = $this->run_xml_streaming_batch_case( $processor, $implementation, $case );
+
+			if ( 'matching_tag_compact' === $case ) {
+				$this->assertNull( $result, 'Expected no matching compact row before the incomplete child is complete.' );
+			} else {
+				$this->assertNotEmpty( $result, 'Expected batch case ' . $case . ' to expose prior complete tokens.' );
+			}
+
+			$this->assertNull( $processor->get_last_error(), 'Expected batch case ' . $case . ' not to report an error before input is finished.' );
+			$this->assertTrue( $processor->is_paused_at_incomplete_input(), 'Expected batch case ' . $case . ' to pause at incomplete input.' );
+			$this->assertTrue( $processor->is_expecting_more_input(), 'Expected batch case ' . $case . ' to keep expecting input.' );
+			$this->assertTrue( $processor->append_bytes( ' id="1" /></root>' ), 'Expected batch case ' . $case . ' to accept appended bytes.' );
+			$this->assertTrue( $processor->next_token(), 'Expected batch case ' . $case . ' to resume at the incomplete child tag.' );
+			$this->assertSame( 'item', $processor->get_token_name() );
+			$this->assertSame( '1', $this->get_xml_attribute( $processor, $implementation, 'id' ) );
+		}
+	}
+
+	/**
+	 * Verifies finishing incomplete streaming input reports a syntax error on the next scan.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_streaming_input_finished_reports_incomplete_input_error( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_streaming_processor( $implementation, '<root><item' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected root tag before incomplete child.' );
+		$this->assertSame( 'root', $processor->get_token_name() );
+		$this->assertFalse( $processor->next_token(), 'Expected incomplete child tag to pause token scanning.' );
+		$this->assertNull( $processor->get_last_error() );
+		$this->assertTrue( $processor->is_paused_at_incomplete_input() );
+		$this->assertTrue( $processor->is_expecting_more_input() );
+
+		$processor->input_finished();
+
+		$this->assertNull( $processor->get_last_error(), 'Expected finished input to defer the syntax error until the next scan.' );
+		$this->assertFalse( $processor->is_paused_at_incomplete_input() );
+		$this->assertFalse( $processor->is_expecting_more_input() );
+		$this->assertFalse( $processor->is_finished() );
+		$this->assertFalse( $processor->next_token(), 'Expected finished incomplete input to report a syntax error.' );
+		$this->assertNotNull( $processor->get_last_error() );
+		$this->assertFalse( $processor->is_finished() );
+	}
+
+	/**
+	 * Verifies XML documents without a document element report a syntax error.
+	 *
+	 * @dataProvider data_xml_without_document_element
+	 *
+	 * @param string $xml            XML input.
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_requires_document_element( $xml, $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		while ( $processor->next_token() ) {
+			continue;
+		}
+
+		$this->assertNotNull( $processor->get_last_error() );
+	}
+
+	/**
+	 * Verifies leading whitespace outside the document element is skipped.
+	 *
+	 * @dataProvider data_xml_with_leading_misc_whitespace
+	 *
+	 * @param string $xml            XML input.
+	 * @param array  $token_names    Expected token names.
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_skips_leading_misc_whitespace( $xml, $token_names, $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		foreach ( $token_names as $token_name ) {
+			$this->assertTrue( $processor->next_token() );
+			$this->assertSame( $token_name, $processor->get_token_name() );
+		}
+	}
+
+	/**
+	 * Verifies streaming processors pause and resume for incomplete token kinds.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_streaming_pauses_for_incomplete_token_kinds( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$cases = array(
+			array( '<root><!--note', '--></root>' ),
+			array( '<root><![CDATA[x', ']]></root>' ),
+			array( '<!DOCTYPE root', '><root />' ),
+			array( '<root><?xml-stylesheet href="x"', '?></root>' ),
+			array( '<', 'root />' ),
+			array( '<root a="x', '" />' ),
+			array( '<root a', '="x" />' ),
+			array( '<root a=', '"x" />' ),
+		);
+
+		foreach ( $cases as $case ) {
+			$processor = $this->create_xml_streaming_processor( $implementation, $case[0] );
+			while ( $processor->next_token() ) {
+				// Advance to the incomplete token.
+			}
+
+			$this->assertTrue( $processor->is_paused_at_incomplete_input(), 'Expected incomplete input to pause for: ' . $case[0] );
+			$this->assertTrue( $processor->is_expecting_more_input(), 'Expected processor to keep expecting input for: ' . $case[0] );
+			$this->assertTrue( $processor->append_bytes( $case[1] ), 'Expected processor to accept appended bytes for: ' . $case[0] );
+			$this->assertTrue( $processor->next_token(), 'Expected processor to resume after appended bytes for: ' . $case[0] );
+		}
+	}
+
+	/**
+	 * Verifies the first native slice matches the PHP XML processor token stream.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reads_tags_and_attributes( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root><item id="7" data-kind="post" /></root>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the root token.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'root', $processor->get_token_name() );
+		$this->assertSame( '', $processor->get_tag_namespace() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the item tag.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'item', $processor->get_token_name() );
+		$this->assertSame( '', $processor->get_tag_namespace() );
+		$this->assertSame( '7', $this->get_xml_attribute( $processor, $implementation, 'id' ) );
+		$this->assertSame( 'post', $this->get_xml_attribute( $processor, $implementation, 'data-kind' ) );
+		$this->assertSame(
+			array( array( '', 'data-kind' ) ),
+			$processor->get_attribute_names_with_prefix( null, 'data-' )
+		);
+		$this->assertNull( $processor->get_last_error() );
+	}
+
+	/**
+	 * Verifies attribute-prefix reads preserve XML input order.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_preserves_attribute_prefix_order( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<content xmlns:wp="http://wordpress.org/export/1.2/" wp:data-foo="bar" wp:data-bar="baz" data-foo="no-ns" />'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the content tag.' );
+		$this->assertSame(
+			array(
+				array( 'http://wordpress.org/export/1.2/', 'data-foo' ),
+				array( 'http://wordpress.org/export/1.2/', 'data-bar' ),
+			),
+			$processor->get_attribute_names_with_prefix( 'http://wordpress.org/export/1.2/', 'data-' )
+		);
+		$this->assertSame(
+			array( array( '', 'data-foo' ) ),
+			$processor->get_attribute_names_with_prefix( null, 'data-' )
+		);
+	}
+
+	/**
+	 * Verifies document-level attribute-prefix summaries match repeated scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_attribute_prefixes( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root xmlns:wp="http://wordpress.org/export/1.2/"><wp:item wp:data-id="7" data-kind="post" /><item data-id="8" /></root>'
+		);
+
+		$this->assertSame(
+			array(
+				'tag_count'       => 3,
+				'attribute_count' => 2,
+			),
+			$this->summarize_xml_attribute_names_with_prefix( $processor, $implementation, null, 'data-' )
+		);
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root xmlns:wp="http://wordpress.org/export/1.2/"><wp:item wp:data-id="7" data-kind="post" /><item data-id="8" /></root>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the root tag before summarizing remaining tags.' );
+		$this->assertSame(
+			array(
+				'tag_count'       => 2,
+				'attribute_count' => 1,
+			),
+			$this->summarize_xml_attribute_names_with_prefix( $processor, $implementation, 'http://wordpress.org/export/1.2/', 'data-' )
+		);
+	}
+
+	/**
+	 * Verifies document-level token stream summaries match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_token_streams( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0" encoding="UTF-8"?><root id="root"><item id="7">Text</item><empty></empty></root>'
+		);
+
+		$this->assertSame(
+			array(
+				'token_count'     => 8,
+				'tag_count'       => 3,
+				'attribute_count' => 2,
+			),
+			$this->summarize_xml_token_stream( $processor, $implementation, 'id' )
+		);
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0" encoding="UTF-8"?><root id="root"><item id="7">Text</item><empty></empty></root>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the XML declaration before summarizing remaining tokens.' );
+		$this->assertSame(
+			array(
+				'token_count'     => 7,
+				'tag_count'       => 3,
+				'attribute_count' => 2,
+			),
+			$this->summarize_xml_token_stream( $processor, $implementation, 'id' )
+		);
+	}
+
+	/**
+	 * Verifies document-level tag stream summaries match repeated tag scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_tag_streams( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0" encoding="UTF-8"?><root id="root"><item id="7">Text</item><empty></empty></root>'
+		);
+
+		$this->assertSame(
+			array(
+				'tag_count'       => 3,
+				'attribute_count' => 2,
+			),
+			$this->summarize_xml_tag_stream( $processor, $implementation, 'id' )
+		);
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0" encoding="UTF-8"?><root id="root"><item id="7">Text</item><empty></empty></root>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the root tag before summarizing remaining tags.' );
+		$this->assertSame(
+			array(
+				'tag_count'       => 2,
+				'attribute_count' => 1,
+			),
+			$this->summarize_xml_tag_stream( $processor, $implementation, 'id' )
+		);
+	}
+
+	/**
+	 * Verifies incremental tag count batches match repeated tag scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_counts_tag_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0" encoding="UTF-8"?><root id="root"><item id="7">Text</item><empty></empty></root>'
+		);
+
+		$this->assertSame(
+			array(
+				'token_count'     => 3,
+				'tag_count'       => 2,
+				'attribute_count' => 2,
+			),
+			$this->next_xml_tag_count_batch( $processor, $implementation, 2, 'id' )
+		);
+		$this->assertSame(
+			array(
+				'token_count'     => 5,
+				'tag_count'       => 1,
+				'attribute_count' => 0,
+			),
+			$this->next_xml_tag_count_batch( $processor, $implementation, 2, 'id' )
+		);
+		$this->assertSame(
+			array(
+				'token_count'     => 0,
+				'tag_count'       => 0,
+				'attribute_count' => 0,
+			),
+			$this->next_xml_tag_count_batch( $processor, $implementation, 2, 'id' )
+		);
+	}
+
+	/**
+	 * Verifies document-level prefixed attribute removals match repeated scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_removes_attribute_prefixes_from_document( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<root xmlns:wp="http://wordpress.org/export/1.2/" data-root="1"><wp:item wp:data-id="7" data-kind="post" keep="x" /><item data-id="8" /></root>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'tag_count'     => 3,
+				'removed_count' => 3,
+				'xml'           => '<root xmlns:wp="http://wordpress.org/export/1.2/" ><wp:item wp:data-id="7"  keep="x" /><item  /></root>',
+			),
+			$this->remove_xml_attribute_names_with_prefix_from_document( $processor, $implementation, null, 'data-' )
+		);
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertSame(
+			array(
+				'tag_count'     => 3,
+				'removed_count' => 1,
+				'xml'           => '<root xmlns:wp="http://wordpress.org/export/1.2/" data-root="1"><wp:item  data-kind="post" keep="x" /><item data-id="8" /></root>',
+			),
+			$this->remove_xml_attribute_names_with_prefix_from_document( $processor, $implementation, 'http://wordpress.org/export/1.2/', 'data-' )
+		);
+	}
+
+	/**
+	 * Verifies empty-element markers are exposed consistently.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reports_empty_elements( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root><empty /><parent></parent></root>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the root token.' );
+		$this->assertSame( 'root', $processor->get_token_name() );
+		$this->assertFalse( $processor->is_empty_element() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the empty element token.' );
+		$this->assertSame( 'empty', $processor->get_token_name() );
+		$this->assertTrue( $processor->is_empty_element() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the non-empty parent token.' );
+		$this->assertSame( 'parent', $processor->get_token_name() );
+		$this->assertFalse( $processor->is_empty_element() );
+	}
+
+	/**
+	 * Verifies XML character references are decoded in text and attributes.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_decodes_character_references( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root a="&amp; &amp;amp; &lt; &gt; &quot; &apos;&#65;&#x42; &#0; &unknown;">&amp; &amp;amp; &lt; &gt; &quot; &apos;&#67;&#x44; &#xD800; &unknown;</root>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the root token.' );
+		$this->assertSame( '& &amp; < > " \'AB &#0; &unknown;', $this->get_xml_attribute( $processor, $implementation, 'a' ) );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the text token.' );
+		$this->assertSame( '& &amp; < > " \'CD &#xD800; &unknown;', $processor->get_modifiable_text() );
+		$this->assertNull( $processor->get_last_error() );
+	}
+
+	/**
+	 * Verifies malformed documents are observable through the shared error API.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reports_syntax_errors( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root><item id=7 /></root>'
+		);
+
+		while ( $processor->next_token() ) {
+			continue;
+		}
+
+		$this->assertNotNull( $processor->get_last_error() );
+	}
+
+	/**
+	 * Verifies malformed closing tags stop scanning after prior valid tokens.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_rejects_attributes_in_closing_tags( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<content>Test</content post-type="test">'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the opening tag before the invalid closer.' );
+		$this->assertSame( 'content', $processor->get_token_name() );
+		$this->assertTrue( $processor->next_token(), 'Expected the text token before the invalid closer.' );
+		$this->assertSame( 'Test', $processor->get_modifiable_text() );
+		$this->assertFalse( $processor->next_token(), 'Expected the invalid closing tag to stop token scanning.' );
+		$this->assertNotNull( $processor->get_last_error() );
+	}
+
+	/**
+	 * Verifies malformed attributes reject the current token.
+	 *
+	 * @dataProvider data_malformed_attribute_xml_processor_implementations
+	 *
+	 * @param string $xml            XML input.
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_rejects_malformed_attributes( $xml, $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertFalse( $processor->next_tag(), 'Expected malformed attributes to stop tag scanning.' );
+		$this->assertNotNull( $processor->get_last_error() );
+		$this->assertNotNull( $processor->get_exception() );
+	}
+
+	/**
+	 * Verifies unsupported processing instructions are observable as errors.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reports_processing_instruction_errors( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root><?pi data?><child /></root>'
+		);
+
+		while ( $processor->next_token() ) {
+			continue;
+		}
+
+		$this->assertNotNull( $processor->get_last_error() );
+	}
+
+	/**
+	 * Verifies namespace-local tag reads and namespaced attributes stay aligned.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reads_namespace_qualified_tags_and_attributes( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root xmlns:wp="https://wordpress.org"><wp:item wp:id="7" plain="yes" /></root>'
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the root tag.' );
+		$this->assertSame( 'root', $processor->get_token_name() );
+		$this->assertSame( 'root', $processor->get_tag_local_name() );
+		$this->assertSame( 'root', $processor->get_tag_namespace_and_local_name() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the namespaced item tag.' );
+		$this->assertSame( 'item', $processor->get_token_name() );
+		$this->assertSame( 'item', $processor->get_tag_local_name() );
+		$this->assertSame( 'https://wordpress.org', $processor->get_tag_namespace() );
+		$this->assertSame( '{https://wordpress.org}item', $processor->get_tag_namespace_and_local_name() );
+		$this->assertSame( '7', $this->get_xml_attribute( $processor, $implementation, 'id', 'https://wordpress.org' ) );
+		$this->assertSame( 'yes', $this->get_xml_attribute( $processor, $implementation, 'plain' ) );
+	}
+
+	/**
+	 * Verifies breadcrumbs and current depth stay aligned while skipping closing tags.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reports_breadcrumbs_and_current_depth( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root xmlns:wp="w.org"><wp:text><post /></wp:text><image /></root>'
+		);
+
+		$this->assertSame( 0, $processor->get_current_depth() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the root tag.' );
+		$this->assertSame( 1, $processor->get_current_depth() );
+		$this->assertSame(
+			array( array( '', 'root' ) ),
+			$processor->get_breadcrumbs()
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the namespaced text tag.' );
+		$this->assertSame( 2, $processor->get_current_depth() );
+		$this->assertSame(
+			array( array( '', 'root' ), array( 'w.org', 'text' ) ),
+			$processor->get_breadcrumbs()
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected the post tag.' );
+		$this->assertSame( 3, $processor->get_current_depth() );
+		$this->assertSame(
+			array( array( '', 'root' ), array( 'w.org', 'text' ), array( '', 'post' ) ),
+			$processor->get_breadcrumbs()
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip closing tags and find image.' );
+		$this->assertSame( 'image', $processor->get_token_name() );
+		$this->assertSame( 2, $processor->get_current_depth() );
+		$this->assertSame(
+			array( array( '', 'root' ), array( '', 'image' ) ),
+			$processor->get_breadcrumbs()
+		);
+	}
+
+	/**
+	 * Verifies text and comment tokens stay aligned with the PHP XML processor.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reads_text_and_comment_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root xmlns:wp="w.org"><wp:text>Hello<!--note--><post />World</wp:text></root>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the root tag.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'root', $processor->get_token_name() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the namespaced text tag.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'text', $processor->get_token_name() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the first text token.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( '#text', $processor->get_token_name() );
+		$this->assertSame( 'Hello', $processor->get_modifiable_text() );
+		$this->assertSame( 2, $processor->get_current_depth() );
+		$this->assertSame(
+			array( array( '', 'root' ), array( 'w.org', 'text' ) ),
+			$processor->get_breadcrumbs()
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the comment token.' );
+		$this->assertSame( '#comment', $processor->get_token_type() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
+		$this->assertSame( 'note', $processor->get_modifiable_text() );
+		$this->assertSame( 2, $processor->get_current_depth() );
+		$this->assertSame(
+			array( array( '', 'root' ), array( 'w.org', 'text' ) ),
+			$processor->get_breadcrumbs()
+		);
+
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip text and find the post tag.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'post', $processor->get_token_name() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the second text token.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( 'World', $processor->get_modifiable_text() );
+	}
+
+	/**
+	 * Verifies opening tag modifiable text stays aligned with the PHP XML processor.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reads_opening_tag_modifiable_text( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root><item id="1">Text &amp; More</item></root>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the root tag.' );
+		$this->assertSame( 'root', $processor->get_token_name() );
+		$this->assertSame( '<item id="1">Text & More</item></', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the item tag.' );
+		$this->assertSame( 'item', $processor->get_token_name() );
+		$this->assertSame( 'Text & More</', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the text token.' );
+		$this->assertSame( '#text', $processor->get_token_name() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the item closer.' );
+		$this->assertSame( 'item', $processor->get_token_name() );
+
+		$processor = $this->create_xml_processor( $implementation, '<root><empty /></root>' );
+		$this->assertTrue( $processor->next_token(), 'Expected the root tag before the empty element.' );
+		$this->assertTrue( $processor->next_token(), 'Expected the empty element.' );
+		$this->assertSame( 'empty', $processor->get_token_name() );
+		$this->assertSame( '', $processor->get_modifiable_text() );
+	}
+
+	/**
+	 * Verifies CDATA sections stay aligned with the PHP XML processor.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reads_cdata_section_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root xmlns:wp="w.org"><wp:text>before<![CDATA[<b>&c]]>after</wp:text></root>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the root tag.' );
+		$this->assertTrue( $processor->next_token(), 'Expected the namespaced text tag.' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the text token before CDATA.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( 'before', $processor->get_modifiable_text() );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the CDATA token.' );
+		$this->assertSame( '#cdata-section', $processor->get_token_type() );
+		$this->assertSame( '#cdata-section', $processor->get_token_name() );
+		$this->assertSame( '<b>&c', $processor->get_modifiable_text() );
+		$this->assertSame( 2, $processor->get_current_depth() );
+		$this->assertSame(
+			array( array( '', 'root' ), array( 'w.org', 'text' ) ),
+			$processor->get_breadcrumbs()
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the text token after CDATA.' );
+		$this->assertSame( '#text', $processor->get_token_type() );
+		$this->assertSame( 'after', $processor->get_modifiable_text() );
+	}
+
+	/**
+	 * Verifies modifiable text updates stay aligned with the PHP XML processor.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_updates_modifiable_text_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<root>One<!--note--><![CDATA[raw]]><tail /></root>'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the root tag.' );
+		$this->assertFalse( $processor->set_modifiable_text( 'nope' ), 'Expected tag text mutation to be rejected.' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the text token.' );
+		$this->assertTrue( $processor->set_modifiable_text( 'Two & <three>' ), 'Expected text mutation to succeed.' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the comment token.' );
+		$this->assertTrue( $processor->set_modifiable_text( 'comment & <tag>' ), 'Expected comment mutation to succeed.' );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the CDATA token.' );
+		$this->assertTrue( $processor->set_modifiable_text( 'inside ]]> cdata' ), 'Expected CDATA mutation to succeed.' );
+
+		$this->assertSame(
+			'<root>Two &amp; &lt;three&gt;<!--comment &amp; &lt;tag&gt;--><![CDATA[inside ]]&gt; cdata]]><tail /></root>',
+			$processor->get_updated_xml()
+		);
+		$this->assertTrue( $processor->next_tag(), 'Expected processor to continue after text mutations.' );
+		$this->assertSame( 'tail', $processor->get_token_name() );
+	}
+
+	/**
+	 * Verifies prolog declaration tokens stay aligned with the PHP XML processor.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reads_xml_declaration_and_doctype_tokens( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE root><root />'
+		);
+
+		$this->assertTrue( $processor->next_token(), 'Expected the XML declaration token.' );
+		$this->assertSame( '#xml-declaration', $processor->get_token_type() );
+		$this->assertSame( '#xml-declaration', $processor->get_token_name() );
+		$this->assertSame( 'xml version="1.0" encoding="UTF-8"', $processor->get_modifiable_text() );
+		$this->assertSame( 0, $processor->get_current_depth() );
+		$this->assertSame( array(), $processor->get_breadcrumbs() );
+		$this->assertSame( '1.0', $this->get_xml_attribute( $processor, $implementation, 'version' ) );
+		$this->assertSame( 'UTF-8', $this->get_xml_attribute( $processor, $implementation, 'encoding' ) );
+
+		$this->assertTrue( $processor->next_token(), 'Expected the DOCTYPE token.' );
+		$this->assertSame( '#doctype', $processor->get_token_type() );
+		$this->assertSame( '#doctype', $processor->get_token_name() );
+		$this->assertSame( '', $processor->get_modifiable_text() );
+		$this->assertSame( 0, $processor->get_current_depth() );
+		$this->assertSame( array(), $processor->get_breadcrumbs() );
+
+		$this->assertTrue( $processor->next_tag(), 'Expected next_tag() to skip prolog tokens and find the root tag.' );
+		$this->assertSame( '#tag', $processor->get_token_type() );
+		$this->assertSame( 'root', $processor->get_token_name() );
+	}
+
+	/**
+	 * Verifies chunked token summaries stay aligned with token-by-token reads.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reads_token_summary_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0"?><root id="root"><item id="7">Text</item><empty /></root>'
+		);
+		$rows      = array();
+
+		do {
+			$batch = $this->next_xml_token_summary_batch( $processor, $implementation, 2 );
+			$rows  = array_merge( $rows, $batch );
+		} while ( ! empty( $batch ) );
+
+		$this->assertCount( 7, $rows );
+		$this->assertSame(
+			array( '#xml-declaration', '#tag', '#tag', '#text', '#tag', '#tag', '#tag' ),
+			array_column( $rows, 'token_type' )
+		);
+		$this->assertSame(
+			array( null, 'root', '7', null, null, null, null ),
+			array_column( $rows, 'id' )
+		);
+		$this->assertSame( 'root', $rows[1]['tag_local_name'] );
+		$this->assertSame( 1, $rows[1]['current_depth'] );
+		$this->assertSame( 'item', $rows[2]['tag_local_name'] );
+		$this->assertSame( 2, $rows[2]['current_depth'] );
+		$this->assertSame( true, $rows[4]['is_tag_closer'] );
+		$this->assertSame( true, $rows[5]['is_empty_element'] );
+		$this->assertSame( 0, $rows[6]['current_depth'] );
+	}
+
+	/**
+	 * Verifies document-level inventory summaries match token-by-token reads.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_document_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0"?><root><!-- note --><item>Text</item><empty /><data><![CDATA[x]]></data></root>'
+		);
+
+		$this->assertSame(
+			array(
+				'token_count'         => 11,
+				'tag_count'           => 4,
+				'closing_tag_count'   => 3,
+				'text_token_count'    => 1,
+				'comment_count'       => 1,
+				'cdata_count'         => 1,
+				'max_depth'           => 2,
+				'empty_element_count' => 1,
+			),
+			$this->summarize_xml_document_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0"?><root><!-- note --><item>Text</item><empty /><data><![CDATA[x]]></data></root>'
+		);
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'         => 9,
+				'tag_count'           => 3,
+				'closing_tag_count'   => 3,
+				'text_token_count'    => 1,
+				'comment_count'       => 1,
+				'cdata_count'         => 1,
+				'max_depth'           => 2,
+				'empty_element_count' => 1,
+			),
+			$this->summarize_xml_document_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+	}
+
+	/**
+	 * Verifies element-name inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_element_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org"><wp:item /><wp:item><plain /></wp:item><plain /></wp:root>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'              => 8,
+				'tag_count'                => 5,
+				'closing_tag_count'        => 2,
+				'unique_tag_name_count'    => 3,
+				'duplicate_tag_name_count' => 2,
+				'namespaced_tag_count'     => 3,
+				'empty_element_count'      => 3,
+			),
+			$this->summarize_xml_element_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'              => 6,
+				'tag_count'                => 4,
+				'closing_tag_count'        => 2,
+				'unique_tag_name_count'    => 2,
+				'duplicate_tag_name_count' => 2,
+				'namespaced_tag_count'     => 2,
+				'empty_element_count'      => 3,
+			),
+			$this->summarize_xml_element_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+	}
+
+	/**
+	 * Verifies document-level depth inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_depth_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><root><section><item /><item><child /></item></section><single /></root>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'          => 10,
+				'tag_count'            => 6,
+				'closing_tag_count'    => 3,
+				'empty_element_count'  => 3,
+				'root_level_tag_count' => 1,
+				'nested_tag_count'     => 3,
+				'total_tag_depth'      => 15,
+				'max_depth'            => 4,
+			),
+			$this->summarize_xml_depth_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'          => 8,
+				'tag_count'            => 5,
+				'closing_tag_count'    => 3,
+				'empty_element_count'  => 3,
+				'root_level_tag_count' => 0,
+				'nested_tag_count'     => 3,
+				'total_tag_depth'      => 14,
+				'max_depth'            => 4,
+			),
+			$this->summarize_xml_depth_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+	}
+
+	/**
+	 * Verifies leaf and branch element inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_leaf_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><root><section><item /><item><child /></item></section><single /></root>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'             => 10,
+				'tag_count'               => 6,
+				'closing_tag_count'       => 3,
+				'empty_element_count'     => 3,
+				'leaf_element_count'      => 3,
+				'branch_element_count'    => 3,
+				'max_child_element_count' => 2,
+			),
+			$this->summarize_xml_leaf_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'             => 8,
+				'tag_count'               => 5,
+				'closing_tag_count'       => 3,
+				'empty_element_count'     => 3,
+				'leaf_element_count'      => 3,
+				'branch_element_count'    => 2,
+				'max_child_element_count' => 2,
+			),
+			$this->summarize_xml_leaf_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+	}
+
+	/**
+	 * Verifies structural inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_structural_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org"><wp:section><wp:item /><wp:item><child /></wp:item></wp:section><single /></wp:root>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'              => 10,
+				'tag_count'                => 6,
+				'closing_tag_count'        => 3,
+				'unique_tag_name_count'    => 5,
+				'duplicate_tag_name_count' => 1,
+				'namespaced_tag_count'     => 4,
+				'empty_element_count'      => 3,
+				'root_level_tag_count'     => 1,
+				'nested_tag_count'         => 3,
+				'total_tag_depth'          => 15,
+				'max_depth'                => 4,
+				'leaf_element_count'       => 3,
+				'branch_element_count'     => 3,
+				'max_child_element_count'  => 2,
+			),
+			$this->summarize_xml_structural_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'              => 8,
+				'tag_count'                => 5,
+				'closing_tag_count'        => 3,
+				'unique_tag_name_count'    => 4,
+				'duplicate_tag_name_count' => 1,
+				'namespaced_tag_count'     => 3,
+				'empty_element_count'      => 3,
+				'root_level_tag_count'     => 0,
+				'nested_tag_count'         => 3,
+				'total_tag_depth'          => 14,
+				'max_depth'                => 4,
+				'leaf_element_count'       => 3,
+				'branch_element_count'     => 2,
+				'max_child_element_count'  => 2,
+			),
+			$this->summarize_xml_structural_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+	}
+
+	/**
+	 * Verifies document-level attribute inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_attribute_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org" id="root"><wp:item id="7" wp:slug="first"><wp:title>Title</wp:title><empty data-id="x" /></wp:item></wp:root>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'                  => 9,
+				'tag_count'                    => 4,
+				'attribute_count'              => 4,
+				'namespaced_attribute_count'   => 1,
+				'tags_with_attributes_count'   => 3,
+				'max_attribute_count'          => 2,
+			),
+			$this->summarize_xml_attribute_inventory( $processor, $implementation )
+		);
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'                  => 7,
+				'tag_count'                    => 3,
+				'attribute_count'              => 3,
+				'namespaced_attribute_count'   => 1,
+				'tags_with_attributes_count'   => 2,
+				'max_attribute_count'          => 2,
+			),
+			$this->summarize_xml_attribute_inventory( $processor, $implementation )
+		);
+	}
+
+	/**
+	 * Verifies document-level ID inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_id_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org" id="root"><wp:item id="7" wp:id="ignored"><wp:title id="title">Title</wp:title><empty id="7" /><plain /></wp:item></wp:root>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'        => 10,
+				'tag_count'          => 5,
+				'id_attribute_count' => 4,
+				'unique_id_count'    => 3,
+				'duplicate_id_count' => 1,
+				'id_value_bytes'     => 11,
+			),
+			$this->summarize_xml_id_inventory( $processor, $implementation )
+		);
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'        => 8,
+				'tag_count'          => 4,
+				'id_attribute_count' => 3,
+				'unique_id_count'    => 2,
+				'duplicate_id_count' => 1,
+				'id_value_bytes'     => 7,
+			),
+			$this->summarize_xml_id_inventory( $processor, $implementation )
+		);
+	}
+
+	/**
+	 * Verifies document-level namespace inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_namespace_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org" xmlns:media="https://example.com/media" id="root"><wp:item id="7" wp:slug="first" media:type="image"><media:title>Title</media:title><empty data-id="x" /></wp:item></wp:root>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'                  => 9,
+				'tag_count'                    => 4,
+				'namespaced_tag_count'         => 3,
+				'attribute_count'              => 5,
+				'namespaced_attribute_count'   => 2,
+				'unique_namespace_count'       => 2,
+			),
+			$this->summarize_xml_namespace_inventory( $processor, $implementation )
+		);
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'                  => 7,
+				'tag_count'                    => 3,
+				'namespaced_tag_count'         => 2,
+				'attribute_count'              => 4,
+				'namespaced_attribute_count'   => 2,
+				'unique_namespace_count'       => 2,
+			),
+			$this->summarize_xml_namespace_inventory( $processor, $implementation )
+		);
+	}
+
+	/**
+	 * Verifies document-level text inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_text_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><root> Alpha <item>Two</item><data><![CDATA[raw]]></data><space>   </space></root>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'           => 13,
+				'text_token_count'      => 3,
+				'cdata_count'           => 1,
+				'non_empty_text_count'  => 3,
+				'whitespace_text_count' => 1,
+				'total_text_bytes'      => 16,
+				'max_text_bytes'        => 7,
+			),
+			$this->summarize_xml_text_inventory( $processor, $implementation )
+		);
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'           => 11,
+				'text_token_count'      => 3,
+				'cdata_count'           => 1,
+				'non_empty_text_count'  => 3,
+				'whitespace_text_count' => 1,
+				'total_text_bytes'      => 16,
+				'max_text_bytes'        => 7,
+			),
+			$this->summarize_xml_text_inventory( $processor, $implementation )
+		);
+	}
+
+	/**
+	 * Verifies document-level processing instruction inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_processing_instruction_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><root><?xml-stylesheet type="text/xsl"?><?xml audit data?><item /></root><?xml trailing?>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'                    => 7,
+				'processing_instruction_count'   => 3,
+				'xml_declaration_count'          => 1,
+				'non_empty_instruction_count'    => 4,
+				'total_instruction_bytes'        => 64,
+				'max_instruction_bytes'          => 27,
+			),
+			$this->summarize_xml_processing_instruction_inventory( $processor, $implementation )
+		);
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'                    => 5,
+				'processing_instruction_count'   => 3,
+				'xml_declaration_count'          => 0,
+				'non_empty_instruction_count'    => 3,
+				'total_instruction_bytes'        => 47,
+				'max_instruction_bytes'          => 27,
+			),
+			$this->summarize_xml_processing_instruction_inventory( $processor, $implementation )
+		);
+	}
+
+	/**
+	 * Verifies document-level comment inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_comment_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><root><!-- lead --><item><!-- --></item><empty><!--x--></empty><!--   --></root><!--trailer-->';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'             => 12,
+				'comment_count'           => 5,
+				'non_empty_comment_count' => 3,
+				'empty_comment_count'     => 2,
+				'total_comment_bytes'     => 18,
+				'max_comment_bytes'       => 7,
+			),
+			$this->summarize_xml_comment_inventory( $processor, $implementation )
+		);
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'             => 10,
+				'comment_count'           => 5,
+				'non_empty_comment_count' => 3,
+				'empty_comment_count'     => 2,
+				'total_comment_bytes'     => 18,
+				'max_comment_bytes'       => 7,
+			),
+			$this->summarize_xml_comment_inventory( $processor, $implementation )
+		);
+	}
+
+	/**
+	 * Verifies document-level payload inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_payload_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><root>Alpha<!-- note --><item><![CDATA[raw]]><?xml audit data?></item><space>   </space></root><?xml trailing?>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'                  => 13,
+				'text_token_count'             => 2,
+				'cdata_count'                  => 1,
+				'comment_count'                => 1,
+				'processing_instruction_count' => 2,
+				'total_payload_bytes'          => 37,
+				'max_payload_bytes'            => 11,
+			),
+			$this->summarize_xml_payload_inventory( $processor, $implementation )
+		);
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'                  => 11,
+				'text_token_count'             => 2,
+				'cdata_count'                  => 1,
+				'comment_count'                => 1,
+				'processing_instruction_count' => 2,
+				'total_payload_bytes'          => 37,
+				'max_payload_bytes'            => 11,
+			),
+			$this->summarize_xml_payload_inventory( $processor, $implementation )
+		);
+	}
+
+	/**
+	 * Verifies document-level content inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_content_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><root id="root"><item data-kind="post">Title<!-- note --><![CDATA[raw]]><?xml audit data?></item><empty data-id="x" /></root><?xml trailing?>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'                  => 11,
+				'tag_count'                    => 3,
+				'attribute_count'              => 3,
+				'text_token_count'             => 1,
+				'cdata_count'                  => 1,
+				'comment_count'                => 1,
+				'processing_instruction_count' => 2,
+				'total_attribute_value_bytes'  => 9,
+				'max_attribute_value_bytes'    => 4,
+				'total_payload_bytes'          => 34,
+				'max_payload_bytes'            => 11,
+			),
+			$this->summarize_xml_content_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'                  => 9,
+				'tag_count'                    => 2,
+				'attribute_count'              => 2,
+				'text_token_count'             => 1,
+				'cdata_count'                  => 1,
+				'comment_count'                => 1,
+				'processing_instruction_count' => 2,
+				'total_attribute_value_bytes'  => 5,
+				'max_attribute_value_bytes'    => 4,
+				'total_payload_bytes'          => 34,
+				'max_payload_bytes'            => 11,
+			),
+			$this->summarize_xml_content_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+	}
+
+	/**
+	 * Verifies importer-facing inventories match repeated token scans.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_summarizes_import_inventory( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$xml       = '<?xml version="1.0"?><root id="root"><item data-kind="post">Title<!-- note --><![CDATA[raw]]><?xml audit data?></item><empty data-id="x" /></root><?xml trailing?>';
+		$processor = $this->create_xml_processor( $implementation, $xml );
+
+		$this->assertSame(
+			array(
+				'token_count'                  => 11,
+				'tag_count'                    => 3,
+				'closing_tag_count'            => 2,
+				'unique_tag_name_count'        => 3,
+				'duplicate_tag_name_count'     => 0,
+				'namespaced_tag_count'         => 0,
+				'empty_element_count'          => 1,
+				'root_level_tag_count'         => 1,
+				'nested_tag_count'             => 0,
+				'total_tag_depth'              => 5,
+				'max_depth'                    => 2,
+				'leaf_element_count'           => 2,
+				'branch_element_count'         => 1,
+				'max_child_element_count'      => 2,
+				'attribute_count'              => 3,
+				'text_token_count'             => 1,
+				'cdata_count'                  => 1,
+				'comment_count'                => 1,
+				'processing_instruction_count' => 2,
+				'total_attribute_value_bytes'  => 9,
+				'max_attribute_value_bytes'    => 4,
+				'total_payload_bytes'          => 34,
+				'max_payload_bytes'            => 11,
+			),
+			$this->summarize_xml_import_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+
+		$processor = $this->create_xml_processor( $implementation, $xml );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'                  => 9,
+				'tag_count'                    => 2,
+				'closing_tag_count'            => 2,
+				'unique_tag_name_count'        => 2,
+				'duplicate_tag_name_count'     => 0,
+				'namespaced_tag_count'         => 0,
+				'empty_element_count'          => 1,
+				'root_level_tag_count'         => 0,
+				'nested_tag_count'             => 0,
+				'total_tag_depth'              => 4,
+				'max_depth'                    => 2,
+				'leaf_element_count'           => 2,
+				'branch_element_count'         => 0,
+				'max_child_element_count'      => 0,
+				'attribute_count'              => 2,
+				'text_token_count'             => 1,
+				'cdata_count'                  => 1,
+				'comment_count'                => 1,
+				'processing_instruction_count' => 2,
+				'total_attribute_value_bytes'  => 5,
+				'max_attribute_value_bytes'    => 4,
+				'total_payload_bytes'          => 34,
+				'max_payload_bytes'            => 11,
+			),
+			$this->summarize_xml_import_inventory( $processor, $implementation )
+		);
+		$this->assertTrue( $processor->is_finished() );
+	}
+
+	/**
+	 * Verifies chunked tag summaries stay aligned with tag-by-tag reads.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reads_tag_summary_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0"?><root id="root"><item id="7">Text</item><empty /></root>'
+		);
+		$rows      = array();
+
+		do {
+			$batch = $this->next_xml_tag_summary_batch( $processor, $implementation, 2, 'id' );
+			$rows  = array_merge( $rows, $batch );
+		} while ( ! empty( $batch ) );
+
+		$this->assertCount( 3, $rows );
+		$this->assertSame(
+			array( 'root', 'item', 'empty' ),
+			array_column( $rows, 'tag_local_name' )
+		);
+		$this->assertSame(
+			array( 'root', '7', null ),
+			array_column( $rows, 'id' )
+		);
+		$this->assertSame( 1, $rows[0]['current_depth'] );
+		$this->assertSame( 2, $rows[1]['current_depth'] );
+		$this->assertTrue( $rows[2]['is_empty_element'] );
+	}
+
+	/**
+	 * Verifies matching tag summaries skip non-matching tags while preserving metadata.
+	 *
+	 * @dataProvider data_xml_processor_implementations
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	public function test_xml_processor_reads_matching_tag_summary_batches( $implementation ) {
+		$this->skip_if_native_is_unavailable( $implementation );
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org"><wp:item id="7"><wp:title>Title</wp:title></wp:item><item id="plain" /><wp:item id="8" /></wp:root>'
+		);
+		$rows      = array();
+
+		do {
+			$batch = $this->next_xml_matching_tag_summary_batch( $processor, $implementation, 1, 'https://wordpress.org', 'item', 'id' );
+			$rows  = array_merge( $rows, $batch );
+		} while ( ! empty( $batch ) );
+
+		$this->assertCount( 2, $rows );
+		$this->assertSame(
+			array( 'item', 'item' ),
+			array_column( $rows, 'tag_local_name' )
+		);
+		$this->assertSame(
+			array( 'https://wordpress.org', 'https://wordpress.org' ),
+			array_column( $rows, 'tag_namespace' )
+		);
+		$this->assertSame(
+			array( '7', '8' ),
+			array_column( $rows, 'id' )
+		);
+		$this->assertSame( 2, $rows[0]['current_depth'] );
+		$this->assertSame( 2, $rows[1]['current_depth'] );
+		$this->assertFalse( $rows[0]['is_empty_element'] );
+		$this->assertTrue( $rows[1]['is_empty_element'] );
+
+		$this->assertSame(
+			array(),
+			$this->next_xml_matching_tag_summary_batch( $processor, $implementation, 1, 'https://wordpress.org', 'missing', 'id' )
+		);
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org"><wp:item id="7"><wp:title>Title</wp:title></wp:item><item id="plain" /><wp:item id="8" /></wp:root>'
+		);
+
+		$this->assertSame(
+			array(
+				'token_count'     => 3,
+				'tag_count'       => 1,
+				'attribute_count' => 1,
+			),
+			$this->next_xml_matching_tag_count_batch( $processor, $implementation, 1, 'https://wordpress.org', 'item', 'id' )
+		);
+		$this->assertSame(
+			array(
+				'token_count'     => 6,
+				'tag_count'       => 1,
+				'attribute_count' => 1,
+			),
+			$this->next_xml_matching_tag_count_batch( $processor, $implementation, 1, 'https://wordpress.org', 'item', 'id' )
+		);
+		$this->assertSame(
+			array(
+				'token_count'     => 1,
+				'tag_count'       => 0,
+				'attribute_count' => 0,
+			),
+			$this->next_xml_matching_tag_count_batch( $processor, $implementation, 1, 'https://wordpress.org', 'item', 'id' )
+		);
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org"><wp:item id="7"><wp:title>Title</wp:title></wp:item><item id="plain" /><wp:item id="8" /></wp:root>'
+		);
+
+		$this->assertSame(
+			array(
+				'token_count'     => 10,
+				'tag_count'       => 2,
+				'attribute_count' => 2,
+			),
+			$this->summarize_xml_matching_tag_stream( $processor, $implementation, 'https://wordpress.org', 'item', 'id' )
+		);
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org"><wp:item id="7"><wp:title>Title</wp:title></wp:item><item id="plain" /><wp:item id="8" /></wp:root>'
+		);
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame(
+			array(
+				'token_count'     => 8,
+				'tag_count'       => 2,
+				'attribute_count' => 2,
+			),
+			$this->summarize_xml_matching_tag_stream( $processor, $implementation, 'https://wordpress.org', 'item', 'id' )
+		);
+
+		$processor = $this->create_xml_processor(
+			$implementation,
+			'<?xml version="1.0"?><wp:root xmlns:wp="https://wordpress.org"><wp:item id="7" slug="first"><wp:title>Title</wp:title></wp:item><item id="plain" slug="skip" /><wp:item id="8" status="draft" /></wp:root>'
+		);
+
+		$this->assertSame(
+			array(
+				'token_count'     => 10,
+				'tag_count'       => 2,
+				'attribute_count' => 4,
+			),
+			$this->summarize_xml_matching_tag_attributes_stream(
+				$processor,
+				$implementation,
+				'https://wordpress.org',
+				'item',
+				array( 'id', 'slug', 'status', 'missing' )
+			)
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_xml_processor_implementations() {
+		return array(
+			'php-xml-processor'    => array( 'php-xml-processor' ),
+			'native-xml-processor' => array( 'native-xml-processor' ),
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_xml_without_document_element() {
+		return array(
+			'php-empty'              => array( '', 'php-xml-processor' ),
+			'native-empty'           => array( '', 'native-xml-processor' ),
+			'php-whitespace'         => array( " \n\t", 'php-xml-processor' ),
+			'native-whitespace'      => array( " \n\t", 'native-xml-processor' ),
+			'php-comment-only'       => array( '<!--c-->', 'php-xml-processor' ),
+			'native-comment-only'    => array( '<!--c-->', 'native-xml-processor' ),
+			'php-declaration-only'   => array( '<?xml version="1.0"?>', 'php-xml-processor' ),
+			'native-declaration-only' => array( '<?xml version="1.0"?>', 'native-xml-processor' ),
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_xml_with_leading_misc_whitespace() {
+		return array(
+			'php-whitespace-root'              => array( " \n\t<root />", array( 'root' ), 'php-xml-processor' ),
+			'native-whitespace-root'           => array( " \n\t<root />", array( 'root' ), 'native-xml-processor' ),
+			'php-comment-whitespace-root'      => array( "<!--c-->\n<root />", array( '#comment', 'root' ), 'php-xml-processor' ),
+			'native-comment-whitespace-root'   => array( "<!--c-->\n<root />", array( '#comment', 'root' ), 'native-xml-processor' ),
+			'php-declaration-whitespace-root'  => array( "<?xml version=\"1.0\"?>\n<root />", array( '#xml-declaration', 'root' ), 'php-xml-processor' ),
+			'native-declaration-whitespace-root' => array( "<?xml version=\"1.0\"?>\n<root />", array( '#xml-declaration', 'root' ), 'native-xml-processor' ),
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_malformed_attribute_xml_processor_implementations() {
+		return array(
+			'php-lt-in-attribute-value'       => array( '<root enabled="I love <3 this" />', 'php-xml-processor' ),
+			'native-lt-in-attribute-value'    => array( '<root enabled="I love <3 this" />', 'native-xml-processor' ),
+			'php-duplicate-attribute'         => array( '<root id="first" id="second" />', 'php-xml-processor' ),
+			'native-duplicate-attribute'      => array( '<root id="first" id="second" />', 'native-xml-processor' ),
+			'php-empty-prefixed-namespace'    => array( '<root xmlns:a="" />', 'php-xml-processor' ),
+			'native-empty-prefixed-namespace' => array( '<root xmlns:a="" />', 'native-xml-processor' ),
+		);
+	}
+
+	/**
+	 * Creates an XML processor for a specific implementation.
+	 *
+	 * @param string $implementation Implementation identifier.
+	 * @param string $xml            XML input.
+	 * @return object Processor instance.
+	 */
+	private function create_xml_processor( $implementation, $xml ) {
+		if ( 'native-xml-processor' === $implementation ) {
+			$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+
+			return $class_name::create_from_string( $xml );
+		}
+
+		$processor = XMLProcessor::create_from_string( $xml );
+		$this->disable_native_delegate( $processor );
+
+		return $processor;
+	}
+
+	/**
+	 * Creates a streaming XML processor for a specific implementation.
+	 *
+	 * @param string $implementation Implementation identifier.
+	 * @param string $xml            XML input.
+	 * @return object Processor instance.
+	 */
+	private function create_xml_streaming_processor( $implementation, $xml ) {
+		if ( 'native-xml-processor' === $implementation ) {
+			$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+
+			return $class_name::create_for_streaming( $xml, null, 'UTF-8', array() );
+		}
+
+		$processor = XMLProcessor::create_for_streaming( $xml );
+		$this->disable_native_delegate( $processor );
+
+		return $processor;
+	}
+
+	/**
+	 * Creates a streaming XML processor from a reentrancy cursor for a specific implementation.
+	 *
+	 * @param string $implementation Implementation identifier.
+	 * @param string $xml            XML input.
+	 * @param string $cursor         Reentrancy cursor.
+	 * @return object Processor instance.
+	 */
+	private function create_xml_streaming_processor_from_cursor( $implementation, $xml, $cursor ) {
+		if ( 'native-xml-processor' === $implementation ) {
+			$class_name = 'WordPress\\XML\\NativeXMLProcessor';
+
+			return $class_name::create_for_streaming( $xml, $cursor, 'UTF-8', array() );
+		}
+
+		$processor = XMLProcessor::create_for_streaming( $xml, $cursor );
+		$this->disable_native_delegate( $processor );
+
+		return $processor;
+	}
+
+	/**
+	 * Disables the native delegate so PHP implementation rows still cover PHP.
+	 *
+	 * @param object $processor Processor instance.
+	 */
+	private function disable_native_delegate( $processor ) {
+		if ( method_exists( $processor, 'disable_native_processor' ) ) {
+			$processor->disable_native_processor();
+		}
+	}
+
+	/**
+	 * Returns the native delegate for public-class default checks.
+	 *
+	 * @param object $processor Processor instance.
+	 * @return object|null Native delegate.
+	 */
+	private function get_native_delegate( $processor ) {
+		if (
+			class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) &&
+			! method_exists( 'WordPress\\XML\\NativeXMLProcessor', 'supports_public_api' )
+		) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor does not expose the public API surface; rebuild the native extension.' );
+		}
+
+		if ( method_exists( $processor, 'get_native_processor' ) ) {
+			return $processor->get_native_processor();
+		}
+
+		return null;
+	}
+
+	/**
+	 * Runs a fresh PHP process that defines native-default constants before bootstrap.
+	 *
+	 * @param string $constant_definitions PHP source defining constants.
+	 * @return string[] Probe output lines.
+	 */
+	private function run_xml_native_defaults_constant_probe( $constant_definitions ) {
+		$root      = dirname( __DIR__, 3 );
+		$extension = $root . '/extensions/native-apis/target/release/libwp_native_apis.so';
+
+		if ( ! file_exists( $extension ) ) {
+			$this->markTestSkipped( 'Native API extension binary is not built.' );
+		}
+
+		$code = $constant_definitions . "\n" .
+			'require ' . var_export( $root . '/bootstrap.php', true ) . ";\n" .
+			'$class_name = \'WordPress\\\\XML\\\\XMLProcessor\';' . "\n" .
+			'$processor = $class_name::create_from_string( \'<root><item id="1" /></root>\' );' . "\n" .
+			'$delegate = method_exists( $processor, \'get_native_processor\' ) ? $processor->get_native_processor() : null;' . "\n" .
+			'echo \'delegate:\' . ( null === $delegate ? \'php\' : get_class( $delegate ) ) . "\n";' . "\n" .
+			'$processor->next_tag( \'item\' );' . "\n" .
+			'echo \'token:\' . $processor->get_token_name() . "\n";' . "\n" .
+			'echo \'id:\' . $processor->get_attribute( \'\', \'id\' ) . "\n";';
+
+		$command = escapeshellarg( PHP_BINARY ) . ' -d extension=' . escapeshellarg( $extension ) . ' -r ' . escapeshellarg( $code );
+		$output  = array();
+		$status  = 0;
+		exec( $command . ' 2>&1', $output, $status );
+
+		$this->assertSame( 0, $status, implode( "\n", $output ) );
+
+		return $output;
+	}
+
+	/**
+	 * Reads an XML attribute through the implementation-specific signature.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param string $local_name     Attribute local name.
+	 * @return string|true|null Attribute value.
+	 */
+	private function get_xml_attribute( $processor, $implementation, $local_name, $namespace = '' ) {
+		return $processor->get_attribute( $namespace, $local_name );
+	}
+
+	/**
+	 * Skips implementation rows when an API is provided only by the native class.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param string $method         Method name.
+	 */
+	private function skip_if_xml_method_is_unavailable( $processor, $implementation, $method ) {
+		if ( ! method_exists( $processor, $method ) ) {
+			$this->markTestSkipped( "{$method} is not exposed by {$implementation}." );
+		}
+	}
+
+	/**
+	 * Runs the implementation-specific XML attribute-prefix summary API.
+	 *
+	 * @param object      $processor             Processor instance.
+	 * @param string      $implementation        Implementation identifier.
+	 * @param string|null $full_namespace_prefix Namespace prefix to match.
+	 * @param string      $local_name_prefix     Local name prefix to match.
+	 * @return array Summary with `tag_count` and `attribute_count`.
+	 */
+	private function summarize_xml_attribute_names_with_prefix( $processor, $implementation, $full_namespace_prefix, $local_name_prefix ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_attribute_names_with_prefix' );
+
+		$summary = $processor->summarize_attribute_names_with_prefix( $full_namespace_prefix, $local_name_prefix );
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 3 );
+
+		return array(
+			'tag_count'       => (int) $parts[1],
+			'attribute_count' => (int) $parts[2],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML token stream summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param string $attribute_name Attribute name to count.
+	 * @return array Summary with `token_count`, `tag_count`, and `attribute_count`.
+	 */
+	private function summarize_xml_token_stream( $processor, $implementation, $attribute_name ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_token_stream' );
+
+		$summary = $processor->summarize_token_stream( $attribute_name );
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 3 );
+
+		return array(
+			'token_count'     => (int) $parts[0],
+			'tag_count'       => (int) $parts[1],
+			'attribute_count' => (int) $parts[2],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML document inventory summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with token category counts and maximum depth.
+	 */
+	private function summarize_xml_document_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_document_inventory' );
+
+		$summary = $processor->summarize_document_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 8 );
+		$this->assertCount( 8, $parts, 'Expected compact XML document inventory summary.' );
+
+		return array(
+			'token_count'         => (int) $parts[0],
+			'tag_count'           => (int) $parts[1],
+			'closing_tag_count'   => (int) $parts[2],
+			'text_token_count'    => (int) $parts[3],
+			'comment_count'       => (int) $parts[4],
+			'cdata_count'         => (int) $parts[5],
+			'max_depth'           => (int) $parts[6],
+			'empty_element_count' => (int) $parts[7],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML element inventory summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with element-name inventory counts.
+	 */
+	private function summarize_xml_element_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_element_inventory' );
+
+		$summary = $processor->summarize_element_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 7 );
+		$this->assertCount( 7, $parts, 'Expected compact XML element inventory summary.' );
+
+		return array(
+			'token_count'              => (int) $parts[0],
+			'tag_count'                => (int) $parts[1],
+			'closing_tag_count'        => (int) $parts[2],
+			'unique_tag_name_count'    => (int) $parts[3],
+			'duplicate_tag_name_count' => (int) $parts[4],
+			'namespaced_tag_count'     => (int) $parts[5],
+			'empty_element_count'      => (int) $parts[6],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML depth inventory summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with depth distribution counts.
+	 */
+	private function summarize_xml_depth_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_depth_inventory' );
+
+		$summary = $processor->summarize_depth_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 8 );
+		$this->assertCount( 8, $parts, 'Expected compact XML depth inventory summary.' );
+
+		return array(
+			'token_count'          => (int) $parts[0],
+			'tag_count'            => (int) $parts[1],
+			'closing_tag_count'    => (int) $parts[2],
+			'empty_element_count'  => (int) $parts[3],
+			'root_level_tag_count' => (int) $parts[4],
+			'nested_tag_count'     => (int) $parts[5],
+			'total_tag_depth'      => (int) $parts[6],
+			'max_depth'            => (int) $parts[7],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML leaf inventory summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with leaf and branch element counts.
+	 */
+	private function summarize_xml_leaf_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_leaf_inventory' );
+
+		$summary = $processor->summarize_leaf_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 7 );
+		$this->assertCount( 7, $parts, 'Expected compact XML leaf inventory summary.' );
+
+		return array(
+			'token_count'             => (int) $parts[0],
+			'tag_count'               => (int) $parts[1],
+			'closing_tag_count'       => (int) $parts[2],
+			'empty_element_count'     => (int) $parts[3],
+			'leaf_element_count'      => (int) $parts[4],
+			'branch_element_count'    => (int) $parts[5],
+			'max_child_element_count' => (int) $parts[6],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML structural inventory summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with structural element counts.
+	 */
+	private function summarize_xml_structural_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_structural_inventory' );
+
+		$summary = $processor->summarize_structural_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 14 );
+		$this->assertCount( 14, $parts, 'Expected compact XML structural inventory summary.' );
+
+		return array(
+			'token_count'              => (int) $parts[0],
+			'tag_count'                => (int) $parts[1],
+			'closing_tag_count'        => (int) $parts[2],
+			'unique_tag_name_count'    => (int) $parts[3],
+			'duplicate_tag_name_count' => (int) $parts[4],
+			'namespaced_tag_count'     => (int) $parts[5],
+			'empty_element_count'      => (int) $parts[6],
+			'root_level_tag_count'     => (int) $parts[7],
+			'nested_tag_count'         => (int) $parts[8],
+			'total_tag_depth'          => (int) $parts[9],
+			'max_depth'                => (int) $parts[10],
+			'leaf_element_count'       => (int) $parts[11],
+			'branch_element_count'     => (int) $parts[12],
+			'max_child_element_count'  => (int) $parts[13],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML attribute inventory summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with attribute inventory counts.
+	 */
+	private function summarize_xml_attribute_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_attribute_inventory' );
+
+		$summary = $processor->summarize_attribute_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 6 );
+		$this->assertCount( 6, $parts, 'Expected compact XML attribute inventory summary.' );
+
+		return array(
+			'token_count'                  => (int) $parts[0],
+			'tag_count'                    => (int) $parts[1],
+			'attribute_count'              => (int) $parts[2],
+			'namespaced_attribute_count'   => (int) $parts[3],
+			'tags_with_attributes_count'   => (int) $parts[4],
+			'max_attribute_count'          => (int) $parts[5],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML ID inventory summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with ID inventory counts.
+	 */
+	private function summarize_xml_id_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_id_inventory' );
+
+		$summary = $processor->summarize_id_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 6 );
+		$this->assertCount( 6, $parts, 'Expected compact XML ID inventory summary.' );
+
+		return array(
+			'token_count'        => (int) $parts[0],
+			'tag_count'          => (int) $parts[1],
+			'id_attribute_count' => (int) $parts[2],
+			'unique_id_count'    => (int) $parts[3],
+			'duplicate_id_count' => (int) $parts[4],
+			'id_value_bytes'     => (int) $parts[5],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML namespace inventory summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with namespace inventory counts.
+	 */
+	private function summarize_xml_namespace_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_namespace_inventory' );
+
+		$summary = $processor->summarize_namespace_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 6 );
+		$this->assertCount( 6, $parts, 'Expected compact XML namespace inventory summary.' );
+
+		return array(
+			'token_count'                  => (int) $parts[0],
+			'tag_count'                    => (int) $parts[1],
+			'namespaced_tag_count'         => (int) $parts[2],
+			'attribute_count'              => (int) $parts[3],
+			'namespaced_attribute_count'   => (int) $parts[4],
+			'unique_namespace_count'       => (int) $parts[5],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML text inventory summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with text and CDATA inventory counts.
+	 */
+	private function summarize_xml_text_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_text_inventory' );
+
+		$summary = $processor->summarize_text_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 7 );
+		$this->assertCount( 7, $parts, 'Expected compact XML text inventory summary.' );
+
+		return array(
+			'token_count'           => (int) $parts[0],
+			'text_token_count'      => (int) $parts[1],
+			'cdata_count'           => (int) $parts[2],
+			'non_empty_text_count'  => (int) $parts[3],
+			'whitespace_text_count' => (int) $parts[4],
+			'total_text_bytes'      => (int) $parts[5],
+			'max_text_bytes'        => (int) $parts[6],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML processing instruction inventory API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with XML declaration and processing instruction counts.
+	 */
+	private function summarize_xml_processing_instruction_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_processing_instruction_inventory' );
+
+		$summary = $processor->summarize_processing_instruction_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 6 );
+		$this->assertCount( 6, $parts, 'Expected compact XML processing instruction inventory summary.' );
+
+		return array(
+			'token_count'                    => (int) $parts[0],
+			'processing_instruction_count'   => (int) $parts[1],
+			'xml_declaration_count'          => (int) $parts[2],
+			'non_empty_instruction_count'    => (int) $parts[3],
+			'total_instruction_bytes'        => (int) $parts[4],
+			'max_instruction_bytes'          => (int) $parts[5],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML comment inventory API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with XML comment counts and byte totals.
+	 */
+	private function summarize_xml_comment_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_comment_inventory' );
+
+		$summary = $processor->summarize_comment_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 6 );
+		$this->assertCount( 6, $parts, 'Expected compact XML comment inventory summary.' );
+
+		return array(
+			'token_count'             => (int) $parts[0],
+			'comment_count'           => (int) $parts[1],
+			'non_empty_comment_count' => (int) $parts[2],
+			'empty_comment_count'     => (int) $parts[3],
+			'total_comment_bytes'     => (int) $parts[4],
+			'max_comment_bytes'       => (int) $parts[5],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML payload inventory API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with XML payload counts and byte totals.
+	 */
+	private function summarize_xml_payload_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_payload_inventory' );
+
+		$summary = $processor->summarize_payload_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 7 );
+		$this->assertCount( 7, $parts, 'Expected compact XML payload inventory summary.' );
+
+		return array(
+			'token_count'                  => (int) $parts[0],
+			'text_token_count'             => (int) $parts[1],
+			'cdata_count'                  => (int) $parts[2],
+			'comment_count'                => (int) $parts[3],
+			'processing_instruction_count' => (int) $parts[4],
+			'total_payload_bytes'          => (int) $parts[5],
+			'max_payload_bytes'            => (int) $parts[6],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML content inventory API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with XML content and metadata byte totals.
+	 */
+	private function summarize_xml_content_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_content_inventory' );
+
+		$summary = $processor->summarize_content_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 11 );
+		$this->assertCount( 11, $parts, 'Expected compact XML content inventory summary.' );
+
+		return array(
+			'token_count'                  => (int) $parts[0],
+			'tag_count'                    => (int) $parts[1],
+			'attribute_count'              => (int) $parts[2],
+			'text_token_count'             => (int) $parts[3],
+			'cdata_count'                  => (int) $parts[4],
+			'comment_count'                => (int) $parts[5],
+			'processing_instruction_count' => (int) $parts[6],
+			'total_attribute_value_bytes'  => (int) $parts[7],
+			'max_attribute_value_bytes'    => (int) $parts[8],
+			'total_payload_bytes'          => (int) $parts[9],
+			'max_payload_bytes'            => (int) $parts[10],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML import inventory API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @return array Summary with importer-facing XML structure and content counts.
+	 */
+	private function summarize_xml_import_inventory( $processor, $implementation ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_import_inventory' );
+
+		$summary = $processor->summarize_import_inventory();
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 23 );
+		$this->assertCount( 23, $parts, 'Expected compact XML import inventory summary.' );
+
+		return array(
+			'token_count'                  => (int) $parts[0],
+			'tag_count'                    => (int) $parts[1],
+			'closing_tag_count'            => (int) $parts[2],
+			'unique_tag_name_count'        => (int) $parts[3],
+			'duplicate_tag_name_count'     => (int) $parts[4],
+			'namespaced_tag_count'         => (int) $parts[5],
+			'empty_element_count'          => (int) $parts[6],
+			'root_level_tag_count'         => (int) $parts[7],
+			'nested_tag_count'             => (int) $parts[8],
+			'total_tag_depth'              => (int) $parts[9],
+			'max_depth'                    => (int) $parts[10],
+			'leaf_element_count'           => (int) $parts[11],
+			'branch_element_count'         => (int) $parts[12],
+			'max_child_element_count'      => (int) $parts[13],
+			'attribute_count'              => (int) $parts[14],
+			'text_token_count'             => (int) $parts[15],
+			'cdata_count'                  => (int) $parts[16],
+			'comment_count'                => (int) $parts[17],
+			'processing_instruction_count' => (int) $parts[18],
+			'total_attribute_value_bytes'  => (int) $parts[19],
+			'max_attribute_value_bytes'    => (int) $parts[20],
+			'total_payload_bytes'          => (int) $parts[21],
+			'max_payload_bytes'            => (int) $parts[22],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML tag stream summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param string $attribute_name Attribute name to count.
+	 * @return array Summary with `tag_count` and `attribute_count`.
+	 */
+	private function summarize_xml_tag_stream( $processor, $implementation, $attribute_name ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_tag_stream' );
+
+		$summary = $processor->summarize_tag_stream( $attribute_name );
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 3 );
+
+		return array(
+			'tag_count'       => (int) $parts[1],
+			'attribute_count' => (int) $parts[2],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML token summary batch API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param int    $max_tokens     Maximum number of tokens to fetch.
+	 * @return array[] Token summary rows.
+	 */
+	private function next_xml_token_summary_batch( $processor, $implementation, $max_tokens ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'next_token_summary_batch' );
+
+		return $processor->next_token_summary_batch( $max_tokens );
+	}
+
+	/**
+	 * Runs the implementation-specific XML tag summary batch API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param int    $max_tags       Maximum number of tags to fetch.
+	 * @param string $attribute_name Attribute name to include.
+	 * @return array[] Tag summary rows.
+	 */
+	private function next_xml_tag_summary_batch( $processor, $implementation, $max_tags, $attribute_name ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'next_tag_summary_batch' );
+
+		return $processor->next_tag_summary_batch( $max_tags, $attribute_name );
+	}
+
+	/**
+	 * Runs the implementation-specific XML matching tag summary batch API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param int    $max_tags       Maximum number of matching tags to fetch.
+	 * @param string $tag_namespace  Namespace URI to match.
+	 * @param string $tag_local_name Local tag name to match.
+	 * @param string $attribute_name Attribute name to include.
+	 * @return array[] Tag summary rows.
+	 */
+	private function next_xml_matching_tag_summary_batch( $processor, $implementation, $max_tags, $tag_namespace, $tag_local_name, $attribute_name ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'next_matching_tag_summary_batch' );
+
+		return $processor->next_matching_tag_summary_batch( $max_tags, $tag_namespace, $tag_local_name, $attribute_name );
+	}
+
+	/**
+	 * Runs the implementation-specific XML matching tag count batch API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param int    $max_tags       Maximum number of matching tags to count.
+	 * @param string $tag_namespace  Namespace URI to match.
+	 * @param string $tag_local_name Local tag name to match.
+	 * @param string $attribute_name Attribute name to count.
+	 * @return array Summary with `token_count`, `tag_count`, and `attribute_count`.
+	 */
+	private function next_xml_matching_tag_count_batch( $processor, $implementation, $max_tags, $tag_namespace, $tag_local_name, $attribute_name ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'next_matching_tag_count_batch' );
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $processor->next_matching_tag_count_batch( $max_tags, $tag_namespace, $tag_local_name, $attribute_name );
+		}
+
+		$summary = $processor->next_matching_tag_count_batch( $max_tags, $tag_namespace, $tag_local_name, $attribute_name );
+		if ( ! is_string( $summary ) ) {
+			return array(
+				'token_count'     => 0,
+				'tag_count'       => 0,
+				'attribute_count' => 0,
+			);
+		}
+
+		$parts = explode( "\x1f", $summary, 3 );
+		$this->assertCount( 3, $parts, 'Expected compact XML matching tag count batch summary.' );
+
+		return array(
+			'token_count'     => (int) $parts[0],
+			'tag_count'       => (int) $parts[1],
+			'attribute_count' => (int) $parts[2],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML matching tag summary API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param string $tag_namespace  Namespace URI to match.
+	 * @param string $tag_local_name Local tag name to match.
+	 * @param string $attribute_name Attribute name to count.
+	 * @return array Summary with `token_count`, `tag_count`, and `attribute_count`.
+	 */
+	private function summarize_xml_matching_tag_stream( $processor, $implementation, $tag_namespace, $tag_local_name, $attribute_name ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_matching_tag_stream' );
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $processor->summarize_matching_tag_stream( $tag_namespace, $tag_local_name, $attribute_name );
+		}
+
+		$summary = $processor->summarize_matching_tag_stream( $tag_namespace, $tag_local_name, $attribute_name );
+		$this->assertIsString( $summary );
+
+		$parts = explode( "\x1f", $summary, 3 );
+		$this->assertCount( 3, $parts, 'Expected compact XML matching tag stream summary.' );
+
+		return array(
+			'token_count'     => (int) $parts[0],
+			'tag_count'       => (int) $parts[1],
+			'attribute_count' => (int) $parts[2],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML matching tag attributes summary API.
+	 *
+	 * @param object $processor       Processor instance.
+	 * @param string $implementation  Implementation identifier.
+	 * @param string $tag_namespace   Namespace URI to match.
+	 * @param string $tag_local_name  Local tag name to match.
+	 * @param array  $attribute_names Attribute names to count.
+	 * @return array Summary with `token_count`, `tag_count`, and `attribute_count`.
+	 */
+	private function summarize_xml_matching_tag_attributes_stream( $processor, $implementation, $tag_namespace, $tag_local_name, $attribute_names ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'summarize_matching_tag_attributes_stream' );
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $processor->summarize_matching_tag_attributes_stream( $tag_namespace, $tag_local_name, $attribute_names );
+		}
+
+		$summary = $processor->summarize_matching_tag_attributes_stream(
+			$tag_namespace,
+			$tag_local_name,
+			implode( "\x1f", $attribute_names )
+		);
+		$this->assertIsString( $summary );
+
+		$parts = explode( "\x1f", $summary, 3 );
+		$this->assertCount( 3, $parts, 'Expected compact XML matching tag attributes stream summary.' );
+
+		return array(
+			'token_count'     => (int) $parts[0],
+			'tag_count'       => (int) $parts[1],
+			'attribute_count' => (int) $parts[2],
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML tag count batch API.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param int    $max_tags       Maximum number of tags to count.
+	 * @param string $attribute_name Attribute name to count.
+	 * @return array Summary with `token_count`, `tag_count`, and `attribute_count`.
+	 */
+	private function next_xml_tag_count_batch( $processor, $implementation, $max_tags, $attribute_name ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'next_tag_count_batch' );
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $processor->next_tag_count_batch( $max_tags, $attribute_name );
+		}
+
+		$summary = $processor->next_tag_count_batch( $max_tags, $attribute_name );
+		if ( ! is_string( $summary ) ) {
+			return array(
+				'token_count'     => 0,
+				'tag_count'       => 0,
+				'attribute_count' => 0,
+			);
+		}
+
+		$parts = explode( "\x1f", $summary, 3 );
+		$this->assertCount( 3, $parts, 'Expected compact XML tag count batch summary.' );
+
+		return array(
+			'token_count'     => (int) $parts[0],
+			'tag_count'       => (int) $parts[1],
+			'attribute_count' => (int) $parts[2],
+		);
+	}
+
+	/**
+	 * Runs a streaming XML batch case.
+	 *
+	 * @param object $processor      Processor instance.
+	 * @param string $implementation Implementation identifier.
+	 * @param string $case           Batch case identifier.
+	 * @return mixed Batch result.
+	 */
+	private function run_xml_streaming_batch_case( $processor, $implementation, $case ) {
+		switch ( $case ) {
+			case 'token_compact':
+				$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'next_token_compact_summary_batch' );
+				return $processor->next_token_compact_summary_batch( 10 );
+
+			case 'tag_compact':
+				$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'next_tag_compact_summary_batch' );
+				return $processor->next_tag_compact_summary_batch( 10, 'id' );
+
+			case 'tag_count':
+				return $this->next_xml_tag_count_batch( $processor, $implementation, 10, 'id' );
+
+			case 'matching_tag_compact':
+				$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'next_matching_tag_compact_summary_batch' );
+				return $processor->next_matching_tag_compact_summary_batch( 10, '', 'item', 'id' );
+
+			case 'matching_tag_count':
+				return $this->next_xml_matching_tag_count_batch( $processor, $implementation, 10, '', 'item', 'id' );
+		}
+
+		$this->fail( 'Unknown XML streaming batch case: ' . $case );
+	}
+
+	/**
+	 * Parses a native compact XML token summary row.
+	 *
+	 * @param string $metadata Native compact metadata row.
+	 * @return array Token summary row.
+	 */
+	private function parse_native_compact_token_summary( $metadata ) {
+		$parts = explode( "\x1f", $metadata, 6 );
+		$this->assertCount( 6, $parts, 'Expected compact XML token summary row.' );
+
+		switch ( $parts[0] ) {
+			case 't':
+				$token_type = '#tag';
+				$token_name = $parts[1];
+				break;
+			case 'x':
+				$token_type = '#xml-declaration';
+				$token_name = '#xml-declaration';
+				break;
+			case 'd':
+				$token_type = '#doctype';
+				$token_name = '#doctype';
+				break;
+			case 'p':
+				$token_type = '#processing-instructions';
+				$token_name = '#processing-instructions';
+				break;
+			case 'c':
+				$token_type = '#comment';
+				$token_name = '#comment';
+				break;
+			case 'a':
+				$token_type = '#cdata-section';
+				$token_name = '#cdata-section';
+				break;
+			default:
+				$token_type = '#text';
+				$token_name = '#text';
+				break;
+		}
+
+		$id_found = isset( $parts[5][0] ) && '1' === $parts[5][0];
+
+		return array(
+			'token_type'                   => $token_type,
+			'token_name'                   => $token_name,
+			'tag_local_name'               => '#tag' === $token_type ? $parts[1] : '',
+			'tag_namespace'                => '#tag' === $token_type ? $parts[2] : '',
+			'tag_namespace_and_local_name' => '#tag' === $token_type && '' !== $parts[2] ? '{' . $parts[2] . '}' . $parts[1] : ( '#tag' === $token_type ? $parts[1] : '' ),
+			'is_tag_closer'                => isset( $parts[3][0] ) && '1' === $parts[3][0],
+			'is_empty_element'             => isset( $parts[3][1] ) && '1' === $parts[3][1],
+			'current_depth'                => (int) $parts[4],
+			'id'                           => $id_found ? substr( $parts[5], 1 ) : null,
+		);
+	}
+
+	/**
+	 * Parses a native compact XML tag summary row.
+	 *
+	 * @param string $metadata       Native compact metadata row.
+	 * @param string $attribute_name Attribute name included in the row.
+	 * @return array Tag summary row.
+	 */
+	private function parse_native_compact_tag_summary( $metadata, $attribute_name ) {
+		$parts = explode( "\x1f", $metadata, 6 );
+		$this->assertCount( 6, $parts, 'Expected compact XML tag summary row.' );
+		$this->assertGreaterThan( 0, (int) $parts[0], 'Expected compact XML tag summary to include consumed token count.' );
+
+		$attribute_found = isset( $parts[5][0] ) && '1' === $parts[5][0];
+
+		return array(
+			'tag_local_name'               => $parts[1],
+			'tag_namespace'                => $parts[2],
+			'tag_namespace_and_local_name' => '' === $parts[2] ? $parts[1] : '{' . $parts[2] . '}' . $parts[1],
+			'is_empty_element'             => isset( $parts[3][0] ) && '1' === $parts[3][0],
+			'current_depth'                => (int) $parts[4],
+			$attribute_name                => $attribute_found ? substr( $parts[5], 1 ) : null,
+		);
+	}
+
+	/**
+	 * Runs the implementation-specific XML attribute-prefix document removal API.
+	 *
+	 * @param object      $processor             Processor instance.
+	 * @param string      $implementation        Implementation identifier.
+	 * @param string|null $full_namespace_prefix Namespace prefix to match.
+	 * @param string      $local_name_prefix     Local name prefix to match.
+	 * @return array Summary with `tag_count`, `removed_count`, and `xml`.
+	 */
+	private function remove_xml_attribute_names_with_prefix_from_document( $processor, $implementation, $full_namespace_prefix, $local_name_prefix ) {
+		$this->skip_if_xml_method_is_unavailable( $processor, $implementation, 'remove_attributes_with_prefix_from_document' );
+
+		$summary = $processor->remove_attributes_with_prefix_from_document( $full_namespace_prefix, $local_name_prefix );
+
+		if ( 'native-xml-processor' !== $implementation ) {
+			return $summary;
+		}
+
+		$parts = explode( "\x1f", $summary, 3 );
+
+		return array(
+			'tag_count'     => (int) $parts[0],
+			'removed_count' => (int) $parts[1],
+			'xml'           => $parts[2],
+		);
+	}
+
+	/**
+	 * Skips native implementation cases when the extension is unavailable.
+	 *
+	 * @param string $implementation Implementation identifier.
+	 */
+	private function skip_if_native_is_unavailable( $implementation ) {
+		if ( 'native-xml-processor' === $implementation && ! class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) ) {
+			$this->markTestSkipped( 'WordPress\\XML\\NativeXMLProcessor is not registered; load the native API extension to run this case.' );
+		}
+	}
+}

--- a/components/XML/class-xmlnativecursorprocessor.php
+++ b/components/XML/class-xmlnativecursorprocessor.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace WordPress\XML;
+
+class XMLNativeCursorProcessor extends NativeXMLProcessor {}

--- a/components/XML/class-xmlprocessor.php
+++ b/components/XML/class-xmlprocessor.php
@@ -1,0 +1,19 @@
+<?php
+// phpcs:disable Generic.Classes.DuplicateClassName.Found,Generic.Files.OneObjectStructurePerFile.MultipleFound
+
+namespace WordPress\XML;
+
+$wp_xml_use_native_processor =
+	class_exists( 'WordPress\\XML\\NativeXMLProcessor', false ) &&
+	method_exists( 'WordPress\\XML\\NativeXMLProcessor', 'supports_public_api' ) &&
+	( ! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) || ! WP_NATIVE_APIS_DISABLE_DEFAULTS );
+
+if ( $wp_xml_use_native_processor ) {
+	class XMLProcessor extends NativeXMLProcessor {}
+} else {
+	require_once __DIR__ . '/PHP/class-phpxmlprocessor.php';
+
+	class XMLProcessor extends PHPXMLProcessor {}
+}
+
+unset( $wp_xml_use_native_processor );

--- a/docs/native-rust-apis.md
+++ b/docs/native-rust-apis.md
@@ -1,0 +1,394 @@
+# Native Rust API Extension Notes
+
+This document captures the first-pass implementation shape for Rust-backed PHP
+extensions for the HTML, XML, and URL-in-text APIs.
+
+## Reference Architecture
+
+The local reference checkout is:
+
+```text
+/home/claude/explore-sqlite-rust/packages/php-ext-wp-mysql-parser
+```
+
+That package builds a PHP extension with `ext-php-rs`:
+
+```bash
+PHP_CONFIG=/path/to/php-config \
+LIBCLANG_PATH=/path/to/libclang/lib \
+cargo build --release
+```
+
+The extension registers native classes such as `WP_MySQL_Native_Lexer` and
+`WP_MySQL_Native_Parser`. The PHP package keeps public classes stable:
+
+- PHP load code checks `class_exists( 'WP_MySQL_Native_Lexer', false )`.
+- If native classes exist, public wrapper classes are loaded from a `native/`
+  directory.
+- If they do not exist, pure-PHP classes are loaded.
+- The public parser class still extends the pure-PHP base class where caller
+  `instanceof` contracts matter, but delegates work to a composed native object.
+- Native-only tests are skipped when native classes are unavailable.
+- Verification scripts fail with explicit stderr diagnostics when the extension
+  is missing or not wired into the public API.
+
+The same pattern should be used here: first add native classes and shared
+conformance tests, then stack PHP default-to-native wrappers after correctness is
+proven.
+
+## Current Repository Surface
+
+- `components/HTML` contains the global `WP_HTML_Tag_Processor` and
+  `WP_HTML_Processor` APIs.
+- `components/XML` contains `WordPress\XML\XMLProcessor` and W3C-oriented tests.
+- `components/DataLiberation/URL` contains a WHATWG URL parser wrapper and
+  `URLInTextProcessor` for plain-text URL detection. This native extension stack
+  does not add an RFC URL parser; it adds a native URL-in-text candidate scanner
+  that the public processor can validate through the existing WHATWG parser.
+- The root autoloader is classmap-based. Do not convert this to PSR-4.
+
+## Proposed Native Package Layout
+
+Start the first native branch with a reviewable package that does not change the
+default PHP behavior:
+
+```text
+extensions/native-apis/
+  Cargo.toml
+  README.md
+  src/
+    lib.rs
+    html.rs
+    xml.rs
+  tests/
+    verify-native-apis.php
+```
+
+Native class names should avoid taking over public names until the second stacked
+branch:
+
+- `WP_HTML_Native_Tag_Processor`
+- `WP_HTML_Native_Processor`
+- `WordPress\XML\NativeXMLProcessor`
+- `WordPress\DataLiberation\URL\NativeURLInTextProcessor`
+The current stack includes PHP wrappers that select native implementations when
+the classes are already registered by the extension, while preserving PHP-only
+fallback behavior.
+
+## Native Default Controls
+
+Public wrappers use native delegates only when the extension has already loaded
+the matching native classes. Define `WP_NATIVE_APIS_DISABLE_DEFAULTS` as a
+truthy constant before loading the components to force every public wrapper back
+to the PHP implementation.
+
+`WP_HTML_Processor::create_full_parser()` remains PHP-backed for now even when
+the native extension is loaded, because the native full-document parser is not
+yet public-parity safe. `WP_HTML_Processor::create_fragment()` can use native
+delegates for covered table, list, description-list, select/option/optgroup,
+omitted-paragraph, and ruby tree-builder cases.
+
+`URLInTextProcessor` can use the native URL-in-text scanner as its thick sieve
+for ASCII input when enabled. The public class still validates every candidate
+with the existing WHATWG parser and falls back to the PHP regular-expression
+sieve for non-ASCII text or when the native scanner is unavailable.
+
+## Shared Conformance Strategy
+
+Conformance tests should be implementation-parameterized, not duplicated. Each
+suite should expose a provider with at least:
+
+- pure PHP class factory
+- native class factory, skipped when the native class is unavailable
+
+HTML tests should focus first on the public streaming surface:
+
+- `next_token()`
+- `next_tag()`
+- `get_token_type()`
+- `get_token_name()`
+- `get_tag()`
+- `get_namespace()` for the current first-slice HTML namespace
+- `get_qualified_tag_name()` and `get_qualified_attribute_name()` for the
+  current first-slice HTML namespace
+- `get_attribute()`
+- `class_list()` and `has_class()` for decoded class access
+- `get_attribute_names_with_prefix()` for prefixed attribute-name scans
+- `remove_attribute()` for current-token attribute removal bookkeeping
+- `is_virtual()` for current-token virtual status
+- `get_last_error()` diagnostics
+- `get_unsupported_exception()` diagnostics
+- `expects_closer()` for current-token closer expectation
+- `is_void()` static void-element checks
+- `is_special()` static special-category checks
+- `has_self_closing_flag()` syntax checks
+- `paused_at_incomplete_token()` complete-input status for direct native tag
+  processors
+- `next_tag_summary_batch()` public row batches for direct native tag
+  processors, including current-tag state after native batch advancement
+- `next_tag_prefix_count_compact_batch()` current-tag state after public
+  native-default count-only batch advancement
+- `next_matching_tag_summary_batch()` public row batches for direct native tag
+  processors
+- `next_matching_tag_attribute_summary_batch()` public row batches for direct
+  native tag processors
+- `next_matching_tag_attributes_summary_batch()` public row batches for direct
+  native tag processors
+- `get_modifiable_text()` for text, comment, RAWTEXT, and RCDATA tokens
+- public native-default `set_modifiable_text()` and
+  `subdivide_text_appropriately()` delegation after native token advancement
+- public native-default remaining-document aggregate scans leaving the public
+  tag processor in the same complete state as PHP fallback scans
+- `get_breadcrumbs()`
+- `matches_breadcrumbs()` suffix and wildcard checks
+- `set_bookmark()`, `seek()`, `has_bookmark()`, and `release_bookmark()` for
+  direct native cursor state restore
+- serialization behavior for `WP_HTML_Processor`
+  when native defaults are loaded, including the PHP serializer fallback used
+  by public `normalize()` / `serialize()` and the started-processor rejection
+  after native token or token-summary advancement
+
+XML tests should focus first on:
+
+- `create_from_string()`
+- `next_token()`
+- `next_tag()`
+- namespace-aware tag and attribute reads
+- malformed document diagnostics via `get_last_error()`
+- complete-input status, including rejected `append_bytes()` calls on direct
+  native complete-string processors
+- public native-default structural, metadata, payload, content, and import
+  inventory summaries leaving the processor finished after remaining-document
+  native scans
+- public native-default token, tag, matching-tag, prefixed-attribute, and
+  document-removal aggregate summaries leaving the processor finished after
+  remaining-document native scans
+- public native-default token, tag, matching-tag, and count batches leaving the
+  processor finished after exhausted native batch scans
+- `next_token_summary_batch()` public row batches for direct native processors
+- `next_tag_summary_batch()` public row batches for direct native processors
+- `next_matching_tag_summary_batch()` public row batches for direct native
+  processors
+- `set_bookmark()`, `seek()`, `has_bookmark()`, and `release_bookmark()` for
+  direct native cursor state restore
+
+The native XML first slice now resolves namespace declarations into
+`get_tag_local_name()`, `get_tag_namespace()`, and
+`get_tag_namespace_and_local_name()` results, and stores namespaced attributes
+under the resolved `{namespace}local_name` key for conformance and verification
+coverage.
+
+Native-specific tests should cover wrapper identity, skipped native availability,
+and diagnostics, following the sqlite parser extension tests.
+
+URL-in-text tests should cover:
+
+- direct native candidate scanning for HTTP, HTTPS, protocol-relative, and bare
+  domain references
+- trailing punctuation preservation during replacements
+- malformed host and malformed port rejection/truncation before WHATWG
+  validation
+- public `URLInTextProcessor` behavior with and without the native extension
+  loaded, proving the existing WHATWG parser remains the fine sieve
+
+## Benchmarking
+
+Use `bin/benchmark-native-apis.php` to capture PHP baseline CPU and memory
+before native work starts. Re-run the same command with the extension loaded:
+
+```bash
+php bin/benchmark-native-apis.php --iterations=50
+php -d extension=/path/to/libwp_native_apis.so \
+	bin/benchmark-native-apis.php --iterations=50 --mode=both --require-native
+```
+
+The benchmark supports `--mode=php|native|both` and emits an `implementation`
+field in each result row. Native rows fail softly with unavailable-class
+diagnostics when the extension is not loaded, so CI or local workers can still
+verify the harness without PHP development headers.
+
+Pass `--disable-native-defaults` when the extension is loaded but the PHP row
+should force public wrappers back to PHP fallback classes. The harness defines
+`WP_NATIVE_APIS_DISABLE_DEFAULTS` before loading the repository bootstrap so the
+global native-default kill switch applies consistently across HTML, XML, and
+URL workloads.
+
+Use `--require-native` in post-build benchmark jobs. It preserves the soft
+missing-extension behavior for PHP-only development runs, but exits non-zero if
+any selected native row is unavailable.
+
+Pass `--component=url --name=url-in-text-processor` to benchmark URL-in-text
+scans specifically. The PHP row measures the public `URLInTextProcessor`, while
+the native row measures the direct native scanner.
+
+Record the PHP version, command, wall time, CPU time, and peak memory in
+`.autonomous-loop/memory.md` after each run.
+
+## Performance API Shape
+
+The native defaults preserve the existing public token and tag processors, but
+token-by-token loops still execute PHP code for every public method call. The
+performance branch therefore adds explicit fused and chunked APIs for common
+high-throughput workflows where callers can accept summarized rows instead of
+calling several accessors per token or tag.
+
+HTML tag workflows now have compact chunked summaries for incremental callers
+that only need tag names and closer state:
+
+- `next_tag_summary_batch()` returns structured rows for the next chunk of
+  tag metadata, including direct native public-row batches.
+- `next_tag_compact_summary_batch()` returns the same rows as a compact string.
+- `next_matching_tag_summary_batch()` returns structured rows for matching
+  tags, including direct native public-row batches.
+- `next_matching_tag_attribute_summary_batch()` returns structured rows for
+  matching tags and one decoded attribute value, including direct native
+  public-row batches.
+- `next_matching_tag_attributes_summary_batch()` returns structured rows for
+  matching tags and decoded multi-attribute maps, including direct native
+  public-row batches.
+- `summarize_tag_inventory()` consumes the remaining tag stream and returns
+  tag, opener, closer, attribute, and unique tag-name counts for audit
+  workflows that do not need one PHP call per tag.
+- `summarize_heading_inventory()` consumes the remaining tag stream and returns
+  heading counts by level for outline audits that do not need one PHP call per
+  tag.
+- `summarize_id_inventory()` consumes the remaining tag stream and returns
+  ID-bearing tag counts, unique decoded ID counts, duplicate ID counts, and
+  decoded ID value bytes for anchor/accessibility audits.
+- `summarize_attribute_inventory()` consumes the remaining tag stream and
+  returns attribute, unique attribute-name, and decoded attribute-value byte
+  counts for audits that do not need one PHP call per tag or attribute.
+- `summarize_data_attribute_inventory()` consumes the remaining tag stream and
+  returns `data-*` tag, attribute, unique-name, and decoded value-byte counts
+  for custom-data audits.
+- `summarize_aria_attribute_inventory()` consumes the remaining tag stream and
+  returns `aria-*` tag, attribute, unique-name, and decoded value-byte counts
+  for accessibility audits.
+- `summarize_class_inventory()` consumes the remaining tag stream and returns
+  class-attribute, per-tag class-name, unique class-name, and decoded class
+  value byte counts for class audits that do not need one PHP call per tag.
+- `summarize_resource_inventory()` consumes the remaining tag stream and
+  returns counts and decoded value bytes for common `href`/`src` resources on
+  anchors, images, scripts, links, and sources.
+- `summarize_image_inventory()` consumes the remaining tag stream and returns
+  image, `src`, `alt`, empty-alt, dimension, and decoded value-byte counts for
+  image audits.
+- `summarize_form_inventory()` consumes the remaining tag stream and returns
+  form/control counts, named-control counts, unique control-name counts, and
+  decoded control-name byte totals.
+
+HTML tag-prefix workflows build on that pattern with three shapes:
+
+- `count_attribute_names_with_prefix()` counts matching attributes on the
+  current tag.
+- `summarize_attribute_names_with_prefix()` and
+  `remove_attributes_with_prefix_from_document()` consume the remaining
+  document in one call for fully fused read-only or sanitizer workflows.
+- `next_tag_prefix_summary_batch()` and
+  `next_tag_prefix_compact_summary_batch()` consume the next chunk of tags,
+  preserving incremental processing while amortizing PHP/native crossings.
+- `next_tag_prefix_count_compact_batch()` consumes the next chunk of tags and
+  returns only aggregate tag and prefixed-attribute counts for callers that do
+  not need per-tag rows. Native-backed public wrappers preserve the current tag
+  after count-only batch advancement and map final short batches to the same
+  complete public parser state as the PHP fallback loop.
+
+HTML processor token workflows now also expose `next_token_summary_batch()` and
+`next_token_compact_summary_batch()` for common read-only scans that need token
+type, token name, closer state, depth, and breadcrumbs without several accessor
+calls per token. Native-backed public wrappers map full remaining-document and
+final short token batches to the same complete public parser state as the PHP
+fallback loop.
+
+XML token workflows follow the same pattern:
+
+- Direct native XML processor instances expose `create_for_streaming()` and
+  `get_reentrancy_cursor()` for the supported UTF-8 native-cursor factory path.
+- `summarize_token_stream()` consumes the remaining token stream and returns
+  aggregate token, tag, and attribute counts.
+- `summarize_document_inventory()` consumes the remaining token stream and
+  returns structural counts such as open/closing tags, text/comment/CDATA
+  tokens, maximum depth, and empty elements.
+- `summarize_attribute_inventory()` consumes the remaining token stream and
+  returns opening-tag attribute counts, namespaced attribute counts, tags with
+  attributes, and maximum attributes per tag.
+- `summarize_id_inventory()` consumes the remaining token stream and returns
+  no-namespace `id` attribute counts, unique ID counts, duplicate ID counts,
+  and decoded ID value bytes for importer/dedupe audits.
+- `summarize_content_inventory()` consumes the remaining token stream and
+  returns combined attribute-value and payload-byte counts for importer/audit
+  workflows that need both metadata and text-like content in one pass.
+- `summarize_import_inventory()` consumes the remaining token stream and
+  returns combined structural, attribute, and payload counts for importer/audit
+  workflows that need one document-shape and content-size pass.
+- `next_token_summary_batch()` returns structured rows for the next chunk of
+  token metadata.
+- `next_token_compact_summary_batch()` returns the same rows as a compact
+  string using `\x1f` field separators and `\x1e` record separators.
+
+XML tag workflows also expose `next_tag_summary_batch()` and
+`next_tag_compact_summary_batch()` for incremental read-only scans that only
+need opening tag metadata and one cached attribute. The compact rows include
+the number of tokens consumed in the current batch so native-backed public
+wrappers can replay accurately if a later call falls back to PHP.
+
+Count-only XML tag workflows can use `next_tag_count_batch()` for structured
+counts or `next_tag_count_compact_batch()` for a compact `token_count`,
+`tag_count`, and `attribute_count` row. This caller shape avoids per-tag
+metadata rows when the caller only needs aggregate progress through an
+incremental scan.
+
+Namespace/local-name XML tag scans can use `next_matching_tag_summary_batch()`,
+`next_matching_tag_compact_summary_batch()`, `next_matching_tag_count_batch()`,
+`next_matching_tag_count_compact_batch()`, or `summarize_matching_tag_stream()`.
+These match the common `next_tag( array( $namespace, $local_name ) )` loop shape
+while allowing native implementations to skip unrelated tags and amortize or
+avoid the crossing cost.
+
+HTML tag-name scans that also read one attribute can use
+`next_matching_tag_attribute_summary_batch()` or
+`next_matching_tag_attribute_compact_summary_batch()`. This matches common link,
+image, and script scans where the caller filters by tag name and immediately
+extracts `href`, `src`, or a similar single attribute.
+
+HTML tag-name scans that need several attributes can use
+`next_matching_tag_attributes_summary_batch()` or
+`next_matching_tag_attributes_compact_summary_batch()`. This matches link-audit
+workflows that filter to `A` tags and extract fields such as `href`, `title`,
+and `rel` in one native scan instead of one crossing per attribute.
+
+HTML link-audit workflows that only need aggregate counts can use
+`summarize_matching_tag_attributes()`. This consumes the remaining matching tags
+in one call and returns tag, present-attribute, and decoded attribute byte
+counts without PHP parsing one compact row per link.
+
+The structured array batch methods are the readability path. The compact string
+methods are the performance path for callers that can aggregate directly from
+the separator-delimited rows.
+
+Current benchmark interpretation: native-backed public wrappers clear the 5x
+CPU target with the same peak memory for caller-shaped HTML/XML fused or chunked
+workflows. This includes HTML sanitizer, processor, token batch, compact tag,
+matching-tag, matching-attribute, prefix, and inventory rows; and XML fused
+token/tag/prefix summaries, compact token/tag/count batches, matching-tag
+batches, sanitizer rows, and document, attribute, ID, namespace, payload,
+structural, content, and import inventory summaries.
+
+Direct native HTML processor instances also expose qualified-name accessors,
+complete-input pause status, prefixed-attribute count and aggregate summary
+access, compact tag-prefix count batches, inventory aggregate summaries,
+current-token and document-level prefixed-attribute removal,
+normalization/serialization through the PHP fragment serializer, text
+subdivision, modifiable text mutation, DOCTYPE info access, full-parser
+factory, processor stepping, namespace switching, attribute setting, class
+additions/removals, updated HTML serialization and string-cast serialization,
+structured and compact token/tag/matching-tag summary rows, and matching-tag
+attribute aggregate summaries for parity with the public processor API.
+
+The unqualified performance target remains open for transparent generic public
+cursor loops. Focused generic HTML cursor snapshots improved substantially, but
+the reviewable performance claim is still scoped to caller-shaped rows. Generic
+public `next_tag()` and `next_token()` loops that call several accessors per
+item, especially the XML `next_token()` cursor row, remain compatibility paths
+below 5x because they still pay repeated PHP method dispatch plus native row
+hydration or accessor export overhead.

--- a/extensions/native-apis/README.md
+++ b/extensions/native-apis/README.md
@@ -1,9 +1,9 @@
 # WordPress Native APIs PHP Extension
 
-This package is the Rust-backed PHP extension surface for native parser and
-scanner classes in the toolkit. It registers direct native classes while leaving
-public PHP components unchanged unless a later integration layer chooses to use
-those classes.
+This package is the first Rust-backed PHP extension surface for the toolkit's
+native HTML, XML, and URL-in-text API work. It registers native classes that the public
+PHP wrappers can use when the extension is loaded, while preserving PHP-only
+fallback behavior when it is unavailable or explicitly disabled.
 
 ## Native Classes
 
@@ -11,6 +11,25 @@ those classes.
 - `WP_HTML_Native_Processor`
 - `WordPress\XML\NativeXMLProcessor`
 - `WordPress\DataLiberation\URL\NativeURLInTextProcessor`
+
+## Public Wrapper Defaults
+
+When the extension is loaded before the PHP components, public wrappers may use
+native delegates by default while preserving PHP fallback behavior.
+
+Define `WP_NATIVE_APIS_DISABLE_DEFAULTS` as a truthy constant before loading the
+components to disable all public native defaults.
+
+HTML full-document parsing is intentionally still PHP-backed through
+`WP_HTML_Processor::create_full_parser()` until native full-document semantics
+match the public parser. Fragment processors, including covered table, list,
+description-list, select/option/optgroup, omitted-paragraph, ruby, tag
+processor, and simpler fragment inputs, can use native delegates when enabled.
+
+`URLInTextProcessor` can use the native URL-in-text class as its ASCII
+candidate scanner. The public PHP class still validates candidates with the
+existing WHATWG parser and uses the PHP regular-expression scanner for non-ASCII
+text or when native defaults are disabled.
 
 ## Build
 
@@ -61,21 +80,128 @@ The Rust parser kernels can be checked without PHP development headers:
 cargo test
 ```
 
+## Benchmarking
+
+The repository benchmark harness defaults to PHP userland rows so existing
+baseline commands keep their shape:
+
+```bash
+php bin/benchmark-native-apis.php --iterations=50
+```
+
+Native rows normally fail softly with unavailable-class diagnostics so the
+harness remains usable without PHP development headers. Add `--require-native`
+to post-build benchmark commands when missing native classes should produce a
+non-zero exit.
+
+After building and loading the extension, compare PHP and native rows with the
+same workloads:
+
+```bash
+php -d extension=extensions/native-apis/target/release/libwp_native_apis.so \
+	bin/benchmark-native-apis.php --iterations=50 --mode=both --require-native
+```
+
+When the extension is loaded but a PHP row should force public wrappers back to
+their PHP fallback classes, pass `--disable-native-defaults`. The harness
+defines `WP_NATIVE_APIS_DISABLE_DEFAULTS` before loading the repository
+bootstrap:
+
+```bash
+php -d extension=extensions/native-apis/target/release/libwp_native_apis.so \
+	bin/benchmark-native-apis.php --iterations=50 --mode=php --disable-native-defaults
+```
+
+### Fused and Chunked Workloads
+
+Native-backed public wrappers are fastest when one extension call can cover a
+caller-shaped workflow. The benchmark harness includes rows for these paths:
+
+- HTML tag-prefix sanitizing through document-level removal/update.
+- HTML tag-name scans through compact chunked batches.
+- HTML matching tag-name scans through compact chunked batches.
+- HTML matching tag-name plus attribute extraction through compact chunked batches.
+- HTML matching tag-name plus multi-attribute extraction through compact chunked batches.
+- HTML matching tag-name plus multi-attribute aggregate summaries for link audits.
+- HTML tag inventory summaries for tag, closer, attribute, and unique-name audits.
+- HTML heading inventory summaries for outline and heading-level audits.
+- HTML ID inventory summaries for unique and duplicate ID audits.
+- HTML attribute inventory summaries for attribute-name and decoded-value audits.
+- HTML data-attribute inventory summaries for `data-*` usage audits.
+- HTML ARIA attribute inventory summaries for `aria-*` accessibility audits.
+- HTML class inventory summaries for class-attribute, class-name, and unique-class audits.
+- HTML resource inventory summaries for common `href` and `src` link/media audits.
+- HTML image inventory summaries for image source, alt-text, and dimension audits.
+- HTML form inventory summaries for form/control name audits.
+- HTML tag-prefix count batches for incremental callers that only need aggregate counts.
+- HTML tag-prefix summary scans through compact chunked batches.
+- HTML processor token scans through compact chunked batches.
+- XML token stream summaries and compact token-summary batches.
+- XML streaming factory and reentrancy cursor support for direct native
+  processor instances.
+- XML document, attribute, ID, content, and import inventory summaries through
+  direct source scans.
+- XML tag scans through compact chunked batches.
+- XML tag count scans through compact chunked count batches.
+- XML namespace/local-name tag scans through compact matching-tag batches.
+- XML namespace/local-name tag counts through compact matching-tag count batches.
+- XML namespace/local-name tag summaries through direct source scans.
+- XML tag, prefix, and sanitizer summaries through direct source scans.
+- URL-in-text scans through a direct native plain-text URL candidate processor,
+  with public `URLInTextProcessor` rows preserving WHATWG validation.
+The compact batch APIs return strings with `\x1f` field separators and `\x1e`
+record separators. They are intended for callers that need incremental
+processing but can aggregate without building one PHP array per tag or token.
+Array-returning batch wrappers remain available for clearer application code.
+
+Current benchmark claims should be scoped to these fused and chunked workflow
+rows. Generic public `next_tag()` / `next_token()` loops remain compatibility
+paths and still pay per-item PHP/native crossing overhead; use the aggregate
+benchmark rows to distinguish those loops from target-clearing caller-shaped
+APIs.
+
 ## Current Scope
 
-The Rust implementation currently provides parser kernels and direct native
-classes for the first conformance slice:
+The Rust implementation currently provides parser kernels and native class
+stubs for the first conformance slice:
 
-- HTML tag iteration, token iteration, tag-name reads, namespace and
-  qualified-name reads, attribute reads and mutations, class-list reads,
-  bookmark lifecycle methods, text/comment/RAWTEXT/RCDATA handling,
-  serialization, compact tag/token batches, aggregate inventory summaries, and
-  selected tree-builder breadcrumbs.
-- XML token and tag iteration, local-name and namespace reads, resolved
-  namespaced attribute reads, text/comment/CDATA handling, bookmark lifecycle
-  methods, complete-input and streaming support, serialization, compact
-  tag/token batches, aggregate inventory summaries, and malformed document
-  diagnostics.
+- HTML tag iteration, tag-name reads, first-slice namespace and qualified-name
+  reads, virtual-token status, last-error and unsupported-exception
+  diagnostics, syntax-level self-closing flag reads, closer-expectation status,
+  attribute reads/removals, decoded class-list and class-membership reads,
+  normalization/serialization through the PHP fragment serializer, public native-default token/tag, summary-batch, count-batch, short-batch exhaustion, and aggregate completion-state alignment, text subdivision, modifiable text mutation, DOCTYPE info access, full-parser factory, processor stepping, namespace switching, attribute setting, class additions/removals, prefixed attribute-name scans, public tag-summary,
+  tag-prefix compact summary,
+  matching-tag summary, matching-tag attribute summary, and matching-tag
+  multi-attribute summary batches, complete-input pause status, bookmark
+  lifecycle methods, and static
+  void/special-category checks, including first-slice character reference
+  decoding for numeric and common named references.
+- HTML token iteration via the native processor stub, including text, comment,
+  RAWTEXT, and RCDATA token text, qualified-name reads, decoded class reads,
+  complete-input pause status, prefixed attribute-name count reads and
+  aggregate summaries, tag-prefix summary batches, compact tag-prefix summary
+  batch aliases, compact tag-prefix count batches, tag-inventory aggregate
+  summaries, current-token and document-level prefixed attribute removal,
+  full-parser factory, namespace switching, attribute setting, class additions/removals, PHP serializer-backed normalization/serialization for public compatibility including started-processor rejection after native token advancement, updated HTML serialization and string-cast serialization, breadcrumbs, breadcrumb matching, public
+  token-summary with native-default full/final-short batch completion-state
+  alignment, structured tag-summary, and compact
+  tag-summary/matching-tag summary/matching-tag attribute summary/matching-tag
+  multi-attribute summary batches, structured matching-tag summary,
+  matching-tag attribute summary, and matching-tag multi-attribute summary
+  batches, matching-tag attribute aggregate summaries, and bookmark lifecycle
+  methods.
+- XML tag iteration, token names, token types, local-name/namespace reads,
+  resolved namespaced attribute reads, text/comment tokens, breadcrumbs,
+  bookmark lifecycle methods, complete-input status and append rejection,
+  structural/metadata/payload/content/import inventory completion-state alignment,
+  token/tag/matching-tag/prefixed-attribute aggregate completion-state alignment,
+  public token-summary, tag-summary, matching-tag summary, and count batch
+  completion-state alignment, current depth, and malformed document diagnostics.
 - URL-in-text candidate scanning for HTTP, HTTPS, protocol-relative, and bare
   domain references, including trailing punctuation trimming, malformed port
-  truncation, replacement serialization, and direct byte offsets.
+  truncation, replacement serialization, and ASCII-only public wrapper defaults
+  that keep the existing WHATWG parser as the fine sieve.
+
+The next milestone should keep extending shared PHPUnit conformance providers
+against the loaded extension and continue targeting caller-shaped fused
+workloads where native code can keep hot scans out of PHP userland.

--- a/extensions/native-apis/build-extension.sh
+++ b/extensions/native-apis/build-extension.sh
@@ -25,7 +25,8 @@ if ! command -v clang >/dev/null 2>&1 && [ -z "${LIBCLANG_PATH:-}" ]; then
 	exit 1
 fi
 
-export PHP_CONFIG="${php_config}"
+PHP_CONFIG="$(command -v "${php_config}")"
+export PHP_CONFIG
 
 cargo build --release --features php-extension
 

--- a/extensions/native-apis/src/html.rs
+++ b/extensions/native-apis/src/html.rs
@@ -3280,41 +3280,83 @@ fn html_serialize_opening_tag(html: &str, tag: &HtmlTag) -> String {
     output.push('<');
     output.push_str(&tag.name);
 
-    let mut seen = Vec::new();
-    for attribute_name in &tag.attribute_order {
-        if seen
-            .iter()
-            .any(|seen_name: &String| seen_name == attribute_name)
-        {
-            continue;
-        }
-        seen.push(attribute_name.clone());
-
+    for (attribute_name, value) in
+        html_source_attribute_items(html.as_bytes(), tag.source_start, tag.source_end)
+    {
         output.push(' ');
-        output.push_str(attribute_name);
+        output.push_str(&attribute_name);
 
-        if find_html_attribute_has_value(
-            html.as_bytes(),
-            tag.source_start,
-            tag.source_end,
-            attribute_name,
-        ) == Some(false)
-        {
-            continue;
+        if let Some(value) = value {
+            output.push_str("=\"");
+            output.push_str(&html_escape_attribute_value(&value));
+            output.push('"');
         }
-
-        let value = tag
-            .attributes
-            .get(attribute_name)
-            .cloned()
-            .unwrap_or_default();
-        output.push_str("=\"");
-        output.push_str(&html_escape_attribute_value(&value));
-        output.push('"');
     }
 
     output.push('>');
     output
+}
+
+fn html_source_attribute_items(
+    bytes: &[u8],
+    source_start: usize,
+    source_end: usize,
+) -> Vec<(String, Option<String>)> {
+    if source_start >= bytes.len() || source_end <= source_start {
+        return Vec::new();
+    }
+
+    let tag_end = source_end.saturating_sub(1).min(bytes.len());
+    let mut cursor = source_start.saturating_add(1);
+    if cursor < tag_end && bytes[cursor] == b'/' {
+        return Vec::new();
+    }
+
+    cursor = skip_ascii_whitespace(bytes, cursor);
+    cursor = span_name(bytes, cursor);
+
+    let mut items = Vec::new();
+    let mut seen = Vec::new();
+    while cursor < tag_end {
+        cursor = skip_ascii_whitespace(bytes, cursor);
+        if cursor >= tag_end || bytes[cursor] == b'>' {
+            break;
+        }
+        if bytes[cursor] == b'/' && cursor + 1 < bytes.len() && bytes[cursor + 1] == b'>' {
+            break;
+        }
+
+        let attr_start = cursor;
+        cursor = span_html_attribute_name(bytes, cursor);
+        if cursor == attr_start {
+            cursor += 1;
+            continue;
+        }
+
+        let attr_name = ascii_lower(&bytes[attr_start..cursor]);
+        cursor = skip_ascii_whitespace(bytes, cursor);
+
+        let mut value = None;
+        if cursor < tag_end && bytes[cursor] == b'=' {
+            cursor += 1;
+            cursor = skip_ascii_whitespace(bytes, cursor);
+            let parsed = parse_attribute_value(bytes, cursor);
+            value = Some(parsed.0);
+            cursor = parsed.1;
+        }
+
+        if seen
+            .iter()
+            .any(|seen_name: &String| seen_name == &attr_name)
+        {
+            continue;
+        }
+
+        seen.push(attr_name.clone());
+        items.push((attr_name, value));
+    }
+
+    items
 }
 
 #[cfg(feature = "php-extension")]
@@ -6200,9 +6242,10 @@ mod tests {
     use super::{
         apply_html_text_removals, find_html_attribute_names_with_prefix_count,
         find_html_attribute_names_with_prefix_string, find_html_attribute_removals,
-        find_html_attribute_removals_with_prefix, html_tag_has_self_closing_flag,
-        html_token_compact_summary, initial_html_breadcrumbs, parse_html_tags,
-        parse_next_html_token, parse_next_plain_html_tag_token, HtmlTextRemoval,
+        find_html_attribute_removals_with_prefix, html_serialize_opening_tag,
+        html_source_attribute_items, html_tag_has_self_closing_flag, html_token_compact_summary,
+        initial_html_breadcrumbs, parse_html_tags, parse_next_html_token,
+        parse_next_plain_html_tag_token, HtmlTextRemoval,
     };
 
     fn collect_processor_tokens(html: &str) -> Vec<(String, bool, String, String)> {
@@ -6277,6 +6320,25 @@ mod tests {
                 "data-x".to_string()
             ],
             tags[0].attribute_order
+        );
+    }
+
+    #[test]
+    fn serializes_opening_tag_attributes_from_source() {
+        let html = "<a href=#anchor v=5 href=\"/\" enabled>One</a>";
+        let tags = parse_html_tags(html);
+
+        assert_eq!(
+            vec![
+                ("href".to_string(), Some("#anchor".to_string())),
+                ("v".to_string(), Some("5".to_string())),
+                ("enabled".to_string(), None),
+            ],
+            html_source_attribute_items(html.as_bytes(), tags[0].source_start, tags[0].source_end)
+        );
+        assert_eq!(
+            "<a href=\"#anchor\" v=\"5\" enabled>",
+            html_serialize_opening_tag(html, &tags[0])
         );
     }
 

--- a/extensions/native-apis/src/html.rs
+++ b/extensions/native-apis/src/html.rs
@@ -8,7 +8,7 @@ use ext_php_rs::prelude::*;
 #[cfg(feature = "php-extension")]
 use ext_php_rs::{
     boxed::ZBox,
-    types::{ZendCallable, ZendHashTable, Zval},
+    types::{ZendHashTable, Zval},
     zend::Function,
 };
 
@@ -2554,7 +2554,7 @@ impl WpHtmlNativeProcessor {
     }
 
     pub fn normalize(html: String) -> Option<String> {
-        html_normalize_via_php(&html)
+        html_serialize_native_fragment(&html)
     }
 
     pub fn serialize(&mut self) -> Option<String> {
@@ -2562,7 +2562,7 @@ impl WpHtmlNativeProcessor {
             return None;
         }
 
-        let serialized = html_normalize_via_php(&self.inner.html)?;
+        let serialized = html_serialize_native_fragment(&self.inner.html)?;
         self.inner.offset = self.inner.html.len();
         Some(serialized)
     }
@@ -3246,6 +3246,78 @@ fn html_breadcrumbs_match(current: &[String], breadcrumbs: &[String]) -> bool {
 }
 
 #[cfg(feature = "php-extension")]
+fn html_serialize_native_fragment(html: &str) -> Option<String> {
+    let mut processor = WpHtmlNativeProcessor::create_fragment(
+        html.to_string(),
+        Some("<body>".to_string()),
+        Some("UTF-8".to_string()),
+    )?;
+    let mut serialized = String::with_capacity(html.len());
+
+    while processor.next_token() {
+        let Some(tag) = processor.inner.current_tag() else {
+            continue;
+        };
+
+        serialized.push_str(&html_serialize_token(html, tag));
+    }
+
+    Some(serialized)
+}
+
+fn html_serialize_token(html: &str, tag: &HtmlTag) -> String {
+    match tag.token_type.as_str() {
+        "#tag" if tag.closing => format!("</{}>", tag.name),
+        "#tag" => html_serialize_opening_tag(html, tag),
+        "#comment" => format!("<!--{}-->", tag.text),
+        "#text" => html_escape_text(&tag.text),
+        _ => String::new(),
+    }
+}
+
+fn html_serialize_opening_tag(html: &str, tag: &HtmlTag) -> String {
+    let mut output = String::new();
+    output.push('<');
+    output.push_str(&tag.name);
+
+    let mut seen = Vec::new();
+    for attribute_name in &tag.attribute_order {
+        if seen
+            .iter()
+            .any(|seen_name: &String| seen_name == attribute_name)
+        {
+            continue;
+        }
+        seen.push(attribute_name.clone());
+
+        output.push(' ');
+        output.push_str(attribute_name);
+
+        if find_html_attribute_has_value(
+            html.as_bytes(),
+            tag.source_start,
+            tag.source_end,
+            attribute_name,
+        ) == Some(false)
+        {
+            continue;
+        }
+
+        let value = tag
+            .attributes
+            .get(attribute_name)
+            .cloned()
+            .unwrap_or_default();
+        output.push_str("=\"");
+        output.push_str(&html_escape_attribute_value(&value));
+        output.push('"');
+    }
+
+    output.push('>');
+    output
+}
+
+#[cfg(feature = "php-extension")]
 fn html_tag_public_summary_row(tag: &HtmlTag) -> Vec<(String, Zval)> {
     vec![
         (
@@ -3427,13 +3499,6 @@ fn html_doctype_info_zval(html: &str, tag: &HtmlTag) -> Option<Zval> {
     } else {
         Some(value)
     }
-}
-
-#[cfg(feature = "php-extension")]
-fn html_normalize_via_php(html: &str) -> Option<String> {
-    let callable = ZendCallable::try_from_name("WP_HTML_Processor::normalize").ok()?;
-    let value = callable.try_call(vec![&html]).ok()?;
-    value.string()
 }
 
 fn html_token_compact_summary(tag: &HtmlTag) -> String {

--- a/extensions/native-apis/src/html.rs
+++ b/extensions/native-apis/src/html.rs
@@ -82,6 +82,15 @@ enum HtmlAttributeValue {
     String(String),
 }
 
+#[derive(Default)]
+struct HtmlNextTagQuery {
+    tag_name: Option<String>,
+    class_name: Option<String>,
+    match_offset: i64,
+    visit_closers: bool,
+    breadcrumbs: Option<Vec<String>>,
+}
+
 #[cfg(feature = "php-extension")]
 impl WpHtmlNativeTagProcessor {
     fn get_attribute_value(&self, name: &str) -> Option<HtmlAttributeValue> {
@@ -174,8 +183,22 @@ impl WpHtmlNativeTagProcessor {
     }
 
     #[php(optional = query)]
-    pub fn next_tag(&mut self, _query: Option<&Zval>) -> bool {
-        self.next_tag_any(false, 1)
+    pub fn next_tag(&mut self, query: Option<&Zval>) -> bool {
+        let query = html_parse_tag_processor_next_tag_query(query);
+        let mut match_offset = query.match_offset.max(1);
+
+        while self.advance_to_next_tag_token() {
+            if !self.current_html_tag_matches_query(&query, false) {
+                continue;
+            }
+
+            match_offset -= 1;
+            if match_offset == 0 {
+                return true;
+            }
+        }
+
+        false
     }
 
     pub fn next_tag_any(&mut self, visit_closers: bool, mut match_offset: i64) -> bool {
@@ -2441,6 +2464,44 @@ impl WpHtmlNativeTagProcessor {
     fn current_tag(&self) -> Option<&HtmlTag> {
         self.current.as_ref()
     }
+
+    fn current_html_tag_matches_query(
+        &self,
+        query: &HtmlNextTagQuery,
+        use_breadcrumbs: bool,
+    ) -> bool {
+        let Some(tag) = self.current_tag() else {
+            return false;
+        };
+
+        if tag.token_type != "#tag" {
+            return false;
+        }
+
+        if tag.closing && (!query.visit_closers || use_breadcrumbs) {
+            return false;
+        }
+
+        if let Some(tag_name) = query.tag_name.as_ref() {
+            if !tag.name.eq_ignore_ascii_case(tag_name) {
+                return false;
+            }
+        }
+
+        if let Some(class_name) = query.class_name.as_ref() {
+            if self.has_class(class_name.clone()) != Some(true) {
+                return false;
+            }
+        }
+
+        if use_breadcrumbs {
+            if let Some(breadcrumbs) = query.breadcrumbs.as_ref() {
+                return html_breadcrumbs_match(&tag.breadcrumbs, breadcrumbs);
+            }
+        }
+
+        true
+    }
 }
 
 #[cfg(feature = "php-extension")]
@@ -2592,7 +2653,27 @@ impl WpHtmlNativeProcessor {
 
     #[php(optional = query)]
     pub fn next_tag(&mut self, query: Option<&Zval>) -> bool {
-        self.inner.next_tag(query)
+        let Some(query) = html_parse_processor_next_tag_query(query) else {
+            return false;
+        };
+        let use_breadcrumbs = query.breadcrumbs.is_some();
+        let mut match_offset = query.match_offset.max(1);
+
+        while self.next_token() {
+            if !self
+                .inner
+                .current_html_tag_matches_query(&query, use_breadcrumbs)
+            {
+                continue;
+            }
+
+            match_offset -= 1;
+            if match_offset == 0 {
+                return true;
+            }
+        }
+
+        false
     }
 
     pub fn next_tag_summary_batch(
@@ -3039,6 +3120,129 @@ fn token_metadata(tag: &HtmlTag) -> String {
     }
 
     metadata
+}
+
+#[cfg(feature = "php-extension")]
+fn html_parse_tag_processor_next_tag_query(query: Option<&Zval>) -> HtmlNextTagQuery {
+    let mut parsed = HtmlNextTagQuery {
+        match_offset: 1,
+        ..Default::default()
+    };
+
+    let Some(query) = query else {
+        return parsed;
+    };
+
+    if let Some(tag_name) = query.str() {
+        parsed.tag_name = Some(tag_name.to_string());
+        return parsed;
+    }
+
+    let Some(query) = query.array() else {
+        return parsed;
+    };
+
+    if let Some(tag_name) = html_array_string(query, "tag_name") {
+        parsed.tag_name = Some(tag_name);
+    }
+
+    if let Some(class_name) = html_array_string(query, "class_name") {
+        parsed.class_name = Some(class_name);
+    }
+
+    if let Some(match_offset) = html_array_positive_i64(query, "match_offset") {
+        parsed.match_offset = match_offset;
+    }
+
+    parsed.visit_closers = html_array_string(query, "tag_closers").as_deref() == Some("visit");
+
+    parsed
+}
+
+#[cfg(feature = "php-extension")]
+fn html_parse_processor_next_tag_query(query: Option<&Zval>) -> Option<HtmlNextTagQuery> {
+    let mut parsed = HtmlNextTagQuery {
+        match_offset: 1,
+        ..Default::default()
+    };
+
+    let Some(query) = query else {
+        return Some(parsed);
+    };
+
+    if let Some(tag_name) = query.str() {
+        parsed.breadcrumbs = Some(vec![tag_name.to_string()]);
+        return Some(parsed);
+    }
+
+    let query = query.array()?;
+
+    if let Some(tag_name) = html_array_string(query, "tag_name") {
+        parsed.tag_name = Some(tag_name);
+    }
+
+    if let Some(class_name) = html_array_string(query, "class_name") {
+        parsed.class_name = Some(class_name);
+    }
+
+    if let Some(match_offset) = html_array_positive_i64(query, "match_offset") {
+        parsed.match_offset = match_offset;
+    }
+
+    parsed.visit_closers = html_array_string(query, "tag_closers").as_deref() == Some("visit");
+    parsed.breadcrumbs = html_array_string_breadcrumbs(query, "breadcrumbs");
+
+    Some(parsed)
+}
+
+#[cfg(feature = "php-extension")]
+fn html_array_string(query: &ZendHashTable, key: &str) -> Option<String> {
+    query
+        .get(key)
+        .and_then(|value| value.str())
+        .map(str::to_string)
+}
+
+#[cfg(feature = "php-extension")]
+fn html_array_positive_i64(query: &ZendHashTable, key: &str) -> Option<i64> {
+    query
+        .get(key)
+        .and_then(|value| value.long())
+        .filter(|value| *value > 0)
+        .map(|value| value as i64)
+}
+
+#[cfg(feature = "php-extension")]
+fn html_array_string_breadcrumbs(query: &ZendHashTable, key: &str) -> Option<Vec<String>> {
+    let breadcrumbs = query.get(key)?.array()?;
+    let mut parsed = Vec::with_capacity(breadcrumbs.len());
+
+    for value in breadcrumbs.iter().map(|(_, value)| value) {
+        parsed.push(value.str()?.to_string());
+    }
+
+    Some(parsed)
+}
+
+fn html_breadcrumbs_match(current: &[String], breadcrumbs: &[String]) -> bool {
+    if breadcrumbs.is_empty() {
+        return true;
+    }
+
+    if breadcrumbs.len() > current.len() {
+        return false;
+    }
+
+    let offset = current.len() - breadcrumbs.len();
+    for (index, breadcrumb) in breadcrumbs.iter().enumerate() {
+        let crumb = breadcrumb.to_ascii_uppercase();
+        let node = &current[offset + index];
+        if crumb != "*" && node != &crumb {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[cfg(feature = "php-extension")]

--- a/extensions/native-apis/src/html.rs
+++ b/extensions/native-apis/src/html.rs
@@ -169,7 +169,12 @@ impl WpHtmlNativeTagProcessor {
         }
     }
 
-    pub fn next_tag(&mut self) -> bool {
+    pub fn supports_public_api() -> bool {
+        true
+    }
+
+    #[php(optional = query)]
+    pub fn next_tag(&mut self, _query: Option<&Zval>) -> bool {
         self.next_tag_any(false, 1)
     }
 
@@ -2449,12 +2454,27 @@ pub struct WpHtmlNativeProcessor {
 #[php_impl]
 #[php(change_method_case = "snake_case")]
 impl WpHtmlNativeProcessor {
-    pub fn create_fragment(html: String) -> Self {
+    pub fn supports_public_api() -> bool {
+        true
+    }
+
+    #[php(optional = context)]
+    pub fn create_fragment(
+        html: String,
+        context: Option<String>,
+        encoding: Option<String>,
+    ) -> Option<Self> {
+        if context.as_deref().unwrap_or("<body>") != "<body>"
+            || encoding.as_deref().unwrap_or("UTF-8") != "UTF-8"
+        {
+            return None;
+        }
+
         let mut inner = WpHtmlNativeTagProcessor::__construct(html);
         inner.synthesize_implied_closers = true;
         inner.ignore_html_body_starts = true;
 
-        Self { inner }
+        Some(Self { inner })
     }
 
     #[php(optional = known_definite_encoding)]
@@ -2570,8 +2590,9 @@ impl WpHtmlNativeProcessor {
         rows
     }
 
-    pub fn next_tag(&mut self) -> bool {
-        self.inner.next_tag()
+    #[php(optional = query)]
+    pub fn next_tag(&mut self, query: Option<&Zval>) -> bool {
+        self.inner.next_tag(query)
     }
 
     pub fn next_tag_summary_batch(

--- a/extensions/native-apis/src/url_text.rs
+++ b/extensions/native-apis/src/url_text.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(not(feature = "php-extension"), allow(dead_code))]
 
 #[cfg(feature = "php-extension")]
-use ext_php_rs::prelude::*;
+use ext_php_rs::{
+    prelude::*,
+    types::{ZendCallable, Zval},
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UrlTextCandidate {
@@ -22,6 +25,7 @@ pub struct NativeUrlInTextProcessor {
     current: Option<UrlTextCandidate>,
     replacements: Vec<UrlTextReplacement>,
     validate_urls: bool,
+    base_url: Option<String>,
     base_protocol: Option<String>,
 }
 
@@ -46,6 +50,7 @@ impl NativeUrlInTextProcessor {
             current: None,
             replacements: Vec::new(),
             validate_urls: true,
+            base_url,
             base_protocol,
         }
     }
@@ -60,6 +65,7 @@ impl NativeUrlInTextProcessor {
 
     pub fn set_base_url(&mut self, base_url: String) {
         self.base_protocol = parse_url_scheme(&base_url);
+        self.base_url = Some(base_url);
     }
 
     pub fn next_url(&mut self) -> bool {
@@ -95,8 +101,26 @@ impl NativeUrlInTextProcessor {
             .map(|candidate| candidate.preprocessed_url.clone())
     }
 
-    pub fn get_parsed_url(&self) -> Option<String> {
-        self.get_preprocessed_url()
+    pub fn get_parsed_url(&self) -> Zval {
+        let Some(candidate) = self.current.as_ref() else {
+            return url_zval_bool(false);
+        };
+
+        let Ok(callable) =
+            ZendCallable::try_from_name("WordPress\\DataLiberation\\URL\\WPURL::parse")
+        else {
+            return url_zval_bool(false);
+        };
+
+        let result = match self.base_url.as_ref() {
+            Some(base_url) => callable.try_call(vec![&candidate.preprocessed_url, base_url]),
+            None => callable.try_call(vec![&candidate.preprocessed_url]),
+        };
+
+        match result {
+            Ok(value) if !value.is_false() && !value.is_null() => value,
+            _ => url_zval_bool(false),
+        }
     }
 
     pub fn get_url_starts_at(&self) -> Option<i64> {
@@ -322,6 +346,13 @@ fn validate_url_text_candidate(
 
     candidate.preprocessed_url = preprocessed_url;
     true
+}
+
+#[cfg(feature = "php-extension")]
+fn url_zval_bool(value: bool) -> Zval {
+    let mut zval = Zval::new();
+    zval.set_bool(value);
+    zval
 }
 
 fn parse_url_scheme(url: &str) -> Option<String> {

--- a/extensions/native-apis/src/url_text.rs
+++ b/extensions/native-apis/src/url_text.rs
@@ -6,9 +6,11 @@ use ext_php_rs::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UrlTextCandidate {
     pub raw_url: String,
+    pub preprocessed_url: String,
     pub starts_at: usize,
     pub length: usize,
     pub had_protocol: bool,
+    pub did_prepend_protocol: bool,
 }
 
 #[cfg(feature = "php-extension")]
@@ -19,6 +21,8 @@ pub struct NativeUrlInTextProcessor {
     bytes_already_parsed: usize,
     current: Option<UrlTextCandidate>,
     replacements: Vec<UrlTextReplacement>,
+    validate_urls: bool,
+    base_protocol: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -32,32 +36,67 @@ struct UrlTextReplacement {
 #[php_impl]
 #[php(change_method_case = "snake_case")]
 impl NativeUrlInTextProcessor {
-    pub fn __construct(text: String) -> Self {
+    #[php(optional = base_url)]
+    pub fn __construct(text: String, base_url: Option<String>) -> Self {
+        let base_protocol = base_url.as_deref().and_then(parse_url_scheme);
+
         Self {
             text,
             bytes_already_parsed: 0,
             current: None,
             replacements: Vec::new(),
+            validate_urls: true,
+            base_protocol,
         }
+    }
+
+    pub fn supports_public_api() -> bool {
+        true
+    }
+
+    pub fn use_url_validation(&mut self) {
+        self.validate_urls = true;
+    }
+
+    pub fn set_base_url(&mut self, base_url: String) {
+        self.base_protocol = parse_url_scheme(&base_url);
     }
 
     pub fn next_url(&mut self) -> bool {
         self.current = None;
 
-        let Some(candidate) = find_next_url_text_candidate(&self.text, self.bytes_already_parsed)
-        else {
-            return false;
-        };
+        while let Some(mut candidate) =
+            find_next_url_text_candidate(&self.text, self.bytes_already_parsed)
+        {
+            self.bytes_already_parsed = candidate.starts_at + candidate.length;
 
-        self.bytes_already_parsed = candidate.starts_at + candidate.length;
-        self.current = Some(candidate);
-        true
+            if self.validate_urls
+                && !validate_url_text_candidate(&mut candidate, self.base_protocol.as_deref())
+            {
+                continue;
+            }
+
+            self.current = Some(candidate);
+            return true;
+        }
+
+        false
     }
 
     pub fn get_raw_url(&self) -> Option<String> {
         self.current
             .as_ref()
             .map(|candidate| candidate.raw_url.clone())
+    }
+
+    pub fn get_preprocessed_url(&self) -> Option<String> {
+        self.current
+            .as_ref()
+            .map(|candidate| candidate.preprocessed_url.clone())
+    }
+
+    pub fn get_parsed_url(&self) -> Option<String> {
+        self.get_preprocessed_url()
     }
 
     pub fn get_url_starts_at(&self) -> Option<i64> {
@@ -78,16 +117,31 @@ impl NativeUrlInTextProcessor {
             .map(|candidate| candidate.had_protocol)
     }
 
+    pub fn did_prepend_protocol(&self) -> Option<bool> {
+        self.current
+            .as_ref()
+            .map(|candidate| candidate.did_prepend_protocol)
+    }
+
     pub fn set_raw_url(&mut self, new_url: String) -> bool {
         let Some(candidate) = self.current.as_mut() else {
             return false;
         };
 
-        self.replacements.push(UrlTextReplacement {
-            start: candidate.starts_at,
-            length: candidate.length,
-            text: new_url.clone(),
-        });
+        if let Some(replacement) = self
+            .replacements
+            .iter_mut()
+            .find(|replacement| replacement.start == candidate.starts_at)
+        {
+            replacement.length = candidate.length;
+            replacement.text = new_url.clone();
+        } else {
+            self.replacements.push(UrlTextReplacement {
+                start: candidate.starts_at,
+                length: candidate.length,
+                text: new_url.clone(),
+            });
+        }
         candidate.raw_url = new_url;
         true
     }
@@ -208,10 +262,165 @@ fn parse_url_text_candidate_at(text: &str, start: usize) -> Option<UrlTextCandid
 
     Some(UrlTextCandidate {
         raw_url: text[start..display_end].to_string(),
+        preprocessed_url: text[start..display_end].to_string(),
         starts_at: start,
         length: display_end - start,
         had_protocol: had_protocol || start + 2 <= bytes.len() && &bytes[start..start + 2] == b"//",
+        did_prepend_protocol: false,
     })
+}
+
+fn validate_url_text_candidate(
+    candidate: &mut UrlTextCandidate,
+    base_protocol: Option<&str>,
+) -> bool {
+    let mut preprocessed_url = candidate.raw_url.clone();
+    if !candidate.had_protocol {
+        let Some(protocol) = base_protocol else {
+            return false;
+        };
+
+        if !is_http_or_https_scheme(protocol) {
+            return false;
+        }
+
+        preprocessed_url = format!("{protocol}://{}", candidate.raw_url);
+        candidate.did_prepend_protocol = true;
+    } else if preprocessed_url.starts_with("//") {
+        let Some(protocol) = base_protocol else {
+            return false;
+        };
+
+        if !is_http_or_https_scheme(protocol) {
+            return false;
+        }
+    } else if !starts_with_http_or_https_scheme(&preprocessed_url) {
+        return false;
+    }
+
+    if has_authority_auth_details(&preprocessed_url) {
+        return false;
+    }
+
+    if has_invalid_authority_port(&preprocessed_url) {
+        return false;
+    }
+
+    if !candidate.had_protocol {
+        let Some(hostname) = candidate_hostname(&candidate.raw_url) else {
+            return false;
+        };
+
+        let Some(last_dot) = hostname.rfind('.') else {
+            return false;
+        };
+
+        if !is_known_public_domain(&hostname[last_dot + 1..]) {
+            return false;
+        }
+    }
+
+    candidate.preprocessed_url = preprocessed_url;
+    true
+}
+
+fn parse_url_scheme(url: &str) -> Option<String> {
+    let colon = url.find(':')?;
+    let first_delimiter = url
+        .find(|character| matches!(character, '/' | '?' | '#'))
+        .unwrap_or(url.len());
+    if colon > first_delimiter {
+        return None;
+    }
+
+    Some(url[..colon].to_ascii_lowercase())
+}
+
+fn is_http_or_https_scheme(scheme: &str) -> bool {
+    scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https")
+}
+
+fn starts_with_http_or_https_scheme(url: &str) -> bool {
+    ascii_starts_with(url.as_bytes(), 0, b"http:")
+        || ascii_starts_with(url.as_bytes(), 0, b"https:")
+}
+
+fn authority_range(url: &str) -> Option<(usize, usize)> {
+    let bytes = url.as_bytes();
+    let authority_start = if bytes.starts_with(b"//") {
+        2
+    } else if ascii_starts_with(bytes, 0, b"http://") {
+        7
+    } else if ascii_starts_with(bytes, 0, b"https://") {
+        8
+    } else {
+        return None;
+    };
+
+    let authority_end = bytes[authority_start..]
+        .iter()
+        .position(|byte| matches!(*byte, b'/' | b'?' | b'#'))
+        .map(|offset| authority_start + offset)
+        .unwrap_or(bytes.len());
+
+    Some((authority_start, authority_end))
+}
+
+fn has_authority_auth_details(url: &str) -> bool {
+    let Some((start, end)) = authority_range(url) else {
+        return false;
+    };
+
+    url.as_bytes()[start..end].contains(&b'@')
+}
+
+fn has_invalid_authority_port(url: &str) -> bool {
+    let Some((start, end)) = authority_range(url) else {
+        return false;
+    };
+
+    let authority = &url[start..end];
+    if authority.starts_with('[') {
+        return authority.find(']').is_none();
+    }
+
+    let Some(colon) = authority.rfind(':') else {
+        return false;
+    };
+
+    let port = &authority[colon + 1..];
+    !port.is_empty()
+        && port.bytes().all(|byte| byte.is_ascii_digit())
+        && port.parse::<u16>().is_err()
+}
+
+fn candidate_hostname(raw_url: &str) -> Option<&str> {
+    let bytes = raw_url.as_bytes();
+    let mut start = 0;
+    if bytes.starts_with(b"//") {
+        start = 2;
+    } else if ascii_starts_with(bytes, 0, b"http:") {
+        start = 5;
+        while start < bytes.len() && bytes[start] == b'/' {
+            start += 1;
+        }
+    } else if ascii_starts_with(bytes, 0, b"https:") {
+        start = 6;
+        while start < bytes.len() && bytes[start] == b'/' {
+            start += 1;
+        }
+    }
+
+    let end = bytes[start..]
+        .iter()
+        .position(|byte| !is_hostish_byte(*byte))
+        .map(|offset| start + offset)
+        .unwrap_or(bytes.len());
+    if end <= start {
+        return None;
+    }
+
+    Some(&raw_url[start..end])
 }
 
 fn find_candidate_end(bytes: &[u8], mut cursor: usize) -> usize {
@@ -288,8 +497,27 @@ fn candidate_host_has_url_shape(host: &str) -> bool {
     let tld = &host[last_dot + 1..];
     tld.len() >= 2
         && tld.len() <= 63
-        && tld.bytes().all(|byte| byte.is_ascii_alphanumeric())
+        && tld
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
         && host.split('.').all(is_valid_hostname_label)
+}
+
+fn is_known_public_domain(tld: &str) -> bool {
+    if tld.eq_ignore_ascii_case("internal") {
+        return true;
+    }
+
+    if tld.is_empty()
+        || !tld
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return false;
+    }
+
+    let needle = format!("'{}'", tld.to_ascii_lowercase());
+    include_str!("../../../components/DataLiberation/URL/public-suffix-list.php").contains(&needle)
 }
 
 fn is_valid_hostname_label(label: &str) -> bool {
@@ -319,7 +547,7 @@ fn ascii_starts_with(bytes: &[u8], offset: usize, needle: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::find_next_url_text_candidate;
+    use super::{find_next_url_text_candidate, validate_url_text_candidate, UrlTextCandidate};
 
     #[test]
     fn finds_http_https_and_bare_domain_candidates() {
@@ -351,5 +579,45 @@ mod tests {
     #[test]
     fn ignores_embedded_protocol_fragments() {
         assert!(find_next_url_text_candidate("ahttp://example.com", 0).is_none());
+    }
+
+    #[test]
+    fn accepts_punycode_tlds() {
+        let text = "Visit http://xn--fsqu00a.xn--0zwm56d";
+        let candidate = find_next_url_text_candidate(text, 0).expect("URL");
+        assert_eq!("http://xn--fsqu00a.xn--0zwm56d", candidate.raw_url);
+    }
+
+    #[test]
+    fn validates_public_url_candidates_with_base_protocol() {
+        let mut candidate = find_next_url_text_candidate("Visit example.com/docs", 0).expect("URL");
+        assert!(validate_url_text_candidate(&mut candidate, Some("https")));
+        assert_eq!("https://example.com/docs", candidate.preprocessed_url);
+        assert!(candidate.did_prepend_protocol);
+    }
+
+    #[test]
+    fn rejects_filename_like_bare_domains_with_unknown_tlds() {
+        let mut candidate = find_next_url_text_candidate("Edit plugins.php", 0).expect("candidate");
+        assert!(!validate_url_text_candidate(&mut candidate, Some("https")));
+    }
+
+    #[test]
+    fn rejects_authority_credentials() {
+        let mut candidate = UrlTextCandidate {
+            raw_url: "https://user@example.com/path".to_string(),
+            preprocessed_url: "https://user@example.com/path".to_string(),
+            starts_at: 6,
+            length: 29,
+            had_protocol: true,
+            did_prepend_protocol: false,
+        };
+        assert!(!validate_url_text_candidate(&mut candidate, Some("https")));
+    }
+
+    #[test]
+    fn rejects_bare_domains_without_base_protocol() {
+        let mut candidate = find_next_url_text_candidate("Visit example.com", 0).expect("URL");
+        assert!(!validate_url_text_candidate(&mut candidate, None));
     }
 }

--- a/extensions/native-apis/src/xml.rs
+++ b/extensions/native-apis/src/xml.rs
@@ -289,7 +289,7 @@ pub struct NativeXmlProcessor {
 #[php_impl]
 #[php(change_method_case = "snake_case")]
 impl NativeXmlProcessor {
-    pub fn create_from_string(xml: String) -> Self {
+    fn new_from_string(xml: String) -> Self {
         Self {
             source: xml,
             document: None,
@@ -305,6 +305,27 @@ impl NativeXmlProcessor {
             pending_stream_error: None,
             bookmarks: HashMap::new(),
         }
+    }
+
+    pub fn supports_public_api() -> bool {
+        true
+    }
+
+    #[php(optional = cursor)]
+    pub fn create_from_string(
+        xml: String,
+        cursor: Option<String>,
+        known_definite_encoding: Option<String>,
+        document_namespaces: Option<&Zval>,
+    ) -> Option<Self> {
+        if cursor.is_some()
+            || known_definite_encoding.as_deref().unwrap_or("UTF-8") != "UTF-8"
+            || document_namespaces.is_some()
+        {
+            return None;
+        }
+
+        Some(Self::new_from_string(xml))
     }
 
     pub fn create_for_streaming(
@@ -329,7 +350,7 @@ impl NativeXmlProcessor {
             None
         };
 
-        let mut processor = Self::create_from_string(xml);
+        let mut processor = Self::new_from_string(xml);
         processor.stream_reentrancy_base_state =
             Some(stream.clone().unwrap_or_else(XmlStreamState::new));
         processor.stream = stream;

--- a/extensions/native-apis/src/xml.rs
+++ b/extensions/native-apis/src/xml.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 #[cfg(feature = "php-extension")]
 use ext_php_rs::prelude::*;
 #[cfg(feature = "php-extension")]
-use ext_php_rs::types::Zval;
+use ext_php_rs::types::{ZendHashTable, Zval};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct XmlToken {
@@ -79,6 +79,12 @@ struct XmlBookmark {
     paused_at_incomplete_input: bool,
     last_error: Option<String>,
     pending_stream_error: Option<String>,
+}
+
+#[derive(Default)]
+struct XmlNextTagQuery {
+    breadcrumbs: Option<Vec<(String, String)>>,
+    match_offset: i64,
 }
 
 #[cfg(feature = "php-extension")]
@@ -1494,9 +1500,35 @@ impl NativeXmlProcessor {
         xml_token_stream_summary(&summary)
     }
 
-    pub fn next_tag(&mut self) -> bool {
+    #[php(optional = query_or_ns)]
+    pub fn next_tag(
+        &mut self,
+        query_or_ns: Option<&Zval>,
+        null_or_local_name: Option<String>,
+    ) -> bool {
+        let Some(query) = xml_parse_next_tag_query(query_or_ns, null_or_local_name) else {
+            return false;
+        };
+
+        let mut match_offset = query.match_offset.max(1);
+
         while self.next_token() {
-            if self.get_token_type().as_deref() == Some("#tag") && !self.is_tag_closer() {
+            if self.get_token_type().as_deref() != Some("#tag") || self.is_tag_closer() {
+                continue;
+            }
+
+            if let Some(breadcrumbs) = query.breadcrumbs.as_ref() {
+                let Some(current_breadcrumbs) = self.current_token_breadcrumbs() else {
+                    continue;
+                };
+
+                if !xml_namespaced_breadcrumbs_match(&current_breadcrumbs, breadcrumbs) {
+                    continue;
+                }
+            }
+
+            match_offset -= 1;
+            if match_offset == 0 {
                 return true;
             }
         }
@@ -3352,6 +3384,114 @@ impl NativeXmlProcessor {
 
         Some((*extend_xml_namespaces(&current_namespaces, namespace_declarations)).clone())
     }
+}
+
+#[cfg(feature = "php-extension")]
+fn xml_parse_next_tag_query(
+    query_or_ns: Option<&Zval>,
+    null_or_local_name: Option<String>,
+) -> Option<XmlNextTagQuery> {
+    let mut parsed = XmlNextTagQuery {
+        match_offset: 1,
+        ..Default::default()
+    };
+
+    let Some(query_or_ns) = query_or_ns else {
+        return Some(parsed);
+    };
+
+    if let Some(namespace_or_local_name) = query_or_ns.str() {
+        parsed.breadcrumbs = Some(vec![match null_or_local_name {
+            Some(local_name) => (namespace_or_local_name.to_string(), local_name),
+            None => ("".to_string(), namespace_or_local_name.to_string()),
+        }]);
+        return Some(parsed);
+    }
+
+    let query = query_or_ns.array()?;
+
+    if query.get_index(0).and_then(|value| value.str()).is_some()
+        && query.get_index(1).and_then(|value| value.str()).is_some()
+    {
+        parsed.breadcrumbs = Some(vec![(
+            query.get_index(0)?.str()?.to_string(),
+            query.get_index(1)?.str()?.to_string(),
+        )]);
+        return Some(parsed);
+    }
+
+    if let Some(match_offset) = xml_array_positive_i64(query, "match_offset") {
+        parsed.match_offset = match_offset;
+    }
+
+    parsed.breadcrumbs = xml_array_namespaced_breadcrumbs(query, "breadcrumbs");
+
+    Some(parsed)
+}
+
+#[cfg(feature = "php-extension")]
+fn xml_array_positive_i64(query: &ZendHashTable, key: &str) -> Option<i64> {
+    query
+        .get(key)
+        .and_then(|value| value.long())
+        .filter(|value| *value > 0)
+        .map(|value| value as i64)
+}
+
+#[cfg(feature = "php-extension")]
+fn xml_array_namespaced_breadcrumbs(
+    query: &ZendHashTable,
+    key: &str,
+) -> Option<Vec<(String, String)>> {
+    let breadcrumbs = query.get(key)?.array()?;
+    let mut parsed = Vec::with_capacity(breadcrumbs.len());
+
+    for value in breadcrumbs.iter().map(|(_, value)| value) {
+        if let Some(local_name) = value.str() {
+            if local_name == "*" {
+                parsed.push(("*".to_string(), "*".to_string()));
+            } else {
+                parsed.push(("*".to_string(), local_name.to_string()));
+            }
+            continue;
+        }
+
+        let pair = value.array()?;
+        parsed.push((
+            pair.get_index(0)?.str()?.to_string(),
+            pair.get_index(1)?.str()?.to_string(),
+        ));
+    }
+
+    Some(parsed)
+}
+
+fn xml_namespaced_breadcrumbs_match(
+    current: &[(String, String)],
+    breadcrumbs: &[(String, String)],
+) -> bool {
+    if breadcrumbs.is_empty() {
+        return true;
+    }
+
+    if breadcrumbs.len() > current.len() {
+        return false;
+    }
+
+    let offset = current.len() - breadcrumbs.len();
+    for (index, (namespace, local_name)) in breadcrumbs.iter().enumerate() {
+        let (current_namespace, current_local_name) = &current[offset + index];
+
+        if local_name != "*" && local_name != current_local_name {
+            return false;
+        }
+
+        if namespace != "*" && namespace != current_namespace {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[cfg(feature = "php-extension")]

--- a/extensions/native-apis/tests/verify-native-apis.php
+++ b/extensions/native-apis/tests/verify-native-apis.php
@@ -60,6 +60,12 @@ assert_same( "A\u{00a0}B\u{00a9}\u{00ae}\u{2026}\u{2014}\u{2209}", $tag_processo
 assert_same( false, $tag_processor->next_tag(), 'Expected HTML next_tag() to skip closing tags.' );
 assert_false( $tag_processor->paused_at_incomplete_token(), 'Expected native HTML tag processor not to pause at an incomplete token after complete input.' );
 
+$tag_query_processor = new WP_HTML_Native_Tag_Processor( '<main><p class="intro"></p><p class="target"></p></main>' );
+assert_true( $tag_query_processor->next_tag( array( 'tag_name' => 'p', 'class_name' => 'target' ) ), 'Expected native HTML tag processor to honor tag and class next_tag() queries.' );
+assert_same( 'P', $tag_query_processor->get_tag(), 'Expected native HTML tag query to stop on the matching paragraph.' );
+assert_true( $tag_query_processor->next_tag( array( 'tag_name' => 'p', 'tag_closers' => 'visit' ) ), 'Expected native HTML tag processor to honor tag_closers query mode.' );
+assert_true( $tag_query_processor->is_tag_closer(), 'Expected native HTML tag processor query to visit matching closers.' );
+
 $comment_qualified_name_processor = new WP_HTML_Native_Tag_Processor( '<!--note-->' );
 assert_true( $comment_qualified_name_processor->next_token(), 'Expected comment token before qualified name checks.' );
 assert_same( null, $comment_qualified_name_processor->get_qualified_tag_name(), 'Expected native HTML qualified tag name to return null on comments.' );
@@ -452,6 +458,10 @@ assert_true( $html_full_parser instanceof WP_HTML_Native_Processor, 'Expected na
 assert_true( $html_full_parser->next_tag(), 'Expected native HTML full parser to scan tags.' );
 assert_same( 'HTML', $html_full_parser->get_tag(), 'Expected native HTML full parser to start at the document HTML tag.' );
 assert_same( null, WP_HTML_Native_Processor::create_full_parser( '<html></html>', 'ISO-8859-1' ), 'Expected native HTML full parser factory to reject unsupported encodings.' );
+
+$html_processor_query = WP_HTML_Native_Processor::create_fragment( '<section><article><img class="hero"></article></section>' );
+assert_true( $html_processor_query->next_tag( array( 'breadcrumbs' => array( 'ARTICLE', 'IMG' ), 'class_name' => 'hero' ) ), 'Expected native HTML processor to honor breadcrumb and class next_tag() queries.' );
+assert_same( 'IMG', $html_processor_query->get_tag(), 'Expected native HTML processor query to stop on the matching image.' );
 
 $html_step_processor = WP_HTML_Native_Processor::create_fragment( '<section><p>Text</p></section>' );
 assert_true( $html_step_processor->step(), 'Expected native HTML processor step() to advance by default.' );
@@ -1120,6 +1130,12 @@ assert_same( $xml_class, get_class( $xml_streaming ), 'Expected native XML strea
 assert_true( $xml_streaming->next_tag(), 'Expected native XML streaming factory processor to expose the root tag.' );
 assert_same( 'root', $xml_streaming->get_token_name(), 'Expected native XML streaming factory root tag name.' );
 assert_same( null, $xml_class::create_for_streaming( '<root />', null, 'ISO-8859-1', array() ), 'Expected native XML streaming factory to reject unsupported encodings.' );
+
+$xml_query = $xml_class::create_from_string( '<root xmlns:wp="https://wordpress.org"><wp:item /><item /></root>' );
+assert_true( $xml_query->next_tag( array( 'breadcrumbs' => array( array( 'https://wordpress.org', 'item' ) ) ) ), 'Expected native XML processor to honor namespaced breadcrumb next_tag() queries.' );
+assert_same( 'https://wordpress.org', $xml_query->get_tag_namespace(), 'Expected native XML namespaced query to stop on the namespaced item.' );
+assert_true( $xml_query->next_tag( 'item' ), 'Expected native XML processor to honor local-name next_tag() queries.' );
+assert_same( '', $xml_query->get_tag_namespace(), 'Expected native XML local-name query to stop on the unnamespaced item.' );
 
 $xml_streaming_incomplete = $xml_class::create_for_streaming( '<root', null, 'UTF-8', array() );
 assert_false( $xml_streaming_incomplete->next_token(), 'Expected incomplete native XML streaming input to pause token scanning.' );
@@ -1872,11 +1888,15 @@ while ( $xml_processing_instruction->next_token() ) {
 assert_true( null !== $xml_processing_instruction->get_last_error(), 'Expected XML processing instruction parse error.' );
 
 $url_text_class     = 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor';
-$url_text_processor = new $url_text_class( 'Visit https://WordPress.org/plugins, then example.com/docs.' );
+$url_text_processor = new $url_text_class( 'Visit https://WordPress.org/plugins, then example.com/docs.', 'https://wordpress.org' );
 assert_true( $url_text_processor->next_url(), 'Expected native URL-in-text processor to find the first URL.' );
 assert_same( 'https://WordPress.org/plugins', $url_text_processor->get_raw_url(), 'Expected native URL-in-text processor to trim trailing punctuation.' );
 assert_same( 6, $url_text_processor->get_url_starts_at(), 'Expected native URL-in-text processor to expose byte offset.' );
 assert_true( $url_text_processor->had_protocol(), 'Expected native URL-in-text processor to mark explicit protocols.' );
+$url_text_parsed = $url_text_processor->get_parsed_url();
+assert_true( is_object( $url_text_parsed ), 'Expected native URL-in-text get_parsed_url() to expose the parsed URL object.' );
+assert_same( 'https:', $url_text_parsed->protocol, 'Expected native URL-in-text parsed URL protocol.' );
+assert_same( 'wordpress.org', $url_text_parsed->hostname, 'Expected native URL-in-text parsed URL hostname.' );
 assert_true( $url_text_processor->next_url(), 'Expected native URL-in-text processor to find the second URL.' );
 assert_same( 'example.com/docs', $url_text_processor->get_raw_url(), 'Expected native URL-in-text processor to find bare-domain URLs.' );
 assert_false( $url_text_processor->had_protocol(), 'Expected native URL-in-text processor to mark bare domains.' );


### PR DESCRIPTION
## What it does

Changes the public PHP classes to progressively use the native extension with no API-consumer burden.

When the extension is installed and the native class advertises `supports_public_api()`, the public PHP class resolves to the native implementation. Otherwise it falls back to the moved PHP implementation.

Implemented wiring:

| Component | PHP integration in this PR |
| --- | --- |
| HTML | `WP_HTML_Tag_Processor` and `WP_HTML_Processor` load either empty native adapter subclasses or the moved PHP classes. |
| XML | `XMLProcessor` loads either `NativeXMLProcessor` directly or `PHPXMLProcessor`. The old cursor bridge is reduced to an empty native subclass. |
| URL-in-text | `URLInTextProcessor` loads either the native class through an empty adapter or `PHPURLInTextProcessor`. |
| Data Liberation HTML | Keeps the public subclass usable with the same native/PHP processor selection model instead of forcing the PHP path. |

The native wrapper files are intentionally tiny:

- `components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php`: 5 lines
- `components/HTML/class-wp-html-native-processor-wrapper.php`: 9 lines
- `components/HTML/class-wp-html-native-tag-processor-wrapper.php`: 9 lines
- `components/XML/class-xmlnativecursorprocessor.php`: 5 lines

## Rationale

The public class names should remain stable for consumers. Installing the native extension should be a progressive upgrade, not a new API they have to opt into.

This PR keeps PHP responsible for loading and fallback only. Parser behavior belongs to the Rust classes already merged from #276 or to the moved PHP fallback classes.

## Implementation

The moved PHP implementations live under component `PHP/` paths. Public loader files choose the native class only when all of these are true:

```php
! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) || ! WP_NATIVE_APIS_DISABLE_DEFAULTS
class_exists( $native_class, false )
method_exists( $native_class, 'supports_public_api' )
$native_class::supports_public_api()
```

There are no per-component `WP_NATIVE_APIS_ENABLE_*` switches. Tests and benchmarks can use the single global opt-out constant when they need to force fallback behavior.

The benchmark harness now tolerates unsupported PHP fallback rows instead of aborting the run, while `--require-native` still fails if any native implementation row is unavailable.

## Benchmarks

Benchmark run: https://github.com/WordPress/php-toolkit/actions/runs/25988013187

Command:

```bash
php -d extension=extensions/native-apis/target/release/libwp_native_apis.so \
  bin/benchmark-native-apis.php \
  --iterations=100 \
  --mode=both \
  --disable-native-defaults \
  --require-native
```

Representative PHP-fallback vs native rows:

| Workload | PHP wall (s) | Native wall (s) | Speedup |
| --- | ---: | ---: | ---: |
| `html-tag-processor` | 0.240940 | 0.035885 | 6.71x |
| `html-processor` | 1.113778 | 0.135704 | 8.21x |
| `xml-processor` | 0.332820 | 0.063290 | 5.26x |
| `url-in-text-processor` | 3.853847 | 0.030515 | 126.29x |

The same run also completed all native fused/chunked benchmark rows for HTML, XML, and URL-in-text with `--require-native` enabled.

## Testing instructions

Local checks run for the benchmark harness fixes:

```bash
php -l bin/benchmark-native-apis.php
```

Previously run locally before the #276 rebase:

```bash
php -l components/HTML/class-wp-html-native-tag-processor-wrapper.php
php -l components/HTML/class-wp-html-native-processor-wrapper.php
php -l components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php
php -l components/XML/class-xmlnativecursorprocessor.php
php -l components/XML/class-xmlprocessor.php
php -l components/HTML/class-wp-html-tag-processor.php
php -l components/HTML/class-wp-html-processor.php
php -l components/DataLiberation/URL/class-urlintextprocessor.php
vendor/bin/phpunit components/HTML/Tests/NativeHTMLConformanceTest.php
vendor/bin/phpunit components/XML/Tests/NativeXMLConformanceTest.php
vendor/bin/phpunit components/DataLiberation/Tests/URLInTextProcessorTest.php components/DataLiberation/Tests/URLInTextProcessorWHATWGComplianceTest.php components/DataLiberation/Tests/WPURLTest.php
vendor/bin/phpcs --standard=phpcs.xml components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php components/DataLiberation/URL/class-urlintextprocessor.php components/HTML/class-wp-html-native-processor-wrapper.php components/HTML/class-wp-html-native-tag-processor-wrapper.php components/HTML/class-wp-html-processor.php components/HTML/class-wp-html-tag-processor.php components/XML/class-xmlnativecursorprocessor.php components/XML/class-xmlprocessor.php components/HTML/Tests/NativeHTMLConformanceTest.php components/XML/Tests/NativeXMLConformanceTest.php
git diff --check
```

GitHub Actions is the authoritative extension build/load check for this PR because this local machine does not have `php-config`.