### PR TITLE
Expose public API entry points from native classes

### DIFF
--- a/.github/workflows/native-apis.yml
+++ b/.github/workflows/native-apis.yml
@@ -1,0 +1,52 @@
+name: Native APIs
+
+on:
+  push:
+    branches:
+      - trunk
+  pull_request:
+    paths:
+      - '.github/workflows/native-apis.yml'
+      - 'components/DataLiberation/URL/**'
+      - 'components/HTML/**'
+      - 'components/XML/**'
+      - 'extensions/native-apis/**'
+
+jobs:
+  build-and-verify:
+    name: Build and verify PHP extension
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, json
+          coverage: none
+          tools: composer:v2
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
+          php-config --version
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run Rust tests
+        working-directory: extensions/native-apis
+        run: cargo test
+
+      - name: Build native extension
+        run: extensions/native-apis/build-extension.sh
+
+      - name: Verify native extension
+        run: php -d extension=extensions/native-apis/target/release/libwp_native_apis.so extensions/native-apis/tests/verify-native-apis.php

--- a/extensions/native-apis/build-extension.sh
+++ b/extensions/native-apis/build-extension.sh
@@ -25,7 +25,8 @@ if ! command -v clang >/dev/null 2>&1 && [ -z "${LIBCLANG_PATH:-}" ]; then
 	exit 1
 fi
 
-export PHP_CONFIG="${php_config}"
+PHP_CONFIG="$(command -v "${php_config}")"
+export PHP_CONFIG
 
 cargo build --release --features php-extension
 

--- a/extensions/native-apis/src/html.rs
+++ b/extensions/native-apis/src/html.rs
@@ -3280,41 +3280,83 @@ fn html_serialize_opening_tag(html: &str, tag: &HtmlTag) -> String {
     output.push('<');
     output.push_str(&tag.name);
 
-    let mut seen = Vec::new();
-    for attribute_name in &tag.attribute_order {
-        if seen
-            .iter()
-            .any(|seen_name: &String| seen_name == attribute_name)
-        {
-            continue;
-        }
-        seen.push(attribute_name.clone());
-
+    for (attribute_name, value) in
+        html_source_attribute_items(html.as_bytes(), tag.source_start, tag.source_end)
+    {
         output.push(' ');
-        output.push_str(attribute_name);
+        output.push_str(&attribute_name);
 
-        if find_html_attribute_has_value(
-            html.as_bytes(),
-            tag.source_start,
-            tag.source_end,
-            attribute_name,
-        ) == Some(false)
-        {
-            continue;
+        if let Some(value) = value {
+            output.push_str("=\"");
+            output.push_str(&html_escape_attribute_value(&value));
+            output.push('"');
         }
-
-        let value = tag
-            .attributes
-            .get(attribute_name)
-            .cloned()
-            .unwrap_or_default();
-        output.push_str("=\"");
-        output.push_str(&html_escape_attribute_value(&value));
-        output.push('"');
     }
 
     output.push('>');
     output
+}
+
+fn html_source_attribute_items(
+    bytes: &[u8],
+    source_start: usize,
+    source_end: usize,
+) -> Vec<(String, Option<String>)> {
+    if source_start >= bytes.len() || source_end <= source_start {
+        return Vec::new();
+    }
+
+    let tag_end = source_end.saturating_sub(1).min(bytes.len());
+    let mut cursor = source_start.saturating_add(1);
+    if cursor < tag_end && bytes[cursor] == b'/' {
+        return Vec::new();
+    }
+
+    cursor = skip_ascii_whitespace(bytes, cursor);
+    cursor = span_name(bytes, cursor);
+
+    let mut items = Vec::new();
+    let mut seen = Vec::new();
+    while cursor < tag_end {
+        cursor = skip_ascii_whitespace(bytes, cursor);
+        if cursor >= tag_end || bytes[cursor] == b'>' {
+            break;
+        }
+        if bytes[cursor] == b'/' && cursor + 1 < bytes.len() && bytes[cursor + 1] == b'>' {
+            break;
+        }
+
+        let attr_start = cursor;
+        cursor = span_html_attribute_name(bytes, cursor);
+        if cursor == attr_start {
+            cursor += 1;
+            continue;
+        }
+
+        let attr_name = ascii_lower(&bytes[attr_start..cursor]);
+        cursor = skip_ascii_whitespace(bytes, cursor);
+
+        let mut value = None;
+        if cursor < tag_end && bytes[cursor] == b'=' {
+            cursor += 1;
+            cursor = skip_ascii_whitespace(bytes, cursor);
+            let parsed = parse_attribute_value(bytes, cursor);
+            value = Some(parsed.0);
+            cursor = parsed.1;
+        }
+
+        if seen
+            .iter()
+            .any(|seen_name: &String| seen_name == &attr_name)
+        {
+            continue;
+        }
+
+        seen.push(attr_name.clone());
+        items.push((attr_name, value));
+    }
+
+    items
 }
 
 #[cfg(feature = "php-extension")]
@@ -6200,9 +6242,10 @@ mod tests {
     use super::{
         apply_html_text_removals, find_html_attribute_names_with_prefix_count,
         find_html_attribute_names_with_prefix_string, find_html_attribute_removals,
-        find_html_attribute_removals_with_prefix, html_tag_has_self_closing_flag,
-        html_token_compact_summary, initial_html_breadcrumbs, parse_html_tags,
-        parse_next_html_token, parse_next_plain_html_tag_token, HtmlTextRemoval,
+        find_html_attribute_removals_with_prefix, html_serialize_opening_tag,
+        html_source_attribute_items, html_tag_has_self_closing_flag, html_token_compact_summary,
+        initial_html_breadcrumbs, parse_html_tags, parse_next_html_token,
+        parse_next_plain_html_tag_token, HtmlTextRemoval,
     };
 
     fn collect_processor_tokens(html: &str) -> Vec<(String, bool, String, String)> {
@@ -6277,6 +6320,25 @@ mod tests {
                 "data-x".to_string()
             ],
             tags[0].attribute_order
+        );
+    }
+
+    #[test]
+    fn serializes_opening_tag_attributes_from_source() {
+        let html = "<a href=#anchor v=5 href=\"/\" enabled>One</a>";
+        let tags = parse_html_tags(html);
+
+        assert_eq!(
+            vec![
+                ("href".to_string(), Some("#anchor".to_string())),
+                ("v".to_string(), Some("5".to_string())),
+                ("enabled".to_string(), None),
+            ],
+            html_source_attribute_items(html.as_bytes(), tags[0].source_start, tags[0].source_end)
+        );
+        assert_eq!(
+            "<a href=\"#anchor\" v=\"5\" enabled>",
+            html_serialize_opening_tag(html, &tags[0])
         );
     }
 

--- a/extensions/native-apis/src/html.rs
+++ b/extensions/native-apis/src/html.rs
@@ -8,7 +8,7 @@ use ext_php_rs::prelude::*;
 #[cfg(feature = "php-extension")]
 use ext_php_rs::{
     boxed::ZBox,
-    types::{ZendCallable, ZendHashTable, Zval},
+    types::{ZendHashTable, Zval},
     zend::Function,
 };
 
@@ -2554,7 +2554,7 @@ impl WpHtmlNativeProcessor {
     }
 
     pub fn normalize(html: String) -> Option<String> {
-        html_normalize_via_php(&html)
+        html_serialize_native_fragment(&html)
     }
 
     pub fn serialize(&mut self) -> Option<String> {
@@ -2562,7 +2562,7 @@ impl WpHtmlNativeProcessor {
             return None;
         }
 
-        let serialized = html_normalize_via_php(&self.inner.html)?;
+        let serialized = html_serialize_native_fragment(&self.inner.html)?;
         self.inner.offset = self.inner.html.len();
         Some(serialized)
     }
@@ -3246,6 +3246,78 @@ fn html_breadcrumbs_match(current: &[String], breadcrumbs: &[String]) -> bool {
 }
 
 #[cfg(feature = "php-extension")]
+fn html_serialize_native_fragment(html: &str) -> Option<String> {
+    let mut processor = WpHtmlNativeProcessor::create_fragment(
+        html.to_string(),
+        Some("<body>".to_string()),
+        Some("UTF-8".to_string()),
+    )?;
+    let mut serialized = String::with_capacity(html.len());
+
+    while processor.next_token() {
+        let Some(tag) = processor.inner.current_tag() else {
+            continue;
+        };
+
+        serialized.push_str(&html_serialize_token(html, tag));
+    }
+
+    Some(serialized)
+}
+
+fn html_serialize_token(html: &str, tag: &HtmlTag) -> String {
+    match tag.token_type.as_str() {
+        "#tag" if tag.closing => format!("</{}>", tag.name),
+        "#tag" => html_serialize_opening_tag(html, tag),
+        "#comment" => format!("<!--{}-->", tag.text),
+        "#text" => html_escape_text(&tag.text),
+        _ => String::new(),
+    }
+}
+
+fn html_serialize_opening_tag(html: &str, tag: &HtmlTag) -> String {
+    let mut output = String::new();
+    output.push('<');
+    output.push_str(&tag.name);
+
+    let mut seen = Vec::new();
+    for attribute_name in &tag.attribute_order {
+        if seen
+            .iter()
+            .any(|seen_name: &String| seen_name == attribute_name)
+        {
+            continue;
+        }
+        seen.push(attribute_name.clone());
+
+        output.push(' ');
+        output.push_str(attribute_name);
+
+        if find_html_attribute_has_value(
+            html.as_bytes(),
+            tag.source_start,
+            tag.source_end,
+            attribute_name,
+        ) == Some(false)
+        {
+            continue;
+        }
+
+        let value = tag
+            .attributes
+            .get(attribute_name)
+            .cloned()
+            .unwrap_or_default();
+        output.push_str("=\"");
+        output.push_str(&html_escape_attribute_value(&value));
+        output.push('"');
+    }
+
+    output.push('>');
+    output
+}
+
+#[cfg(feature = "php-extension")]
 fn html_tag_public_summary_row(tag: &HtmlTag) -> Vec<(String, Zval)> {
     vec![
         (
@@ -3427,13 +3499,6 @@ fn html_doctype_info_zval(html: &str, tag: &HtmlTag) -> Option<Zval> {
     } else {
         Some(value)
     }
-}
-
-#[cfg(feature = "php-extension")]
-fn html_normalize_via_php(html: &str) -> Option<String> {
-    let callable = ZendCallable::try_from_name("WP_HTML_Processor::normalize").ok()?;
-    let value = callable.try_call(vec![&html]).ok()?;
-    value.string()
 }
 
 fn html_token_compact_summary(tag: &HtmlTag) -> String {

--- a/extensions/native-apis/src/html.rs
+++ b/extensions/native-apis/src/html.rs
@@ -82,6 +82,15 @@ enum HtmlAttributeValue {
     String(String),
 }
 
+#[derive(Default)]
+struct HtmlNextTagQuery {
+    tag_name: Option<String>,
+    class_name: Option<String>,
+    match_offset: i64,
+    visit_closers: bool,
+    breadcrumbs: Option<Vec<String>>,
+}
+
 #[cfg(feature = "php-extension")]
 impl WpHtmlNativeTagProcessor {
     fn get_attribute_value(&self, name: &str) -> Option<HtmlAttributeValue> {
@@ -174,8 +183,22 @@ impl WpHtmlNativeTagProcessor {
     }
 
     #[php(optional = query)]
-    pub fn next_tag(&mut self, _query: Option<&Zval>) -> bool {
-        self.next_tag_any(false, 1)
+    pub fn next_tag(&mut self, query: Option<&Zval>) -> bool {
+        let query = html_parse_tag_processor_next_tag_query(query);
+        let mut match_offset = query.match_offset.max(1);
+
+        while self.advance_to_next_tag_token() {
+            if !self.current_html_tag_matches_query(&query, false) {
+                continue;
+            }
+
+            match_offset -= 1;
+            if match_offset == 0 {
+                return true;
+            }
+        }
+
+        false
     }
 
     pub fn next_tag_any(&mut self, visit_closers: bool, mut match_offset: i64) -> bool {
@@ -2441,6 +2464,44 @@ impl WpHtmlNativeTagProcessor {
     fn current_tag(&self) -> Option<&HtmlTag> {
         self.current.as_ref()
     }
+
+    fn current_html_tag_matches_query(
+        &self,
+        query: &HtmlNextTagQuery,
+        use_breadcrumbs: bool,
+    ) -> bool {
+        let Some(tag) = self.current_tag() else {
+            return false;
+        };
+
+        if tag.token_type != "#tag" {
+            return false;
+        }
+
+        if tag.closing && (!query.visit_closers || use_breadcrumbs) {
+            return false;
+        }
+
+        if let Some(tag_name) = query.tag_name.as_ref() {
+            if !tag.name.eq_ignore_ascii_case(tag_name) {
+                return false;
+            }
+        }
+
+        if let Some(class_name) = query.class_name.as_ref() {
+            if self.has_class(class_name.clone()) != Some(true) {
+                return false;
+            }
+        }
+
+        if use_breadcrumbs {
+            if let Some(breadcrumbs) = query.breadcrumbs.as_ref() {
+                return html_breadcrumbs_match(&tag.breadcrumbs, breadcrumbs);
+            }
+        }
+
+        true
+    }
 }
 
 #[cfg(feature = "php-extension")]
@@ -2592,7 +2653,27 @@ impl WpHtmlNativeProcessor {
 
     #[php(optional = query)]
     pub fn next_tag(&mut self, query: Option<&Zval>) -> bool {
-        self.inner.next_tag(query)
+        let Some(query) = html_parse_processor_next_tag_query(query) else {
+            return false;
+        };
+        let use_breadcrumbs = query.breadcrumbs.is_some();
+        let mut match_offset = query.match_offset.max(1);
+
+        while self.next_token() {
+            if !self
+                .inner
+                .current_html_tag_matches_query(&query, use_breadcrumbs)
+            {
+                continue;
+            }
+
+            match_offset -= 1;
+            if match_offset == 0 {
+                return true;
+            }
+        }
+
+        false
     }
 
     pub fn next_tag_summary_batch(
@@ -3039,6 +3120,129 @@ fn token_metadata(tag: &HtmlTag) -> String {
     }
 
     metadata
+}
+
+#[cfg(feature = "php-extension")]
+fn html_parse_tag_processor_next_tag_query(query: Option<&Zval>) -> HtmlNextTagQuery {
+    let mut parsed = HtmlNextTagQuery {
+        match_offset: 1,
+        ..Default::default()
+    };
+
+    let Some(query) = query else {
+        return parsed;
+    };
+
+    if let Some(tag_name) = query.str() {
+        parsed.tag_name = Some(tag_name.to_string());
+        return parsed;
+    }
+
+    let Some(query) = query.array() else {
+        return parsed;
+    };
+
+    if let Some(tag_name) = html_array_string(query, "tag_name") {
+        parsed.tag_name = Some(tag_name);
+    }
+
+    if let Some(class_name) = html_array_string(query, "class_name") {
+        parsed.class_name = Some(class_name);
+    }
+
+    if let Some(match_offset) = html_array_positive_i64(query, "match_offset") {
+        parsed.match_offset = match_offset;
+    }
+
+    parsed.visit_closers = html_array_string(query, "tag_closers").as_deref() == Some("visit");
+
+    parsed
+}
+
+#[cfg(feature = "php-extension")]
+fn html_parse_processor_next_tag_query(query: Option<&Zval>) -> Option<HtmlNextTagQuery> {
+    let mut parsed = HtmlNextTagQuery {
+        match_offset: 1,
+        ..Default::default()
+    };
+
+    let Some(query) = query else {
+        return Some(parsed);
+    };
+
+    if let Some(tag_name) = query.str() {
+        parsed.breadcrumbs = Some(vec![tag_name.to_string()]);
+        return Some(parsed);
+    }
+
+    let query = query.array()?;
+
+    if let Some(tag_name) = html_array_string(query, "tag_name") {
+        parsed.tag_name = Some(tag_name);
+    }
+
+    if let Some(class_name) = html_array_string(query, "class_name") {
+        parsed.class_name = Some(class_name);
+    }
+
+    if let Some(match_offset) = html_array_positive_i64(query, "match_offset") {
+        parsed.match_offset = match_offset;
+    }
+
+    parsed.visit_closers = html_array_string(query, "tag_closers").as_deref() == Some("visit");
+    parsed.breadcrumbs = html_array_string_breadcrumbs(query, "breadcrumbs");
+
+    Some(parsed)
+}
+
+#[cfg(feature = "php-extension")]
+fn html_array_string(query: &ZendHashTable, key: &str) -> Option<String> {
+    query
+        .get(key)
+        .and_then(|value| value.str())
+        .map(str::to_string)
+}
+
+#[cfg(feature = "php-extension")]
+fn html_array_positive_i64(query: &ZendHashTable, key: &str) -> Option<i64> {
+    query
+        .get(key)
+        .and_then(|value| value.long())
+        .filter(|value| *value > 0)
+        .map(|value| value as i64)
+}
+
+#[cfg(feature = "php-extension")]
+fn html_array_string_breadcrumbs(query: &ZendHashTable, key: &str) -> Option<Vec<String>> {
+    let breadcrumbs = query.get(key)?.array()?;
+    let mut parsed = Vec::with_capacity(breadcrumbs.len());
+
+    for value in breadcrumbs.iter().map(|(_, value)| value) {
+        parsed.push(value.str()?.to_string());
+    }
+
+    Some(parsed)
+}
+
+fn html_breadcrumbs_match(current: &[String], breadcrumbs: &[String]) -> bool {
+    if breadcrumbs.is_empty() {
+        return true;
+    }
+
+    if breadcrumbs.len() > current.len() {
+        return false;
+    }
+
+    let offset = current.len() - breadcrumbs.len();
+    for (index, breadcrumb) in breadcrumbs.iter().enumerate() {
+        let crumb = breadcrumb.to_ascii_uppercase();
+        let node = &current[offset + index];
+        if crumb != "*" && node != &crumb {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[cfg(feature = "php-extension")]

--- a/extensions/native-apis/src/html.rs
+++ b/extensions/native-apis/src/html.rs
@@ -169,7 +169,12 @@ impl WpHtmlNativeTagProcessor {
         }
     }
 
-    pub fn next_tag(&mut self) -> bool {
+    pub fn supports_public_api() -> bool {
+        true
+    }
+
+    #[php(optional = query)]
+    pub fn next_tag(&mut self, _query: Option<&Zval>) -> bool {
         self.next_tag_any(false, 1)
     }
 
@@ -2449,12 +2454,27 @@ pub struct WpHtmlNativeProcessor {
 #[php_impl]
 #[php(change_method_case = "snake_case")]
 impl WpHtmlNativeProcessor {
-    pub fn create_fragment(html: String) -> Self {
+    pub fn supports_public_api() -> bool {
+        true
+    }
+
+    #[php(optional = context)]
+    pub fn create_fragment(
+        html: String,
+        context: Option<String>,
+        encoding: Option<String>,
+    ) -> Option<Self> {
+        if context.as_deref().unwrap_or("<body>") != "<body>"
+            || encoding.as_deref().unwrap_or("UTF-8") != "UTF-8"
+        {
+            return None;
+        }
+
         let mut inner = WpHtmlNativeTagProcessor::__construct(html);
         inner.synthesize_implied_closers = true;
         inner.ignore_html_body_starts = true;
 
-        Self { inner }
+        Some(Self { inner })
     }
 
     #[php(optional = known_definite_encoding)]
@@ -2570,8 +2590,9 @@ impl WpHtmlNativeProcessor {
         rows
     }
 
-    pub fn next_tag(&mut self) -> bool {
-        self.inner.next_tag()
+    #[php(optional = query)]
+    pub fn next_tag(&mut self, query: Option<&Zval>) -> bool {
+        self.inner.next_tag(query)
     }
 
     pub fn next_tag_summary_batch(

--- a/extensions/native-apis/src/url_text.rs
+++ b/extensions/native-apis/src/url_text.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(not(feature = "php-extension"), allow(dead_code))]
 
 #[cfg(feature = "php-extension")]
-use ext_php_rs::prelude::*;
+use ext_php_rs::{
+    prelude::*,
+    types::{ZendCallable, Zval},
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UrlTextCandidate {
@@ -22,6 +25,7 @@ pub struct NativeUrlInTextProcessor {
     current: Option<UrlTextCandidate>,
     replacements: Vec<UrlTextReplacement>,
     validate_urls: bool,
+    base_url: Option<String>,
     base_protocol: Option<String>,
 }
 
@@ -46,6 +50,7 @@ impl NativeUrlInTextProcessor {
             current: None,
             replacements: Vec::new(),
             validate_urls: true,
+            base_url,
             base_protocol,
         }
     }
@@ -60,6 +65,7 @@ impl NativeUrlInTextProcessor {
 
     pub fn set_base_url(&mut self, base_url: String) {
         self.base_protocol = parse_url_scheme(&base_url);
+        self.base_url = Some(base_url);
     }
 
     pub fn next_url(&mut self) -> bool {
@@ -95,8 +101,26 @@ impl NativeUrlInTextProcessor {
             .map(|candidate| candidate.preprocessed_url.clone())
     }
 
-    pub fn get_parsed_url(&self) -> Option<String> {
-        self.get_preprocessed_url()
+    pub fn get_parsed_url(&self) -> Zval {
+        let Some(candidate) = self.current.as_ref() else {
+            return url_zval_bool(false);
+        };
+
+        let Ok(callable) =
+            ZendCallable::try_from_name("WordPress\\DataLiberation\\URL\\WPURL::parse")
+        else {
+            return url_zval_bool(false);
+        };
+
+        let result = match self.base_url.as_ref() {
+            Some(base_url) => callable.try_call(vec![&candidate.preprocessed_url, base_url]),
+            None => callable.try_call(vec![&candidate.preprocessed_url]),
+        };
+
+        match result {
+            Ok(value) if !value.is_false() && !value.is_null() => value,
+            _ => url_zval_bool(false),
+        }
     }
 
     pub fn get_url_starts_at(&self) -> Option<i64> {
@@ -322,6 +346,13 @@ fn validate_url_text_candidate(
 
     candidate.preprocessed_url = preprocessed_url;
     true
+}
+
+#[cfg(feature = "php-extension")]
+fn url_zval_bool(value: bool) -> Zval {
+    let mut zval = Zval::new();
+    zval.set_bool(value);
+    zval
 }
 
 fn parse_url_scheme(url: &str) -> Option<String> {

--- a/extensions/native-apis/src/url_text.rs
+++ b/extensions/native-apis/src/url_text.rs
@@ -6,9 +6,11 @@ use ext_php_rs::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UrlTextCandidate {
     pub raw_url: String,
+    pub preprocessed_url: String,
     pub starts_at: usize,
     pub length: usize,
     pub had_protocol: bool,
+    pub did_prepend_protocol: bool,
 }
 
 #[cfg(feature = "php-extension")]
@@ -19,6 +21,8 @@ pub struct NativeUrlInTextProcessor {
     bytes_already_parsed: usize,
     current: Option<UrlTextCandidate>,
     replacements: Vec<UrlTextReplacement>,
+    validate_urls: bool,
+    base_protocol: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -32,32 +36,67 @@ struct UrlTextReplacement {
 #[php_impl]
 #[php(change_method_case = "snake_case")]
 impl NativeUrlInTextProcessor {
-    pub fn __construct(text: String) -> Self {
+    #[php(optional = base_url)]
+    pub fn __construct(text: String, base_url: Option<String>) -> Self {
+        let base_protocol = base_url.as_deref().and_then(parse_url_scheme);
+
         Self {
             text,
             bytes_already_parsed: 0,
             current: None,
             replacements: Vec::new(),
+            validate_urls: true,
+            base_protocol,
         }
+    }
+
+    pub fn supports_public_api() -> bool {
+        true
+    }
+
+    pub fn use_url_validation(&mut self) {
+        self.validate_urls = true;
+    }
+
+    pub fn set_base_url(&mut self, base_url: String) {
+        self.base_protocol = parse_url_scheme(&base_url);
     }
 
     pub fn next_url(&mut self) -> bool {
         self.current = None;
 
-        let Some(candidate) = find_next_url_text_candidate(&self.text, self.bytes_already_parsed)
-        else {
-            return false;
-        };
+        while let Some(mut candidate) =
+            find_next_url_text_candidate(&self.text, self.bytes_already_parsed)
+        {
+            self.bytes_already_parsed = candidate.starts_at + candidate.length;
 
-        self.bytes_already_parsed = candidate.starts_at + candidate.length;
-        self.current = Some(candidate);
-        true
+            if self.validate_urls
+                && !validate_url_text_candidate(&mut candidate, self.base_protocol.as_deref())
+            {
+                continue;
+            }
+
+            self.current = Some(candidate);
+            return true;
+        }
+
+        false
     }
 
     pub fn get_raw_url(&self) -> Option<String> {
         self.current
             .as_ref()
             .map(|candidate| candidate.raw_url.clone())
+    }
+
+    pub fn get_preprocessed_url(&self) -> Option<String> {
+        self.current
+            .as_ref()
+            .map(|candidate| candidate.preprocessed_url.clone())
+    }
+
+    pub fn get_parsed_url(&self) -> Option<String> {
+        self.get_preprocessed_url()
     }
 
     pub fn get_url_starts_at(&self) -> Option<i64> {
@@ -78,16 +117,31 @@ impl NativeUrlInTextProcessor {
             .map(|candidate| candidate.had_protocol)
     }
 
+    pub fn did_prepend_protocol(&self) -> Option<bool> {
+        self.current
+            .as_ref()
+            .map(|candidate| candidate.did_prepend_protocol)
+    }
+
     pub fn set_raw_url(&mut self, new_url: String) -> bool {
         let Some(candidate) = self.current.as_mut() else {
             return false;
         };
 
-        self.replacements.push(UrlTextReplacement {
-            start: candidate.starts_at,
-            length: candidate.length,
-            text: new_url.clone(),
-        });
+        if let Some(replacement) = self
+            .replacements
+            .iter_mut()
+            .find(|replacement| replacement.start == candidate.starts_at)
+        {
+            replacement.length = candidate.length;
+            replacement.text = new_url.clone();
+        } else {
+            self.replacements.push(UrlTextReplacement {
+                start: candidate.starts_at,
+                length: candidate.length,
+                text: new_url.clone(),
+            });
+        }
         candidate.raw_url = new_url;
         true
     }
@@ -208,10 +262,165 @@ fn parse_url_text_candidate_at(text: &str, start: usize) -> Option<UrlTextCandid
 
     Some(UrlTextCandidate {
         raw_url: text[start..display_end].to_string(),
+        preprocessed_url: text[start..display_end].to_string(),
         starts_at: start,
         length: display_end - start,
         had_protocol: had_protocol || start + 2 <= bytes.len() && &bytes[start..start + 2] == b"//",
+        did_prepend_protocol: false,
     })
+}
+
+fn validate_url_text_candidate(
+    candidate: &mut UrlTextCandidate,
+    base_protocol: Option<&str>,
+) -> bool {
+    let mut preprocessed_url = candidate.raw_url.clone();
+    if !candidate.had_protocol {
+        let Some(protocol) = base_protocol else {
+            return false;
+        };
+
+        if !is_http_or_https_scheme(protocol) {
+            return false;
+        }
+
+        preprocessed_url = format!("{protocol}://{}", candidate.raw_url);
+        candidate.did_prepend_protocol = true;
+    } else if preprocessed_url.starts_with("//") {
+        let Some(protocol) = base_protocol else {
+            return false;
+        };
+
+        if !is_http_or_https_scheme(protocol) {
+            return false;
+        }
+    } else if !starts_with_http_or_https_scheme(&preprocessed_url) {
+        return false;
+    }
+
+    if has_authority_auth_details(&preprocessed_url) {
+        return false;
+    }
+
+    if has_invalid_authority_port(&preprocessed_url) {
+        return false;
+    }
+
+    if !candidate.had_protocol {
+        let Some(hostname) = candidate_hostname(&candidate.raw_url) else {
+            return false;
+        };
+
+        let Some(last_dot) = hostname.rfind('.') else {
+            return false;
+        };
+
+        if !is_known_public_domain(&hostname[last_dot + 1..]) {
+            return false;
+        }
+    }
+
+    candidate.preprocessed_url = preprocessed_url;
+    true
+}
+
+fn parse_url_scheme(url: &str) -> Option<String> {
+    let colon = url.find(':')?;
+    let first_delimiter = url
+        .find(|character| matches!(character, '/' | '?' | '#'))
+        .unwrap_or(url.len());
+    if colon > first_delimiter {
+        return None;
+    }
+
+    Some(url[..colon].to_ascii_lowercase())
+}
+
+fn is_http_or_https_scheme(scheme: &str) -> bool {
+    scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https")
+}
+
+fn starts_with_http_or_https_scheme(url: &str) -> bool {
+    ascii_starts_with(url.as_bytes(), 0, b"http:")
+        || ascii_starts_with(url.as_bytes(), 0, b"https:")
+}
+
+fn authority_range(url: &str) -> Option<(usize, usize)> {
+    let bytes = url.as_bytes();
+    let authority_start = if bytes.starts_with(b"//") {
+        2
+    } else if ascii_starts_with(bytes, 0, b"http://") {
+        7
+    } else if ascii_starts_with(bytes, 0, b"https://") {
+        8
+    } else {
+        return None;
+    };
+
+    let authority_end = bytes[authority_start..]
+        .iter()
+        .position(|byte| matches!(*byte, b'/' | b'?' | b'#'))
+        .map(|offset| authority_start + offset)
+        .unwrap_or(bytes.len());
+
+    Some((authority_start, authority_end))
+}
+
+fn has_authority_auth_details(url: &str) -> bool {
+    let Some((start, end)) = authority_range(url) else {
+        return false;
+    };
+
+    url.as_bytes()[start..end].contains(&b'@')
+}
+
+fn has_invalid_authority_port(url: &str) -> bool {
+    let Some((start, end)) = authority_range(url) else {
+        return false;
+    };
+
+    let authority = &url[start..end];
+    if authority.starts_with('[') {
+        return authority.find(']').is_none();
+    }
+
+    let Some(colon) = authority.rfind(':') else {
+        return false;
+    };
+
+    let port = &authority[colon + 1..];
+    !port.is_empty()
+        && port.bytes().all(|byte| byte.is_ascii_digit())
+        && port.parse::<u16>().is_err()
+}
+
+fn candidate_hostname(raw_url: &str) -> Option<&str> {
+    let bytes = raw_url.as_bytes();
+    let mut start = 0;
+    if bytes.starts_with(b"//") {
+        start = 2;
+    } else if ascii_starts_with(bytes, 0, b"http:") {
+        start = 5;
+        while start < bytes.len() && bytes[start] == b'/' {
+            start += 1;
+        }
+    } else if ascii_starts_with(bytes, 0, b"https:") {
+        start = 6;
+        while start < bytes.len() && bytes[start] == b'/' {
+            start += 1;
+        }
+    }
+
+    let end = bytes[start..]
+        .iter()
+        .position(|byte| !is_hostish_byte(*byte))
+        .map(|offset| start + offset)
+        .unwrap_or(bytes.len());
+    if end <= start {
+        return None;
+    }
+
+    Some(&raw_url[start..end])
 }
 
 fn find_candidate_end(bytes: &[u8], mut cursor: usize) -> usize {
@@ -288,8 +497,27 @@ fn candidate_host_has_url_shape(host: &str) -> bool {
     let tld = &host[last_dot + 1..];
     tld.len() >= 2
         && tld.len() <= 63
-        && tld.bytes().all(|byte| byte.is_ascii_alphanumeric())
+        && tld
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
         && host.split('.').all(is_valid_hostname_label)
+}
+
+fn is_known_public_domain(tld: &str) -> bool {
+    if tld.eq_ignore_ascii_case("internal") {
+        return true;
+    }
+
+    if tld.is_empty()
+        || !tld
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return false;
+    }
+
+    let needle = format!("'{}'", tld.to_ascii_lowercase());
+    include_str!("../../../components/DataLiberation/URL/public-suffix-list.php").contains(&needle)
 }
 
 fn is_valid_hostname_label(label: &str) -> bool {
@@ -319,7 +547,7 @@ fn ascii_starts_with(bytes: &[u8], offset: usize, needle: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::find_next_url_text_candidate;
+    use super::{find_next_url_text_candidate, validate_url_text_candidate, UrlTextCandidate};
 
     #[test]
     fn finds_http_https_and_bare_domain_candidates() {
@@ -351,5 +579,45 @@ mod tests {
     #[test]
     fn ignores_embedded_protocol_fragments() {
         assert!(find_next_url_text_candidate("ahttp://example.com", 0).is_none());
+    }
+
+    #[test]
+    fn accepts_punycode_tlds() {
+        let text = "Visit http://xn--fsqu00a.xn--0zwm56d";
+        let candidate = find_next_url_text_candidate(text, 0).expect("URL");
+        assert_eq!("http://xn--fsqu00a.xn--0zwm56d", candidate.raw_url);
+    }
+
+    #[test]
+    fn validates_public_url_candidates_with_base_protocol() {
+        let mut candidate = find_next_url_text_candidate("Visit example.com/docs", 0).expect("URL");
+        assert!(validate_url_text_candidate(&mut candidate, Some("https")));
+        assert_eq!("https://example.com/docs", candidate.preprocessed_url);
+        assert!(candidate.did_prepend_protocol);
+    }
+
+    #[test]
+    fn rejects_filename_like_bare_domains_with_unknown_tlds() {
+        let mut candidate = find_next_url_text_candidate("Edit plugins.php", 0).expect("candidate");
+        assert!(!validate_url_text_candidate(&mut candidate, Some("https")));
+    }
+
+    #[test]
+    fn rejects_authority_credentials() {
+        let mut candidate = UrlTextCandidate {
+            raw_url: "https://user@example.com/path".to_string(),
+            preprocessed_url: "https://user@example.com/path".to_string(),
+            starts_at: 6,
+            length: 29,
+            had_protocol: true,
+            did_prepend_protocol: false,
+        };
+        assert!(!validate_url_text_candidate(&mut candidate, Some("https")));
+    }
+
+    #[test]
+    fn rejects_bare_domains_without_base_protocol() {
+        let mut candidate = find_next_url_text_candidate("Visit example.com", 0).expect("URL");
+        assert!(!validate_url_text_candidate(&mut candidate, None));
     }
 }

--- a/extensions/native-apis/src/xml.rs
+++ b/extensions/native-apis/src/xml.rs
@@ -289,7 +289,7 @@ pub struct NativeXmlProcessor {
 #[php_impl]
 #[php(change_method_case = "snake_case")]
 impl NativeXmlProcessor {
-    pub fn create_from_string(xml: String) -> Self {
+    fn new_from_string(xml: String) -> Self {
         Self {
             source: xml,
             document: None,
@@ -305,6 +305,27 @@ impl NativeXmlProcessor {
             pending_stream_error: None,
             bookmarks: HashMap::new(),
         }
+    }
+
+    pub fn supports_public_api() -> bool {
+        true
+    }
+
+    #[php(optional = cursor)]
+    pub fn create_from_string(
+        xml: String,
+        cursor: Option<String>,
+        known_definite_encoding: Option<String>,
+        document_namespaces: Option<&Zval>,
+    ) -> Option<Self> {
+        if cursor.is_some()
+            || known_definite_encoding.as_deref().unwrap_or("UTF-8") != "UTF-8"
+            || document_namespaces.is_some()
+        {
+            return None;
+        }
+
+        Some(Self::new_from_string(xml))
     }
 
     pub fn create_for_streaming(
@@ -329,7 +350,7 @@ impl NativeXmlProcessor {
             None
         };
 
-        let mut processor = Self::create_from_string(xml);
+        let mut processor = Self::new_from_string(xml);
         processor.stream_reentrancy_base_state =
             Some(stream.clone().unwrap_or_else(XmlStreamState::new));
         processor.stream = stream;

--- a/extensions/native-apis/src/xml.rs
+++ b/extensions/native-apis/src/xml.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 #[cfg(feature = "php-extension")]
 use ext_php_rs::prelude::*;
 #[cfg(feature = "php-extension")]
-use ext_php_rs::types::Zval;
+use ext_php_rs::types::{ZendHashTable, Zval};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct XmlToken {
@@ -79,6 +79,12 @@ struct XmlBookmark {
     paused_at_incomplete_input: bool,
     last_error: Option<String>,
     pending_stream_error: Option<String>,
+}
+
+#[derive(Default)]
+struct XmlNextTagQuery {
+    breadcrumbs: Option<Vec<(String, String)>>,
+    match_offset: i64,
 }
 
 #[cfg(feature = "php-extension")]
@@ -1494,9 +1500,35 @@ impl NativeXmlProcessor {
         xml_token_stream_summary(&summary)
     }
 
-    pub fn next_tag(&mut self) -> bool {
+    #[php(optional = query_or_ns)]
+    pub fn next_tag(
+        &mut self,
+        query_or_ns: Option<&Zval>,
+        null_or_local_name: Option<String>,
+    ) -> bool {
+        let Some(query) = xml_parse_next_tag_query(query_or_ns, null_or_local_name) else {
+            return false;
+        };
+
+        let mut match_offset = query.match_offset.max(1);
+
         while self.next_token() {
-            if self.get_token_type().as_deref() == Some("#tag") && !self.is_tag_closer() {
+            if self.get_token_type().as_deref() != Some("#tag") || self.is_tag_closer() {
+                continue;
+            }
+
+            if let Some(breadcrumbs) = query.breadcrumbs.as_ref() {
+                let Some(current_breadcrumbs) = self.current_token_breadcrumbs() else {
+                    continue;
+                };
+
+                if !xml_namespaced_breadcrumbs_match(&current_breadcrumbs, breadcrumbs) {
+                    continue;
+                }
+            }
+
+            match_offset -= 1;
+            if match_offset == 0 {
                 return true;
             }
         }
@@ -3352,6 +3384,114 @@ impl NativeXmlProcessor {
 
         Some((*extend_xml_namespaces(&current_namespaces, namespace_declarations)).clone())
     }
+}
+
+#[cfg(feature = "php-extension")]
+fn xml_parse_next_tag_query(
+    query_or_ns: Option<&Zval>,
+    null_or_local_name: Option<String>,
+) -> Option<XmlNextTagQuery> {
+    let mut parsed = XmlNextTagQuery {
+        match_offset: 1,
+        ..Default::default()
+    };
+
+    let Some(query_or_ns) = query_or_ns else {
+        return Some(parsed);
+    };
+
+    if let Some(namespace_or_local_name) = query_or_ns.str() {
+        parsed.breadcrumbs = Some(vec![match null_or_local_name {
+            Some(local_name) => (namespace_or_local_name.to_string(), local_name),
+            None => ("".to_string(), namespace_or_local_name.to_string()),
+        }]);
+        return Some(parsed);
+    }
+
+    let query = query_or_ns.array()?;
+
+    if query.get_index(0).and_then(|value| value.str()).is_some()
+        && query.get_index(1).and_then(|value| value.str()).is_some()
+    {
+        parsed.breadcrumbs = Some(vec![(
+            query.get_index(0)?.str()?.to_string(),
+            query.get_index(1)?.str()?.to_string(),
+        )]);
+        return Some(parsed);
+    }
+
+    if let Some(match_offset) = xml_array_positive_i64(query, "match_offset") {
+        parsed.match_offset = match_offset;
+    }
+
+    parsed.breadcrumbs = xml_array_namespaced_breadcrumbs(query, "breadcrumbs");
+
+    Some(parsed)
+}
+
+#[cfg(feature = "php-extension")]
+fn xml_array_positive_i64(query: &ZendHashTable, key: &str) -> Option<i64> {
+    query
+        .get(key)
+        .and_then(|value| value.long())
+        .filter(|value| *value > 0)
+        .map(|value| value as i64)
+}
+
+#[cfg(feature = "php-extension")]
+fn xml_array_namespaced_breadcrumbs(
+    query: &ZendHashTable,
+    key: &str,
+) -> Option<Vec<(String, String)>> {
+    let breadcrumbs = query.get(key)?.array()?;
+    let mut parsed = Vec::with_capacity(breadcrumbs.len());
+
+    for value in breadcrumbs.iter().map(|(_, value)| value) {
+        if let Some(local_name) = value.str() {
+            if local_name == "*" {
+                parsed.push(("*".to_string(), "*".to_string()));
+            } else {
+                parsed.push(("*".to_string(), local_name.to_string()));
+            }
+            continue;
+        }
+
+        let pair = value.array()?;
+        parsed.push((
+            pair.get_index(0)?.str()?.to_string(),
+            pair.get_index(1)?.str()?.to_string(),
+        ));
+    }
+
+    Some(parsed)
+}
+
+fn xml_namespaced_breadcrumbs_match(
+    current: &[(String, String)],
+    breadcrumbs: &[(String, String)],
+) -> bool {
+    if breadcrumbs.is_empty() {
+        return true;
+    }
+
+    if breadcrumbs.len() > current.len() {
+        return false;
+    }
+
+    let offset = current.len() - breadcrumbs.len();
+    for (index, (namespace, local_name)) in breadcrumbs.iter().enumerate() {
+        let (current_namespace, current_local_name) = &current[offset + index];
+
+        if local_name != "*" && local_name != current_local_name {
+            return false;
+        }
+
+        if namespace != "*" && namespace != current_namespace {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[cfg(feature = "php-extension")]

--- a/extensions/native-apis/tests/verify-native-apis.php
+++ b/extensions/native-apis/tests/verify-native-apis.php
@@ -60,6 +60,12 @@ assert_same( "A\u{00a0}B\u{00a9}\u{00ae}\u{2026}\u{2014}\u{2209}", $tag_processo
 assert_same( false, $tag_processor->next_tag(), 'Expected HTML next_tag() to skip closing tags.' );
 assert_false( $tag_processor->paused_at_incomplete_token(), 'Expected native HTML tag processor not to pause at an incomplete token after complete input.' );
 
+$tag_query_processor = new WP_HTML_Native_Tag_Processor( '<main><p class="intro"></p><p class="target"></p></main>' );
+assert_true( $tag_query_processor->next_tag( array( 'tag_name' => 'p', 'class_name' => 'target' ) ), 'Expected native HTML tag processor to honor tag and class next_tag() queries.' );
+assert_same( 'P', $tag_query_processor->get_tag(), 'Expected native HTML tag query to stop on the matching paragraph.' );
+assert_true( $tag_query_processor->next_tag( array( 'tag_name' => 'p', 'tag_closers' => 'visit' ) ), 'Expected native HTML tag processor to honor tag_closers query mode.' );
+assert_true( $tag_query_processor->is_tag_closer(), 'Expected native HTML tag processor query to visit matching closers.' );
+
 $comment_qualified_name_processor = new WP_HTML_Native_Tag_Processor( '<!--note-->' );
 assert_true( $comment_qualified_name_processor->next_token(), 'Expected comment token before qualified name checks.' );
 assert_same( null, $comment_qualified_name_processor->get_qualified_tag_name(), 'Expected native HTML qualified tag name to return null on comments.' );
@@ -452,6 +458,10 @@ assert_true( $html_full_parser instanceof WP_HTML_Native_Processor, 'Expected na
 assert_true( $html_full_parser->next_tag(), 'Expected native HTML full parser to scan tags.' );
 assert_same( 'HTML', $html_full_parser->get_tag(), 'Expected native HTML full parser to start at the document HTML tag.' );
 assert_same( null, WP_HTML_Native_Processor::create_full_parser( '<html></html>', 'ISO-8859-1' ), 'Expected native HTML full parser factory to reject unsupported encodings.' );
+
+$html_processor_query = WP_HTML_Native_Processor::create_fragment( '<section><article><img class="hero"></article></section>' );
+assert_true( $html_processor_query->next_tag( array( 'breadcrumbs' => array( 'ARTICLE', 'IMG' ), 'class_name' => 'hero' ) ), 'Expected native HTML processor to honor breadcrumb and class next_tag() queries.' );
+assert_same( 'IMG', $html_processor_query->get_tag(), 'Expected native HTML processor query to stop on the matching image.' );
 
 $html_step_processor = WP_HTML_Native_Processor::create_fragment( '<section><p>Text</p></section>' );
 assert_true( $html_step_processor->step(), 'Expected native HTML processor step() to advance by default.' );
@@ -1120,6 +1130,12 @@ assert_same( $xml_class, get_class( $xml_streaming ), 'Expected native XML strea
 assert_true( $xml_streaming->next_tag(), 'Expected native XML streaming factory processor to expose the root tag.' );
 assert_same( 'root', $xml_streaming->get_token_name(), 'Expected native XML streaming factory root tag name.' );
 assert_same( null, $xml_class::create_for_streaming( '<root />', null, 'ISO-8859-1', array() ), 'Expected native XML streaming factory to reject unsupported encodings.' );
+
+$xml_query = $xml_class::create_from_string( '<root xmlns:wp="https://wordpress.org"><wp:item /><item /></root>' );
+assert_true( $xml_query->next_tag( array( 'breadcrumbs' => array( array( 'https://wordpress.org', 'item' ) ) ) ), 'Expected native XML processor to honor namespaced breadcrumb next_tag() queries.' );
+assert_same( 'https://wordpress.org', $xml_query->get_tag_namespace(), 'Expected native XML namespaced query to stop on the namespaced item.' );
+assert_true( $xml_query->next_tag( 'item' ), 'Expected native XML processor to honor local-name next_tag() queries.' );
+assert_same( '', $xml_query->get_tag_namespace(), 'Expected native XML local-name query to stop on the unnamespaced item.' );
 
 $xml_streaming_incomplete = $xml_class::create_for_streaming( '<root', null, 'UTF-8', array() );
 assert_false( $xml_streaming_incomplete->next_token(), 'Expected incomplete native XML streaming input to pause token scanning.' );
@@ -1872,11 +1888,15 @@ while ( $xml_processing_instruction->next_token() ) {
 assert_true( null !== $xml_processing_instruction->get_last_error(), 'Expected XML processing instruction parse error.' );
 
 $url_text_class     = 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor';
-$url_text_processor = new $url_text_class( 'Visit https://WordPress.org/plugins, then example.com/docs.' );
+$url_text_processor = new $url_text_class( 'Visit https://WordPress.org/plugins, then example.com/docs.', 'https://wordpress.org' );
 assert_true( $url_text_processor->next_url(), 'Expected native URL-in-text processor to find the first URL.' );
 assert_same( 'https://WordPress.org/plugins', $url_text_processor->get_raw_url(), 'Expected native URL-in-text processor to trim trailing punctuation.' );
 assert_same( 6, $url_text_processor->get_url_starts_at(), 'Expected native URL-in-text processor to expose byte offset.' );
 assert_true( $url_text_processor->had_protocol(), 'Expected native URL-in-text processor to mark explicit protocols.' );
+$url_text_parsed = $url_text_processor->get_parsed_url();
+assert_true( is_object( $url_text_parsed ), 'Expected native URL-in-text get_parsed_url() to expose the parsed URL object.' );
+assert_same( 'https:', $url_text_parsed->protocol, 'Expected native URL-in-text parsed URL protocol.' );
+assert_same( 'wordpress.org', $url_text_parsed->hostname, 'Expected native URL-in-text parsed URL hostname.' );
 assert_true( $url_text_processor->next_url(), 'Expected native URL-in-text processor to find the second URL.' );
 assert_same( 'example.com/docs', $url_text_processor->get_raw_url(), 'Expected native URL-in-text processor to find bare-domain URLs.' );
 assert_false( $url_text_processor->had_protocol(), 'Expected native URL-in-text processor to mark bare domains.' );


### PR DESCRIPTION
## What it does

Adds the native extension class layer that the PHP integration PR can bind to directly.

This PR now implements the public entry points in Rust instead of leaving PHP wrappers to fill behavior back in:

- `WP_HTML_Native_Tag_Processor::next_tag()` accepts the public `string|array|null` query shape, including `tag_name`, `class_name`, `match_offset`, and `tag_closers`.
- `WP_HTML_Native_Processor::next_tag()` accepts public tag, class, match-offset, and breadcrumb queries.
- `WP_HTML_Native_Processor::normalize()` and `serialize()` run through native serialization instead of calling back into the public PHP class, avoiding recursion once the public PHP class resolves to the native implementation.
- `WordPress\XML\NativeXMLProcessor::next_tag()` accepts the public local-name, namespace/local-name, match-offset, and namespaced breadcrumb query shapes.
- `WordPress\DataLiberation\URL\NativeURLInTextProcessor::get_parsed_url()` delegates to `WPURL::parse()` so callers receive the component URL object surface instead of a placeholder string.
- URL-in-text filtering runs in Rust: base-protocol handling, HTTP(S) filtering, credential rejection, public-suffix checks for bare domains, invalid-port rejection, and replacement conflict handling.
- Adds a `Native APIs` GitHub Actions workflow that builds the PHP extension, loads it, and runs `extensions/native-apis/tests/verify-native-apis.php`.

## Rationale

The stacked PHP PR should only decide whether to expose native or PHP implementations. If public behavior lives in PHP wrapper classes, reviewers have to audit two implementations and the wrappers grow into a second parser layer.

This PR moves the public API burden into the extension so the next PR can use empty native subclasses plus fallback loaders.

## Implementation

The native classes expose a `supports_public_api()` marker. PHP loaders in the next PR use that marker to avoid stale extension builds that do not support this public surface.

The verifier now covers representative public calls:

```php
$processor->next_tag( array( 'tag_name' => 'p', 'class_name' => 'target' ) );
$html->next_tag( array( 'breadcrumbs' => array( 'ARTICLE', 'IMG' ) ) );
$xml->next_tag( array( 'breadcrumbs' => array( array( 'https://wordpress.org', 'item' ) ) ) );
$url->get_parsed_url()->hostname;
```

Native HTML serialization normalizes opening-tag attributes from the original source bytes, preserving first-duplicate-wins behavior while quoting unquoted values and retaining boolean attributes.

Unsupported factory options still return `null` for now, keeping native opt-in conservative while the public surface is filled in.

## Testing instructions

Local checks run:

```bash
cd extensions/native-apis
cargo fmt && cargo test
php -l extensions/native-apis/tests/verify-native-apis.php
bash -n extensions/native-apis/build-extension.sh
/home/claude/php-toolkit/vendor/bin/phpcs -d memory_limit=1G /tmp/php-toolkit-public-api/extensions/native-apis/tests/verify-native-apis.php
git diff --check
```

Local limitation: this machine does not have `php-config`, so `cargo check --features php-extension` cannot run locally. The new `Native APIs / Build and verify PHP extension` workflow is the required extension build/load check for this PR.