### PR TITLE
Speed up native URL rewriting

### DIFF
--- a/components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php
+++ b/components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php
@@ -5,6 +5,8 @@ namespace WordPress\DataLiberation\URL;
 
 use WP_HTML_Text_Replacement;
 
+require_once __DIR__ . '/class-urlrewritecache.php';
+
 /**
  * Public URLInTextProcessor adapter backed by the native candidate scanner.
  *
@@ -39,9 +41,7 @@ class NativeURLInTextProcessorWrapper {
 	private $fallback_processor;
 	private $lexical_updates = array();
 
-	private static $candidate_cache      = array();
-	private static $candidate_cache_ring = array();
-	private static $candidate_cache_next = 0;
+	private static $candidate_cache;
 
 	public function __construct( $text, $base_url = null ) {
 		$this->text          = $text;
@@ -86,7 +86,7 @@ class NativeURLInTextProcessorWrapper {
 				: WPURL::has_http_https_protocol( $this->matched_url );
 
 			$cache_key = $this->base_url . "\0" . ( $had_protocol ? '1' : '0' ) . "\0" . $this->matched_url;
-			$cached    = self::candidate_cache_get( $cache_key );
+			$cached    = self::candidate_cache()->get( $cache_key );
 			if ( null !== $cached ) {
 				if ( false === $cached ) {
 					continue;
@@ -99,11 +99,11 @@ class NativeURLInTextProcessorWrapper {
 
 			$parsed_url = $this->parse_and_validate_candidate( $had_protocol );
 			if ( false === $parsed_url ) {
-				self::candidate_cache_set( $cache_key, false );
+				self::candidate_cache()->set( $cache_key, false );
 				continue;
 			}
 
-			self::candidate_cache_set(
+			self::candidate_cache()->set(
 				$cache_key,
 				array(
 					'parsed_url'           => $parsed_url,
@@ -231,25 +231,11 @@ class NativeURLInTextProcessorWrapper {
 		$this->lexical_updates = array();
 	}
 
-	private static function candidate_cache_get( $key ) {
-		return array_key_exists( $key, self::$candidate_cache )
-			? self::$candidate_cache[ $key ]
-			: null;
-	}
-
-	private static function candidate_cache_set( $key, $value ) {
-		if ( ! array_key_exists( $key, self::$candidate_cache ) ) {
-			if ( count( self::$candidate_cache_ring ) < self::CANDIDATE_CACHE_MAX ) {
-				self::$candidate_cache_ring[] = $key;
-			} else {
-				$evicted_key = self::$candidate_cache_ring[ self::$candidate_cache_next ];
-				unset( self::$candidate_cache[ $evicted_key ] );
-				self::$candidate_cache_ring[ self::$candidate_cache_next ] = $key;
-			}
-
-			self::$candidate_cache_next = ( self::$candidate_cache_next + 1 ) % self::CANDIDATE_CACHE_MAX;
+	private static function candidate_cache() {
+		if ( null === self::$candidate_cache ) {
+			self::$candidate_cache = new URLRewriteCache( self::CANDIDATE_CACHE_MAX );
 		}
 
-		self::$candidate_cache[ $key ] = $value;
+		return self::$candidate_cache;
 	}
 }

--- a/components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php
+++ b/components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php
@@ -3,10 +3,243 @@
 
 namespace WordPress\DataLiberation\URL;
 
-if ( class_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', false ) ) {
-	class NativeURLInTextProcessorWrapper extends NativeURLInTextProcessor {}
-} else {
-	require_once __DIR__ . '/PHP/class-phpurlintextprocessor.php';
+use WP_HTML_Text_Replacement;
 
-	class NativeURLInTextProcessorWrapper extends PHPURLInTextProcessor {}
+/**
+ * Public URLInTextProcessor adapter backed by the native candidate scanner.
+ *
+ * The native extension intentionally exposes a narrow scanner surface. This
+ * wrapper keeps the public PHP API intact: native code finds candidate URL
+ * strings, then PHP performs the same WHATWG validation and text replacement
+ * bookkeeping as the fallback implementation.
+ */
+class NativeURLInTextProcessorWrapper {
+	private const CANDIDATE_CACHE_MAX = 4096;
+
+	private $text;
+	private $bytes_already_parsed = 0;
+	private $matched_url;
+	private $parsed_url;
+	private $url_starts_at;
+	private $url_length;
+	private $did_prepend_protocol;
+	private $base_url;
+	private $base_protocol;
+	private $native_processor;
+	private $fallback_processor;
+	private $lexical_updates = array();
+
+	private static $candidate_cache      = array();
+	private static $candidate_cache_ring = array();
+	private static $candidate_cache_next = 0;
+
+	public function __construct( $text, $base_url = null ) {
+		$this->text          = $text;
+		$this->base_url      = $base_url;
+		$this->base_protocol = $base_url ? parse_url( $base_url, PHP_URL_SCHEME ) : null;
+
+		if ( preg_match( '/[^\x00-\x7F]/', $text ) ) {
+			$this->fallback_processor = new PHPURLInTextProcessor( $text, $base_url );
+			return;
+		}
+
+		$native_class           = 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor';
+		$this->native_processor = new $native_class( $text, $base_url );
+	}
+
+	public function next_url() {
+		if ( null !== $this->fallback_processor ) {
+			return $this->fallback_processor->next_url();
+		}
+
+		while ( $this->native_processor->next_url() ) {
+			$this->matched_url          = $this->native_processor->get_raw_url();
+			$this->parsed_url           = null;
+			$this->url_starts_at        = null;
+			$this->url_length           = null;
+			$this->did_prepend_protocol = false;
+
+			if ( false === $this->matched_url || '' === $this->matched_url || '::' === $this->matched_url ) {
+				continue;
+			}
+
+			$url_starts_at = strpos( $this->text, $this->matched_url, $this->bytes_already_parsed );
+			if ( false === $url_starts_at ) {
+				continue;
+			}
+			$this->bytes_already_parsed = $url_starts_at + strlen( $this->matched_url );
+			$this->url_starts_at        = $url_starts_at;
+			$this->url_length           = strlen( $this->matched_url );
+
+			$had_protocol = method_exists( $this->native_processor, 'had_protocol' )
+				? $this->native_processor->had_protocol()
+				: WPURL::has_http_https_protocol( $this->matched_url );
+
+			$cache_key = $this->base_url . "\0" . ( $had_protocol ? '1' : '0' ) . "\0" . $this->matched_url;
+			$cached    = self::candidate_cache_get( $cache_key );
+			if ( null !== $cached ) {
+				if ( false === $cached ) {
+					continue;
+				}
+				$this->parsed_url           = $cached['parsed_url'];
+				$this->did_prepend_protocol = $cached['did_prepend_protocol'];
+
+				return true;
+			}
+
+			$parsed_url = $this->parse_and_validate_candidate( $had_protocol );
+			if ( false === $parsed_url ) {
+				self::candidate_cache_set( $cache_key, false );
+				continue;
+			}
+
+			self::candidate_cache_set(
+				$cache_key,
+				array(
+					'parsed_url'           => $parsed_url,
+					'did_prepend_protocol' => $this->did_prepend_protocol,
+				)
+			);
+
+			$this->parsed_url = $parsed_url;
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public function get_raw_url() {
+		if ( null !== $this->fallback_processor ) {
+			return $this->fallback_processor->get_raw_url();
+		}
+
+		return $this->matched_url ?? false;
+	}
+
+	public function get_parsed_url() {
+		if ( null !== $this->fallback_processor ) {
+			return $this->fallback_processor->get_parsed_url();
+		}
+
+		return $this->parsed_url ?? false;
+	}
+
+	public function set_raw_url( $new_url ) {
+		if ( null !== $this->fallback_processor ) {
+			return $this->fallback_processor->set_raw_url( $new_url );
+		}
+
+		if ( null === $this->matched_url ) {
+			return false;
+		}
+
+		if ( $this->did_prepend_protocol ) {
+			$new_url = substr( $new_url, strpos( $new_url, '://' ) + 3 );
+		}
+
+		$this->matched_url                             = $new_url;
+		$this->lexical_updates[ $this->url_starts_at ] = new WP_HTML_Text_Replacement(
+			$this->url_starts_at,
+			$this->url_length,
+			$new_url
+		);
+
+		return true;
+	}
+
+	public function get_updated_text() {
+		if ( null !== $this->fallback_processor ) {
+			return $this->fallback_processor->get_updated_text();
+		}
+
+		$this->apply_lexical_updates();
+
+		return $this->text;
+	}
+
+	private function parse_and_validate_candidate( $had_protocol ) {
+		$preprocessed_url = $this->matched_url;
+		if ( $this->base_url && $this->base_protocol && ! $had_protocol ) {
+			$preprocessed_url           = WPURL::ensure_protocol( $preprocessed_url, $this->base_protocol );
+			$this->did_prepend_protocol = true;
+		}
+
+		$parsed_url = WPURL::parse( $preprocessed_url, $this->base_url );
+		if ( false === $parsed_url ) {
+			return false;
+		}
+
+		if ( $parsed_url->protocol && ! in_array( $parsed_url->protocol, array( 'http:', 'https:' ), true ) ) {
+			return false;
+		}
+
+		if ( $parsed_url->username || $parsed_url->password ) {
+			return false;
+		}
+
+		if ( ! $had_protocol ) {
+			$last_dot_position = strrpos( $parsed_url->hostname, '.' );
+			if ( false === $last_dot_position ) {
+				return false;
+			}
+
+			$tld = substr( $parsed_url->hostname, $last_dot_position + 1 );
+			if ( ! WPURL::is_known_public_domain( $tld ) ) {
+				return false;
+			}
+		}
+
+		return $parsed_url;
+	}
+
+	private function apply_lexical_updates() {
+		if ( ! count( $this->lexical_updates ) ) {
+			return;
+		}
+
+		ksort( $this->lexical_updates );
+
+		$bytes_already_copied = 0;
+		$output_buffer        = '';
+		foreach ( $this->lexical_updates as $diff ) {
+			$shift = strlen( $diff->text ) - $diff->length;
+			if ( $diff->start < $this->bytes_already_parsed ) {
+				$this->bytes_already_parsed += $shift;
+			}
+
+			$output_buffer .= substr( $this->text, $bytes_already_copied, $diff->start - $bytes_already_copied );
+			if ( $diff->start === $this->url_starts_at ) {
+				$this->url_starts_at = strlen( $output_buffer );
+				$this->url_length    = strlen( $diff->text );
+			}
+			$output_buffer       .= $diff->text;
+			$bytes_already_copied = $diff->start + $diff->length;
+		}
+
+		$this->text            = $output_buffer . substr( $this->text, $bytes_already_copied );
+		$this->lexical_updates = array();
+	}
+
+	private static function candidate_cache_get( $key ) {
+		return array_key_exists( $key, self::$candidate_cache )
+			? self::$candidate_cache[ $key ]
+			: null;
+	}
+
+	private static function candidate_cache_set( $key, $value ) {
+		if ( ! array_key_exists( $key, self::$candidate_cache ) ) {
+			if ( count( self::$candidate_cache_ring ) < self::CANDIDATE_CACHE_MAX ) {
+				self::$candidate_cache_ring[] = $key;
+			} else {
+				$evicted_key = self::$candidate_cache_ring[ self::$candidate_cache_next ];
+				unset( self::$candidate_cache[ $evicted_key ] );
+				self::$candidate_cache_ring[ self::$candidate_cache_next ] = $key;
+			}
+
+			self::$candidate_cache_next = ( self::$candidate_cache_next + 1 ) % self::CANDIDATE_CACHE_MAX;
+		}
+
+		self::$candidate_cache[ $key ] = $value;
+	}
 }

--- a/components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php
+++ b/components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php
@@ -8,10 +8,20 @@ use WP_HTML_Text_Replacement;
 /**
  * Public URLInTextProcessor adapter backed by the native candidate scanner.
  *
- * The native extension intentionally exposes a narrow scanner surface. This
- * wrapper keeps the public PHP API intact: native code finds candidate URL
- * strings, then PHP performs the same WHATWG validation and text replacement
- * bookkeeping as the fallback implementation.
+ * Starting point: a reprint-shaped benchmark over 5,000 post_content values
+ * measured wp_rewrite_urls() at about 90s with the PHP URL-in-text processor.
+ * Using the native scanner plus bounded PHP caches reduced that benchmark to
+ * about 3.6s with identical output. That result suggests the repeated
+ * PHP-side URL parsing and rewrite decisions were the largest proven cost.
+ *
+ * This wrapper is therefore a conservative first step. The native extension
+ * finds ASCII URL candidates, while PHP still performs the public API's WHATWG
+ * validation, replacement bookkeeping, and non-ASCII fallback behavior. Moving
+ * more of this wrapper into Rust may reduce PHP/native crossings and could
+ * plausibly improve the optimized path further, but that conclusion is still a
+ * hypothesis until measured. Porting WPURL::parse(), is_child_url_of(), and
+ * WPURL::replace_base_url() semantics into native code may provide larger
+ * gains, but would require separate parity work before it is safe to rely on.
  */
 class NativeURLInTextProcessorWrapper {
 	private const CANDIDATE_CACHE_MAX = 4096;

--- a/components/DataLiberation/URL/class-urlintextprocessor.php
+++ b/components/DataLiberation/URL/class-urlintextprocessor.php
@@ -5,10 +5,12 @@ namespace WordPress\DataLiberation\URL;
 
 $wp_url_in_text_use_native =
 	class_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', false ) &&
-	method_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', 'supports_public_api' ) &&
+	method_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', 'next_url' ) &&
+	method_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', 'get_raw_url' ) &&
 	( ! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) || ! WP_NATIVE_APIS_DISABLE_DEFAULTS );
 
 if ( $wp_url_in_text_use_native ) {
+	require_once __DIR__ . '/PHP/class-phpurlintextprocessor.php';
 	require_once __DIR__ . '/class-nativeurlintextprocessorwrapper.php';
 
 	class URLInTextProcessor extends NativeURLInTextProcessorWrapper {}

--- a/components/DataLiberation/URL/class-urlintextprocessor.php
+++ b/components/DataLiberation/URL/class-urlintextprocessor.php
@@ -5,11 +5,18 @@ namespace WordPress\DataLiberation\URL;
 
 $wp_url_in_text_use_native =
 	class_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', false ) &&
+	method_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', 'supports_public_api' ) &&
+	( ! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) || ! WP_NATIVE_APIS_DISABLE_DEFAULTS );
+
+$wp_url_in_text_use_native_scanner =
+	class_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', false ) &&
 	method_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', 'next_url' ) &&
 	method_exists( 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor', 'get_raw_url' ) &&
 	( ! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) || ! WP_NATIVE_APIS_DISABLE_DEFAULTS );
 
 if ( $wp_url_in_text_use_native ) {
+	class URLInTextProcessor extends NativeURLInTextProcessor {}
+} elseif ( $wp_url_in_text_use_native_scanner ) {
 	require_once __DIR__ . '/PHP/class-phpurlintextprocessor.php';
 	require_once __DIR__ . '/class-nativeurlintextprocessorwrapper.php';
 
@@ -21,3 +28,4 @@ if ( $wp_url_in_text_use_native ) {
 }
 
 unset( $wp_url_in_text_use_native );
+unset( $wp_url_in_text_use_native_scanner );

--- a/components/DataLiberation/URL/class-urlrewritecache.php
+++ b/components/DataLiberation/URL/class-urlrewritecache.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace WordPress\DataLiberation\URL;
+
+/**
+ * Small bounded cache for URL rewrite hot paths.
+ *
+ * The cache intentionally uses fixed-size ring eviction instead of tracking
+ * frequency or recency. These rewrite paths mostly benefit from avoiding
+ * repeated work for the same few URLs inside a large import batch, and the
+ * constant-memory ring keeps that optimization predictable.
+ */
+class URLRewriteCache {
+	const DEFAULT_MAX_ENTRIES = 4096;
+
+	private $max_entries;
+	private $values = array();
+	private $ring   = array();
+	private $next   = 0;
+
+	public function __construct( $max_entries = self::DEFAULT_MAX_ENTRIES ) {
+		$this->max_entries = max( 1, (int) $max_entries );
+	}
+
+	public function get( $key ) {
+		return array_key_exists( $key, $this->values )
+			? $this->values[ $key ]
+			: null;
+	}
+
+	public function set( $key, $value ) {
+		if ( ! array_key_exists( $key, $this->values ) ) {
+			if ( count( $this->ring ) < $this->max_entries ) {
+				$this->ring[] = $key;
+			} else {
+				$evicted_key = $this->ring[ $this->next ];
+				unset( $this->values[ $evicted_key ] );
+				$this->ring[ $this->next ] = $key;
+			}
+
+			$this->next = ( $this->next + 1 ) % $this->max_entries;
+		}
+
+		$this->values[ $key ] = $value;
+	}
+}

--- a/components/DataLiberation/URL/functions.php
+++ b/components/DataLiberation/URL/functions.php
@@ -40,20 +40,6 @@ require_once __DIR__ . '/class-urlrewritecache.php';
 function wp_rewrite_urls( $options ) {
 	static $rewrite_cache = null;
 
-	/*
-	 * The native extension does not expose this full public wrapper today. If
-	 * it does in the future, prefer it over the PHP implementation below so
-	 * scanning, parsing, rewrite decisions, and any native-side caching can be
-	 * handled in one place.
-	 */
-	$native_rewrite_urls = __NAMESPACE__ . '\\native_wp_rewrite_urls';
-	if (
-		function_exists( $native_rewrite_urls ) &&
-		( ! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) || ! WP_NATIVE_APIS_DISABLE_DEFAULTS )
-	) {
-		return $native_rewrite_urls( $options );
-	}
-
 	if ( null === $rewrite_cache ) {
 		$rewrite_cache = new URLRewriteCache();
 	}

--- a/components/DataLiberation/URL/functions.php
+++ b/components/DataLiberation/URL/functions.php
@@ -5,6 +5,7 @@ namespace WordPress\DataLiberation\URL;
 use Rowbot\URL\URL;
 use WordPress\DataLiberation\BlockMarkup\BlockMarkupUrlProcessor;
 
+require_once __DIR__ . '/class-urlrewritecache.php';
 
 /**
  * Migrate URLs in post content. See WPRewriteUrlsTests for
@@ -37,11 +38,26 @@ use WordPress\DataLiberation\BlockMarkup\BlockMarkupUrlProcessor;
  * to how the tag processor avoids changing parts of the tag it doesn't need to change.
  */
 function wp_rewrite_urls( $options ) {
-	static $rewrite_cache      = array();
-	static $rewrite_cache_ring = array();
-	static $rewrite_cache_next = 0;
+	static $rewrite_cache = null;
 
-	$rewrite_cache_max = 4096;
+	/*
+	 * The native extension does not expose this full public wrapper today. If
+	 * it does in the future, prefer it over the PHP implementation below so
+	 * scanning, parsing, rewrite decisions, and any native-side caching can be
+	 * handled in one place.
+	 */
+	$native_rewrite_urls = __NAMESPACE__ . '\\native_wp_rewrite_urls';
+	if (
+		function_exists( $native_rewrite_urls ) &&
+		( ! defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) || ! WP_NATIVE_APIS_DISABLE_DEFAULTS )
+	) {
+		return $native_rewrite_urls( $options );
+	}
+
+	if ( null === $rewrite_cache ) {
+		$rewrite_cache = new URLRewriteCache();
+	}
+
 	if ( empty( $options['base_url'] ) ) {
 		// Use first from-url as base_url if not specified.
 		$from_urls           = array_keys( $options['url-mapping'] );
@@ -70,8 +86,8 @@ function wp_rewrite_urls( $options ) {
 		$raw_url    = $p->get_raw_url();
 		$cache_key  = $mapping_cache_key . "\0" . $token_type . "\0" . $raw_url;
 
-		if ( array_key_exists( $cache_key, $rewrite_cache ) ) {
-			$cached = $rewrite_cache[ $cache_key ];
+		$cached = $rewrite_cache->get( $cache_key );
+		if ( null !== $cached ) {
 			if ( false !== $cached ) {
 				$p->set_url( $cached['raw_url'], $cached['parsed_url'] );
 			}
@@ -107,18 +123,7 @@ function wp_rewrite_urls( $options ) {
 			$p->set_url( $cache_value['raw_url'], $cache_value['parsed_url'] );
 		}
 
-		if ( ! array_key_exists( $cache_key, $rewrite_cache ) ) {
-			if ( count( $rewrite_cache_ring ) < $rewrite_cache_max ) {
-				$rewrite_cache_ring[] = $cache_key;
-			} else {
-				$evicted_key = $rewrite_cache_ring[ $rewrite_cache_next ];
-				unset( $rewrite_cache[ $evicted_key ] );
-				$rewrite_cache_ring[ $rewrite_cache_next ] = $cache_key;
-			}
-
-			$rewrite_cache_next = ( $rewrite_cache_next + 1 ) % $rewrite_cache_max;
-		}
-		$rewrite_cache[ $cache_key ] = $cache_value;
+		$rewrite_cache->set( $cache_key, $cache_value );
 	}
 
 	return $p->get_updated_html();

--- a/components/DataLiberation/URL/functions.php
+++ b/components/DataLiberation/URL/functions.php
@@ -37,29 +37,88 @@ use WordPress\DataLiberation\BlockMarkup\BlockMarkupUrlProcessor;
  * to how the tag processor avoids changing parts of the tag it doesn't need to change.
  */
 function wp_rewrite_urls( $options ) {
+	static $rewrite_cache      = array();
+	static $rewrite_cache_ring = array();
+	static $rewrite_cache_next = 0;
+
+	$rewrite_cache_max = 4096;
 	if ( empty( $options['base_url'] ) ) {
 		// Use first from-url as base_url if not specified.
 		$from_urls           = array_keys( $options['url-mapping'] );
 		$options['base_url'] = $from_urls[0];
 	}
 
-	$url_mapping = array();
+	$base_url_object = WPURL::parse( $options['base_url'] );
+	if ( false === $base_url_object ) {
+		return $options['block_markup'];
+	}
+
+	$url_mapping       = array();
+	$mapping_key_parts = array( 'base=' . $options['base_url'] );
 	foreach ( $options['url-mapping'] as $from_url_string => $to_url_string ) {
-		$url_mapping[] = array(
+		$url_mapping[]       = array(
 			'from_url' => WPURL::parse( $from_url_string ),
 			'to_url'   => WPURL::parse( $to_url_string ),
 		);
+		$mapping_key_parts[] = $from_url_string . '=>' . $to_url_string;
 	}
+	$mapping_cache_key = sha1( implode( "\0", $mapping_key_parts ) );
 
 	$p = new BlockMarkupUrlProcessor( $options['block_markup'], $options['base_url'] );
 	while ( $p->next_url() ) {
+		$token_type = $p->get_token_type();
+		$raw_url    = $p->get_raw_url();
+		$cache_key  = $mapping_cache_key . "\0" . $token_type . "\0" . $raw_url;
+
+		if ( array_key_exists( $cache_key, $rewrite_cache ) ) {
+			$cached = $rewrite_cache[ $cache_key ];
+			if ( false !== $cached ) {
+				$p->set_url( $cached['raw_url'], $cached['parsed_url'] );
+			}
+			continue;
+		}
+
 		$parsed_url = $p->get_parsed_url();
+		$converted  = false;
 		foreach ( $url_mapping as $mapping ) {
 			if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-				$p->replace_base_url( $mapping['to_url'] );
+				$converted = WPURL::replace_base_url(
+					$parsed_url,
+					array(
+						'old_base_url' => $base_url_object,
+						'new_base_url' => $mapping['to_url'],
+						'raw_url'      => $raw_url,
+						'is_relative'  => (
+							'#text' !== $token_type &&
+							! WPURL::can_parse( $raw_url )
+						),
+					)
+				);
 				break;
 			}
 		}
+
+		$cache_value = false;
+		if ( false !== $converted ) {
+			$cache_value = array(
+				'raw_url'    => (string) $converted,
+				'parsed_url' => $converted->new_url,
+			);
+			$p->set_url( $cache_value['raw_url'], $cache_value['parsed_url'] );
+		}
+
+		if ( ! array_key_exists( $cache_key, $rewrite_cache ) ) {
+			if ( count( $rewrite_cache_ring ) < $rewrite_cache_max ) {
+				$rewrite_cache_ring[] = $cache_key;
+			} else {
+				$evicted_key = $rewrite_cache_ring[ $rewrite_cache_next ];
+				unset( $rewrite_cache[ $evicted_key ] );
+				$rewrite_cache_ring[ $rewrite_cache_next ] = $cache_key;
+			}
+
+			$rewrite_cache_next = ( $rewrite_cache_next + 1 ) % $rewrite_cache_max;
+		}
+		$rewrite_cache[ $cache_key ] = $cache_value;
 	}
 
 	return $p->get_updated_html();

--- a/extensions/native-apis/README.md
+++ b/extensions/native-apis/README.md
@@ -66,7 +66,8 @@ require __DIR__ . '/bootstrap.php';
 
 var_dump( is_subclass_of( 'WP_HTML_Tag_Processor', 'WP_HTML_Native_Tag_Processor' ) );
 var_dump( is_subclass_of( 'WordPress\\XML\\XMLProcessor', 'WordPress\\XML\\NativeXMLProcessor' ) );
-var_dump( is_subclass_of( 'WordPress\\DataLiberation\\URL\\URLInTextProcessor', 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor' ) );
+$p = new WordPress\DataLiberation\URL\URLInTextProcessor( 'Visit example.com/docs.', 'https://wordpress.org' );
+var_dump( get_parent_class( $p ) === 'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessorWrapper' );
 PHP
 ```
 


### PR DESCRIPTION
## What

- Route `URLInTextProcessor` through `NativeURLInTextProcessor` when the native extension is loaded, while preserving the public PHP API around parsing, validation, and replacement.
- Add a bounded ring cache for parsed native URL candidates.
- Add a bounded ring cache in `wp_rewrite_urls()` for final rewrite decisions keyed by mapping, token type, and raw URL.
- Update the native extension README to describe the wrapper-based URL native default.

## Why

Large imports can contain hundreds of thousands of repeated URL occurrences. The native scanner can find candidates quickly, but the old public path still paid repeated PHP WHATWG parsing and `replace_base_url()` costs for the same raw URLs.

The caches are capped at 4096 entries each to avoid unbounded memory growth.

## Benchmarks

Fixture: 5,000 sampled `post_content` values from a large Studio/reprint dump, 16.9 MB decoded content, 350,000 URL occurrences, 2 unique raw URLs. Runtime: PHP.wasm 8.4.21 with `wp_native_apis` loaded.

| Measure | Before | After | Delta |
|---|---:|---:|---:|
| `wp_rewrite_urls()` wall time | 90.18s | 3.57s | -86.60s (-96.0%) |
| Output hash | `44c9750c...` | `44c9750c...` | identical |
| Public URL processor parent | `PHPURLInTextProcessor` | `NativeURLInTextProcessorWrapper` | native scanner active |

## Validation

- `vendor/bin/phpcbf -d memory_limit=1G components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php components/DataLiberation/URL/class-urlintextprocessor.php components/DataLiberation/URL/functions.php`
- `vendor/bin/phpcs -d memory_limit=1G components/DataLiberation/URL/class-nativeurlintextprocessorwrapper.php components/DataLiberation/URL/class-urlintextprocessor.php components/DataLiberation/URL/functions.php`
- `vendor/bin/phpunit -c phpunit.xml components/DataLiberation/Tests/URLInTextProcessorTest.php components/DataLiberation/Tests/RewriteUrlsTest.php`
- `php extensions/native-apis/tests/verify-native-apis.php --allow-missing`
- native-wrapper smoke test with a fake native scanner
- WASM benchmark with `wp_native_apis` loaded

Full `composer test` currently has one unrelated failure in `WordPress\\Blueprints\\Tests\\Unit\\Steps\\DefineConstantsStepTest::testAddNewConstantsToInvalidWpConfig` on PHP 8.4.5: the expected Blueprint error text is absent from the subprocess exception output.