### PR TITLE
Handle strikethrough in MarkdownConsumer

### DIFF
--- a/components/Markdown/Tests/MarkdownConsumerTest.php
+++ b/components/Markdown/Tests/MarkdownConsumerTest.php
@@ -166,6 +166,10 @@ HTML
 				'markdown' => '**Bold** and *Italic*',
 				'expected' => '<!-- wp:paragraph --><p><b>Bold</b> and <em>Italic</em></p><!-- /wp:paragraph -->',
 			),
+			'Strikethrough text' => array(
+				'markdown' => 'Keep ~~removed~~ text and continue.',
+				'expected' => '<!-- wp:paragraph --><p>Keep <del>removed</del> text and continue.</p><!-- /wp:paragraph -->',
+			),
 			'A blockquote' => array(
 				'markdown' => '> A simple blockquote',
 				'expected' => '<!-- wp:quote --><blockquote class="wp-block-quote"><!-- wp:paragraph --><p>A simple blockquote</p><!-- /wp:paragraph --></blockquote><!-- /wp:quote -->',

--- a/components/Markdown/class-markdownconsumer.php
+++ b/components/Markdown/class-markdownconsumer.php
@@ -7,6 +7,7 @@ use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block as ExtensionBlock;
 use League\CommonMark\Extension\CommonMark\Node\Inline as ExtensionInline;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\Extension\Strikethrough\Strikethrough;
 use League\CommonMark\Extension\Table\Table;
 use League\CommonMark\Extension\Table\TableCell;
 use League\CommonMark\Extension\Table\TableRow;
@@ -234,6 +235,10 @@ class MarkdownConsumer implements DataFormatConsumer {
 						$this->append_content( '<em>' );
 						break;
 
+					case Strikethrough::class:
+						$this->append_content( '<del>' );
+						break;
+
 					case ExtensionInline\HtmlInline::class:
 						$this->append_content( htmlspecialchars( $node->getLiteral() ) );
 						break;
@@ -322,6 +327,9 @@ BLOCK;
 						break;
 					case ExtensionInline\Emphasis::class:
 						$this->append_content( '</em>' );
+						break;
+					case Strikethrough::class:
+						$this->append_content( '</del>' );
 						break;
 					case ExtensionInline\Link::class:
 						$this->append_content( '</a>' );


### PR DESCRIPTION
## What
- Adds MarkdownConsumer handling for GitHub-flavored strikethrough nodes.
- Adds a regression case so conversion continues after `~~text~~`.

## Testing
- `php -r 'require "vendor/autoload.php"; $md="Keep ~~removed~~ text and continue.\n\nSecond paragraph."; $out=(new WordPress\Markdown\MarkdownConsumer($md))->consume()->get_block_markup(); if (strpos($out,"<del>removed</del>")===false || strpos($out,"Second paragraph")===false) exit(1); echo "direct strikethrough regression passed\n";'`

Note: `vendor/bin/phpunit --filter MarkdownConsumerTest -c phpunit.xml` could not run locally because dev dependencies are not installed in the submodule checkout.
