### PR TITLE
Use native batch URL rewrites for text nodes

### DIFF
--- a/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
@@ -111,6 +111,40 @@ class BlockMarkupUrlProcessor extends BlockMarkupProcessor {
 		}
 	}
 
+	/**
+	 * Rewrites all supported URLs in the current text node through the native
+	 * batch URL base rewriter.
+	 *
+	 * This only handles ASCII text nodes. Non-ASCII text still falls through to
+	 * the structured PHP path to preserve the broader URL parsing behavior.
+	 */
+	public function rewrite_current_text_node_url_bases( $compact_mapping ) {
+		if (
+			'#text' !== $this->get_token_type() ||
+			! function_exists( 'wp_native_apis_rewrite_text_url_bases' ) ||
+			( defined( 'WP_NATIVE_APIS_DISABLE_DEFAULTS' ) && WP_NATIVE_APIS_DISABLE_DEFAULTS )
+		) {
+			return false;
+		}
+
+		$text = $this->get_modifiable_text();
+		if ( preg_match( '/[^\x00-\x7F]/', $text ) ) {
+			return false;
+		}
+
+		$updated_text = wp_native_apis_rewrite_text_url_bases(
+			$text,
+			$this->base_url_string,
+			$compact_mapping
+		);
+
+		if ( $updated_text === $text ) {
+			return false;
+		}
+
+		return $this->set_modifiable_text( $updated_text );
+	}
+
 	private function next_url_in_text_node() {
 		if ( '#text' !== $this->get_token_type() ) {
 			return false;

--- a/components/DataLiberation/URL/functions.php
+++ b/components/DataLiberation/URL/functions.php
@@ -66,50 +66,61 @@ function wp_rewrite_urls( $options ) {
 	}
 	$mapping_cache_key = sha1( implode( "\0", $mapping_key_parts ) );
 
-	$p = new BlockMarkupUrlProcessor( $options['block_markup'], $options['base_url'] );
-	while ( $p->next_url() ) {
-		$token_type = $p->get_token_type();
-		$raw_url    = $p->get_raw_url();
-		$cache_key  = $mapping_cache_key . "\0" . $token_type . "\0" . $raw_url;
+	$compact_mapping = '';
+	foreach ( $options['url-mapping'] as $from_url_string => $to_url_string ) {
+		$compact_mapping .= $from_url_string . "\x1f" . $to_url_string . "\x1e";
+	}
 
-		$cached = $rewrite_cache->get( $cache_key );
-		if ( null !== $cached ) {
-			if ( false !== $cached ) {
-				$p->set_url( $cached['raw_url'], $cached['parsed_url'] );
-			}
+	$p = new BlockMarkupUrlProcessor( $options['block_markup'], $options['base_url'] );
+	while ( $p->next_token() ) {
+		if ( $p->rewrite_current_text_node_url_bases( $compact_mapping ) ) {
 			continue;
 		}
 
-		$parsed_url = $p->get_parsed_url();
-		$converted  = false;
-		foreach ( $url_mapping as $mapping ) {
-			if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-				$converted = WPURL::replace_base_url(
-					$parsed_url,
-					array(
-						'old_base_url' => $base_url_object,
-						'new_base_url' => $mapping['to_url'],
-						'raw_url'      => $raw_url,
-						'is_relative'  => (
-							'#text' !== $token_type &&
-							! WPURL::can_parse( $raw_url )
-						),
-					)
-				);
-				break;
+		while ( $p->next_url_in_current_token() ) {
+			$token_type = $p->get_token_type();
+			$raw_url    = $p->get_raw_url();
+			$cache_key  = $mapping_cache_key . "\0" . $token_type . "\0" . $raw_url;
+
+			$cached = $rewrite_cache->get( $cache_key );
+			if ( null !== $cached ) {
+				if ( false !== $cached ) {
+					$p->set_url( $cached['raw_url'], $cached['parsed_url'] );
+				}
+				continue;
 			}
-		}
 
-		$cache_value = false;
-		if ( false !== $converted ) {
-			$cache_value = array(
-				'raw_url'    => (string) $converted,
-				'parsed_url' => $converted->new_url,
-			);
-			$p->set_url( $cache_value['raw_url'], $cache_value['parsed_url'] );
-		}
+			$parsed_url = $p->get_parsed_url();
+			$converted  = false;
+			foreach ( $url_mapping as $mapping ) {
+				if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
+					$converted = WPURL::replace_base_url(
+						$parsed_url,
+						array(
+							'old_base_url' => $base_url_object,
+							'new_base_url' => $mapping['to_url'],
+							'raw_url'      => $raw_url,
+							'is_relative'  => (
+								'#text' !== $token_type &&
+								! WPURL::can_parse( $raw_url )
+							),
+						)
+					);
+					break;
+				}
+			}
 
-		$rewrite_cache->set( $cache_key, $cache_value );
+			$cache_value = false;
+			if ( false !== $converted ) {
+				$cache_value = array(
+					'raw_url'    => (string) $converted,
+					'parsed_url' => $converted->new_url,
+				);
+				$p->set_url( $cache_value['raw_url'], $cache_value['parsed_url'] );
+			}
+
+			$rewrite_cache->set( $cache_key, $cache_value );
+		}
 	}
 
 	return $p->get_updated_html();


### PR DESCRIPTION
## What it does

Stacks on #282 and routes `wp_rewrite_urls()` text-node rewriting through `wp_native_apis_rewrite_text_url_bases()` when the native function is available.

The native fast path is intentionally narrow:

- only current `#text` tokens are sent to the native batch rewriter;
- block JSON attributes, URL HTML attributes, style/CSS URLs, and non-ASCII text continue through the structured PHP path;
- if the native batch call makes no change, the existing per-URL path still handles the token.

## Why

#282 adds the coarse native primitive, but the public `wp_rewrite_urls()` path does not call it. This PR shows what kind of speedup is available when a public rewrite workflow uses that native primitive without running it over raw block markup wholesale.

## Benchmark

Same 5,000 sampled `post_content` values used in the reprint experiments: 16.85 MB decoded, 5,000 changed values. PHP.wasm 8.4.21 with a locally built #282 `wp_native_apis` extension.

| Branch | Native batch function | Time | Output hash |
|---|---:|---:|---|
| #282 base | available, not used by `wp_rewrite_urls()` | 95.694s | `44c9750cb310ad822ce73840290c647e609b78ee047365b60f9f123aeed5d9bc` |
| this PR | used for ASCII text nodes | 2.338s | `44c9750cb310ad822ce73840290c647e609b78ee047365b60f9f123aeed5d9bc` |

That is about 40.9x faster than #282 alone on this sample. For context, #283's merged native scanner/cache path measured around 3.5s on the same sample, so this points to another meaningful improvement once #282 is available.

## Testing

```bash
php -l components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php
php -l components/DataLiberation/URL/functions.php
vendor/bin/phpcbf -d memory_limit=1G components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php components/DataLiberation/URL/functions.php
vendor/bin/phpcs -d memory_limit=1G components/DataLiberation/BlockMarkup/class-blockmarkupurlprocessor.php components/DataLiberation/URL/functions.php
vendor/bin/phpunit -c phpunit.xml components/DataLiberation/Tests/RewriteUrlsTest.php components/DataLiberation/Tests/BlockMarkupUrlProcessorTest.php
PHP_WASM_VERSIONS=8.4 ./extensions/native-apis/build-playground-extension.sh .context/wp_native_apis-stacked-wasm-extension
```
