### PR TITLE
Make Native APIs extension more visible in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,6 +46,20 @@ jobs:
             -x "*/Tests/*" "*/tests/*" "*/.git/*" "*/.github/*" "*/node_modules/*"
           php bin/build-reference.php
 
+      - name: Preserve Native APIs Playground release history
+        env:
+          EXTENSION_PATH: wp_native_apis-wasm-extension
+        run: |
+          set -euo pipefail
+          pages_dir="$(mktemp -d)"
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git clone --depth=1 --branch gh-pages "https://github.com/${GITHUB_REPOSITORY}.git" "$pages_dir"
+            if [ -d "$pages_dir/$EXTENSION_PATH" ]; then
+              rm -rf "docs/$EXTENSION_PATH"
+              cp -R "$pages_dir/$EXTENSION_PATH" "docs/$EXTENSION_PATH"
+            fi
+          fi
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs

--- a/.github/workflows/native-apis-playground-extension.yml
+++ b/.github/workflows/native-apis-playground-extension.yml
@@ -6,12 +6,16 @@ on:
       - trunk
     paths:
       - 'extensions/native-apis/**'
+      - 'bin/benchmark-native-apis.php'
+      - 'bin/summarize-native-api-benchmark.php'
       - '.github/workflows/native-apis-playground-extension.yml'
   push:
     branches:
       - trunk
     paths:
       - 'extensions/native-apis/**'
+      - 'bin/benchmark-native-apis.php'
+      - 'bin/summarize-native-api-benchmark.php'
       - '.github/workflows/native-apis-playground-extension.yml'
   workflow_dispatch:
     inputs:
@@ -105,11 +109,68 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ github.event.inputs.retention-days || '30' }}
 
+  benchmark-host-extension:
+    name: Benchmark host PHP extension
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 90
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, json
+          coverage: none
+          tools: composer:v2
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
+          php-config --version
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Build native extension
+        run: extensions/native-apis/build-extension.sh
+
+      - name: Run native API benchmarks
+        run: |
+          mkdir -p build/native-api-benchmark
+          php -d extension=extensions/native-apis/target/release/libwp_native_apis.so \
+            bin/benchmark-native-apis.php \
+            --iterations=50 \
+            --mode=both \
+            --disable-native-defaults \
+            --require-native > build/native-api-benchmark/benchmark.json
+          php bin/summarize-native-api-benchmark.php \
+            build/native-api-benchmark/benchmark.json \
+            build/native-api-benchmark/benchmark-summary.json
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: wp-native-apis-host-benchmark
+          path: build/native-api-benchmark/
+          if-no-files-found: error
+          retention-days: ${{ github.event.inputs.retention-days || '30' }}
+
   publish:
     name: Publish static extension bundle to GitHub Pages
     if: github.ref == 'refs/heads/trunk' && (github.event_name == 'workflow_dispatch' || github.event_name == 'push')
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - build
+      - benchmark-host-extension
     timeout-minutes: 30
     permissions:
       contents: write
@@ -149,9 +210,16 @@ jobs:
           name: wp-native-apis-playground-extension
           path: build/wp_native_apis-wasm-extension
 
+      - name: Download host benchmark results
+        uses: actions/download-artifact@v4
+        with:
+          name: wp-native-apis-host-benchmark
+          path: build/native-api-benchmark
+
       - name: Publish static extension bundle to gh-pages
         env:
           BUNDLE_DIR: build/wp_native_apis-wasm-extension
+          BENCHMARK_DIR: build/native-api-benchmark
           DOCS_DIR: docs
           EXTENSION_PATH: wp_native_apis-wasm-extension
           GITHUB_TOKEN: ${{ github.token }}
@@ -180,6 +248,13 @@ jobs:
           mkdir -p "$pages_dir/$EXTENSION_PATH/$VERSION_PATH" "$pages_dir/$EXTENSION_PATH/latest"
           cp -R "$BUNDLE_DIR"/. "$pages_dir/$EXTENSION_PATH/$VERSION_PATH/"
           cp -R "$BUNDLE_DIR"/. "$pages_dir/$EXTENSION_PATH/latest/"
+          if [ -d "$BENCHMARK_DIR" ]; then
+            mkdir -p "$pages_dir/$EXTENSION_PATH/$VERSION_PATH/benchmarks" "$pages_dir/$EXTENSION_PATH/latest/benchmarks"
+            cp "$BENCHMARK_DIR"/benchmark.json "$pages_dir/$EXTENSION_PATH/$VERSION_PATH/benchmarks/benchmark.json"
+            cp "$BENCHMARK_DIR"/benchmark-summary.json "$pages_dir/$EXTENSION_PATH/$VERSION_PATH/benchmarks/benchmark-summary.json"
+            cp "$BENCHMARK_DIR"/benchmark.json "$pages_dir/$EXTENSION_PATH/latest/benchmarks/benchmark.json"
+            cp "$BENCHMARK_DIR"/benchmark-summary.json "$pages_dir/$EXTENSION_PATH/latest/benchmarks/benchmark-summary.json"
+          fi
           touch "$pages_dir/.nojekyll"
 
           PAGES_DIR="$pages_dir" PUBLISHED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" node <<'NODE'
@@ -300,6 +375,16 @@ jobs:
                 path.join(sanitizedDirectory, artifact.sourcePath)
               );
             }
+
+            const benchmarkDirectory = path.join(releaseDirectory, 'benchmarks');
+            const benchmarkJson = path.join(benchmarkDirectory, 'benchmark.json');
+            const benchmarkSummaryJson = path.join(benchmarkDirectory, 'benchmark-summary.json');
+            if (isRegularFile(benchmarkJson) && isRegularFile(benchmarkSummaryJson)) {
+              const sanitizedBenchmarkDirectory = path.join(sanitizedDirectory, 'benchmarks');
+              fs.mkdirSync(sanitizedBenchmarkDirectory, { recursive: true });
+              fs.copyFileSync(benchmarkJson, path.join(sanitizedBenchmarkDirectory, 'benchmark.json'));
+              fs.copyFileSync(benchmarkSummaryJson, path.join(sanitizedBenchmarkDirectory, 'benchmark-summary.json'));
+            }
           }
 
           fs.rmSync(root, { recursive: true, force: true });
@@ -322,22 +407,46 @@ jobs:
               const relativeManifestPath = path.join(extensionPath, version, 'manifest.json');
               const manifestPath = path.join(root, version, 'manifest.json');
               const manifest = readJson(manifestPath, {});
+              const manifestUrl = `${rootUrl}/${version}/manifest.json`;
+              const benchmarkPath = path.join(root, version, 'benchmarks', 'benchmark.json');
+              const benchmarkSummaryPath = path.join(root, version, 'benchmarks', 'benchmark-summary.json');
+              const benchmarkSummary = readJson(benchmarkSummaryPath, null);
+              const blueprintUrl = `https://raw.githubusercontent.com/${repository}/${version}/extensions/native-apis/playground/blueprint.json`;
+              const phpVersion = Array.isArray(manifest.artifacts) && manifest.artifacts[0] && manifest.artifacts[0].phpVersion
+                ? manifest.artifacts[0].phpVersion
+                : '8.4';
+              const artifacts = Array.isArray(manifest.artifacts)
+                ? manifest.artifacts.map((artifact) => ({
+                    phpVersion: artifact.phpVersion,
+                    sourcePath: artifact.sourcePath,
+                    url: `${rootUrl}/${version}/${artifact.sourcePath}`,
+                  }))
+                : [];
 
               return {
                 version,
                 name: manifest.name || 'wp_native_apis',
-                phpVersions: Array.isArray(manifest.artifacts)
-                  ? manifest.artifacts.map((artifact) => artifact.phpVersion).filter(Boolean)
-                  : [],
+                phpVersions: artifacts.map((artifact) => artifact.phpVersion).filter(Boolean),
+                artifacts,
                 publishedAt: version === versionPath
                   ? process.env.PUBLISHED_AT
                   : existing.publishedAt || lastPublishedAt(relativeManifestPath),
-                manifest: `${rootUrl}/${version}/manifest.json`,
+                manifest: manifestUrl,
                 checksums: `${rootUrl}/${version}/SHA256SUMS`,
                 commit: `https://github.com/${repository}/commit/${version}`,
                 workflowRun: version === versionPath
                   ? `https://github.com/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}`
                   : existing.workflowRun || '',
+                benchmark: isRegularFile(benchmarkPath)
+                  ? `${rootUrl}/${version}/benchmarks/benchmark.json`
+                  : existing.benchmark || '',
+                benchmarkSummaryUrl: isRegularFile(benchmarkSummaryPath)
+                  ? `${rootUrl}/${version}/benchmarks/benchmark-summary.json`
+                  : existing.benchmarkSummaryUrl || '',
+                benchmarkSummary: benchmarkSummary && Array.isArray(benchmarkSummary.top)
+                  ? benchmarkSummary.top
+                  : existing.benchmarkSummary || [],
+                testInPlayground: `https://playground.wordpress.net/?php=${encodeURIComponent(phpVersion)}&php-extension=${encodeURIComponent(manifestUrl)}&blueprint-url=${encodeURIComponent(blueprintUrl)}`,
               };
             })
             .sort((a, b) => {
@@ -349,14 +458,59 @@ jobs:
 
           fs.writeFileSync(releasesPath, `${JSON.stringify(releases, null, 2)}\n`);
 
+          function formatSeconds(value) {
+            if (typeof value !== 'number' || !Number.isFinite(value)) {
+              return 'n/a';
+            }
+            if (value < 0.001) {
+              return `${(value * 1000000).toFixed(0)} µs`;
+            }
+            if (value < 1) {
+              return `${(value * 1000).toFixed(1)} ms`;
+            }
+            return `${value.toFixed(2)} s`;
+          }
+
+          function renderBenchmarkCards(release) {
+            const items = Array.isArray(release.benchmarkSummary)
+              ? release.benchmarkSummary.slice(0, 6)
+              : [];
+            if (!items.length) {
+              return '<p class="muted">Benchmarks were not published for this release.</p>';
+            }
+
+            return `<div class="benchmark-grid">${items.map((item) => `
+              <article class="benchmark-card">
+                <strong>${escapeHtml(item.label || item.name)}</strong>
+                <span>${escapeHtml(item.component || 'Native APIs')}</span>
+                <b>${escapeHtml(item.speedup || 'n/a')}× faster</b>
+                <small>PHP ${escapeHtml(formatSeconds(item.phpWallSeconds))} · native ${escapeHtml(formatSeconds(item.nativeWallSeconds))}</small>
+              </article>
+            `).join('')}</div>`;
+          }
+
+          function renderArtifactLinks(release) {
+            const artifactLinks = Array.isArray(release.artifacts)
+              ? release.artifacts.map((artifact) => `<a href="${escapeHtml(artifact.url)}">${escapeHtml(artifact.sourcePath)}</a>`)
+              : [];
+            return [
+              `<a href="${escapeHtml(release.manifest)}">manifest</a>`,
+              `<a href="${escapeHtml(release.checksums)}">SHA256</a>`,
+              ...artifactLinks,
+              release.benchmark ? `<a href="${escapeHtml(release.benchmark)}">benchmark JSON</a>` : '',
+              release.benchmarkSummaryUrl ? `<a href="${escapeHtml(release.benchmarkSummaryUrl)}">benchmark summary</a>` : '',
+            ].filter(Boolean).join(' · ');
+          }
+
+          const latestRelease = releases[0] || null;
           const rows = releases.map((release) => `
             <tr>
               <td><code>${escapeHtml(release.version.slice(0, 12))}</code></td>
               <td>${escapeHtml(release.publishedAt || 'unknown')}</td>
               <td>${escapeHtml(release.phpVersions.join(', ') || 'unknown')}</td>
-              <td><a href="${escapeHtml(release.manifest)}">manifest</a></td>
-              <td><a href="${escapeHtml(release.checksums)}">checksums</a></td>
-              <td><a href="${escapeHtml(release.commit)}">commit</a></td>
+              <td><a href="${escapeHtml(release.testInPlayground)}">Test in Playground</a></td>
+              <td>${renderArtifactLinks(release)}</td>
+              <td><a href="${escapeHtml(release.commit)}">commit</a>${release.workflowRun ? ` · <a href="${escapeHtml(release.workflowRun)}">workflow</a>` : ''}</td>
             </tr>
           `).join('');
 
@@ -369,56 +523,205 @@ jobs:
             <style>
               :root {
                 color-scheme: light dark;
+                --accent: #2563eb;
+                --muted: #5f6673;
+                --border: color-mix(in srgb, currentColor 18%, transparent);
+                --panel: color-mix(in srgb, currentColor 5%, transparent);
                 font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
               }
               body {
                 margin: 0;
-                padding: 2rem;
-                line-height: 1.5;
+                line-height: 1.55;
               }
-              main {
-                max-width: 72rem;
+              header,
+              main,
+              footer {
+                max-width: 76rem;
+                margin: 0 auto;
+                padding: 1.25rem 1.5rem;
+              }
+              header {
+                display: flex;
+                justify-content: space-between;
+                gap: 1rem;
+                align-items: center;
+                border-bottom: 1px solid var(--border);
+              }
+              header a { color: inherit; text-decoration: none; }
+              header nav { display: flex; gap: 1rem; flex-wrap: wrap; }
+              .hero {
+                padding: 3rem 1.5rem 2rem;
+              }
+              h1 {
+                font-size: clamp(2rem, 6vw, 4rem);
+                line-height: 1;
+                letter-spacing: -0.04em;
+                margin: 0 0 1rem;
+              }
+              h2 { margin-top: 2.5rem; }
+              .lede {
+                max-width: 54rem;
+                font-size: 1.15rem;
+                color: var(--muted);
+              }
+              .cta-row,
+              .link-row {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.75rem;
+                margin: 1.25rem 0;
+              }
+              .button,
+              .pill {
+                display: inline-block;
+                border: 1px solid var(--border);
+                border-radius: 999px;
+                padding: 0.62rem 1rem;
+                text-decoration: none;
+                color: inherit;
+                font-weight: 600;
+              }
+              .button.primary {
+                background: var(--accent);
+                color: white;
+                border-color: var(--accent);
+              }
+              .notice,
+              .release-panel,
+              .benchmark-card {
+                border: 1px solid var(--border);
+                border-radius: 14px;
+                background: var(--panel);
+              }
+              .notice,
+              .release-panel {
+                padding: 1rem 1.1rem;
+              }
+              .release-panel {
+                display: grid;
+                grid-template-columns: minmax(0, 1fr) minmax(280px, 0.75fr);
+                gap: 1.25rem;
+                align-items: start;
+              }
+              .benchmark-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+                gap: 0.8rem;
+                margin: 1rem 0;
+              }
+              .benchmark-card {
+                padding: 0.9rem;
+              }
+              .benchmark-card strong,
+              .benchmark-card b,
+              .benchmark-card span,
+              .benchmark-card small {
+                display: block;
+              }
+              .benchmark-card span,
+              .benchmark-card small,
+              .muted {
+                color: var(--muted);
+              }
+              .benchmark-card b {
+                margin: 0.35rem 0;
+                font-size: 1.3rem;
               }
               table {
                 border-collapse: collapse;
                 width: 100%;
+                margin-top: 1rem;
               }
               th,
               td {
-                border-bottom: 1px solid color-mix(in srgb, currentColor 20%, transparent);
-                padding: 0.65rem 0.75rem;
+                border-bottom: 1px solid var(--border);
+                padding: 0.75rem;
                 text-align: left;
                 vertical-align: top;
               }
-              th {
-                font-size: 0.85rem;
-              }
+              th { font-size: 0.85rem; }
               code {
                 font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+                font-size: 0.92em;
+              }
+              a { color: var(--accent); }
+              footer { color: var(--muted); }
+              @media (max-width: 760px) {
+                .release-panel { grid-template-columns: 1fr; }
+                table { display: block; overflow-x: auto; }
               }
             </style>
           </head>
           <body>
+            <header>
+              <a href="../"><strong>PHP Toolkit</strong></a>
+              <nav>
+                <a href="../native-apis.html">Native APIs docs</a>
+                <a href="https://github.com/${escapeHtml(repository)}">GitHub</a>
+              </nav>
+            </header>
             <main>
-              <h1>wp_native_apis PHP.wasm Extension Releases</h1>
-              <p>The latest Playground manifest is <a href="${escapeHtml(rootUrl)}/latest/manifest.json"><code>latest/manifest.json</code></a>. Use immutable commit manifests below when a test or document needs a stable release.</p>
-              <p>Machine-readable release history is available as <a href="${escapeHtml(rootUrl)}/releases.json"><code>releases.json</code></a>.</p>
-              <table>
-                <thead>
-                  <tr>
-                    <th>Version</th>
-                    <th>Published at (UTC)</th>
-                    <th>PHP versions</th>
-                    <th>Manifest</th>
-                    <th>SHA256</th>
-                    <th>Commit</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  ${rows || '<tr><td colspan="6">No releases published yet.</td></tr>'}
-                </tbody>
-              </table>
+              <section class="hero">
+                <p class="pill">Experimental PHP.wasm extension</p>
+                <h1>wp_native_apis releases</h1>
+                <p class="lede">Published manifests for testing the PHP Toolkit Native APIs extension in WordPress Playground. Use the latest link for quick manual testing, or an immutable commit manifest when a document, demo, or test needs a reproducible runtime.</p>
+                <div class="cta-row">
+                  ${latestRelease ? `<a class="button primary" href="${escapeHtml(latestRelease.testInPlayground)}">Test latest in Playground →</a>` : ''}
+                  <a class="button" href="${escapeHtml(rootUrl)}/latest/manifest.json">Latest manifest</a>
+                  <a class="button" href="${escapeHtml(rootUrl)}/releases.json">releases.json</a>
+                </div>
+              </section>
+
+              <section class="notice">
+                <strong>Status:</strong> this is an experimental Playground extension release channel. Browser Playground loads the PHP.wasm side module with the <code>php-extension</code> query parameter before PHP starts. The host Rust-backed extension is benchmarked separately; the Playground bundle should not be treated as full host-extension parity.
+              </section>
+
+              ${latestRelease ? `<section class="release-panel">
+                <div>
+                  <h2>Latest release</h2>
+                  <p><code>${escapeHtml(latestRelease.version)}</code></p>
+                  <p class="muted">Published ${escapeHtml(latestRelease.publishedAt || 'at an unknown time')} · PHP ${escapeHtml(latestRelease.phpVersions.join(', ') || 'unknown')}</p>
+                  <div class="link-row">
+                    <a class="button primary" href="${escapeHtml(latestRelease.testInPlayground)}">Test in Playground</a>
+                    <a class="button" href="${escapeHtml(latestRelease.manifest)}">Manifest</a>
+                    <a class="button" href="${escapeHtml(latestRelease.checksums)}">Checksums</a>
+                    <a class="button" href="${escapeHtml(latestRelease.commit)}">Source commit</a>
+                  </div>
+                </div>
+                <div>
+                  <h2>Benchmark highlights</h2>
+                  ${renderBenchmarkCards(latestRelease)}
+                </div>
+              </section>` : ''}
+
+              <section>
+                <h2>How to choose a manifest</h2>
+                <p><strong><code>latest/manifest.json</code></strong> always points at the newest published bundle. It is convenient for manual testing, but it moves whenever <code>trunk</code> publishes a new extension.</p>
+                <p><strong>Commit manifests</strong> are immutable. Use the release-history links below for docs, bug reports, demos, and tests that need to keep loading the same bundle over time.</p>
+              </section>
+
+              <section>
+                <h2>Release history</h2>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Version</th>
+                      <th>Published at (UTC)</th>
+                      <th>PHP versions</th>
+                      <th>Playground</th>
+                      <th>Files</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${rows || '<tr><td colspan="6">No releases published yet.</td></tr>'}
+                  </tbody>
+                </table>
+              </section>
             </main>
+            <footer>
+              Machine-readable release history: <a href="${escapeHtml(rootUrl)}/releases.json"><code>releases.json</code></a>.
+            </footer>
           </body>
           </html>
           `);

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 
 Standalone, dependency-free PHP libraries for use in WordPress plugins and standalone PHP projects.
 
+### Experimental Native APIs extension
+
+The toolkit now publishes an experimental Native APIs extension for performance-sensitive HTML, XML, and URL-in-text workloads. Public PHP APIs keep their pure-PHP fallback behavior when the extension is absent, incompatible, or disabled with `WP_NATIVE_APIS_DISABLE_DEFAULTS`.
+
+- [Native APIs docs](https://wordpress.github.io/php-toolkit/native-apis.html) explain what is accelerated and how the fallback model works.
+- [Test the latest PHP.wasm extension in WordPress Playground](https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json).
+- [Browse Playground extension releases](https://wordpress.github.io/php-toolkit/wp_native_apis-wasm-extension/) for manifests, checksums, immutable test links, and benchmark summaries.
+- [Build the host PHP extension](extensions/native-apis/README.md) when you want to benchmark the Rust-backed implementation locally.
+
 ### Components
 
 | Component | What it does | Live docs |

--- a/bin/build-reference.php
+++ b/bin/build-reference.php
@@ -36,7 +36,7 @@ if ( ! is_file( __DIR__ . '/../vendor/autoload.php' ) ) {
 }
 require __DIR__ . '/../vendor/autoload.php';
 
-const ASSET_VERSION = '20260504-php-rewrite';
+const ASSET_VERSION = '20260526-native-apis';
 const ROOT          = __DIR__ . '/..';
 const COMPONENTS    = ROOT . '/components';
 const DOCS          = ROOT . '/docs/reference';
@@ -81,6 +81,7 @@ const PAGE_HEAD = '<!doctype html>
 	<nav>
 		<a href="../learn/">Learn</a>
 		<a href="./">Reference</a>
+		<a href="../native-apis.html">Native APIs</a>
 		<a href="https://github.com/WordPress/php-toolkit">GitHub</a>
 	</nav>
 </header>

--- a/bin/summarize-native-api-benchmark.php
+++ b/bin/summarize-native-api-benchmark.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Summarize native API benchmark JSON for the public release page.
+ *
+ * Usage:
+ *   php bin/summarize-native-api-benchmark.php benchmark.json benchmark-summary.json
+ *
+ * @package WordPress
+ */
+
+declare(strict_types=1);
+
+if ( $argc < 3 ) {
+	fwrite( STDERR, "Usage: php bin/summarize-native-api-benchmark.php <benchmark.json> <summary.json>\n" );
+	exit( 1 );
+}
+
+$input_path  = $argv[1];
+$output_path = $argv[2];
+
+$contents = file_get_contents( $input_path );
+if ( false === $contents ) {
+	fwrite( STDERR, "Unable to read benchmark JSON: {$input_path}\n" );
+	exit( 1 );
+}
+
+$rows = json_decode( $contents, true );
+if ( ! is_array( $rows ) ) {
+	fwrite( STDERR, "Invalid benchmark JSON: {$input_path}\n" );
+	exit( 1 );
+}
+
+$by_name = array();
+foreach ( $rows as $row ) {
+	if ( ! is_array( $row ) || empty( $row['available'] ) || ! isset( $row['name'], $row['implementation'] ) ) {
+		continue;
+	}
+
+	$name           = (string) $row['name'];
+	$implementation = (string) $row['implementation'];
+	if ( ! isset( $by_name[ $name ] ) ) {
+		$by_name[ $name ] = array();
+	}
+	$by_name[ $name ][ $implementation ] = $row;
+}
+
+$comparisons = array();
+foreach ( $by_name as $name => $implementations ) {
+	if ( ! isset( $implementations['php'], $implementations['native'] ) ) {
+		continue;
+	}
+
+	$php_row     = $implementations['php'];
+	$native_row  = $implementations['native'];
+	$php_wall    = isset( $php_row['wall_seconds'] ) ? (float) $php_row['wall_seconds'] : 0.0;
+	$native_wall = isset( $native_row['wall_seconds'] ) ? (float) $native_row['wall_seconds'] : 0.0;
+
+	if ( 0.0 >= $php_wall || 0.0 >= $native_wall ) {
+		continue;
+	}
+
+	$comparisons[] = array(
+		'name'              => $name,
+		'label'             => wp_toolkit_native_api_benchmark_label( $name ),
+		'component'         => wp_toolkit_native_api_benchmark_component( $name ),
+		'iterations'        => isset( $php_row['iterations'] ) ? (int) $php_row['iterations'] : null,
+		'operations'        => isset( $php_row['operations'] ) ? (int) $php_row['operations'] : null,
+		'phpWallSeconds'    => round( $php_wall, 6 ),
+		'nativeWallSeconds' => round( $native_wall, 6 ),
+		'speedup'           => round( $php_wall / $native_wall, 2 ),
+		'phpClass'          => isset( $php_row['class'] ) ? (string) $php_row['class'] : '',
+		'nativeClass'       => isset( $native_row['class'] ) ? (string) $native_row['class'] : '',
+	);
+}
+
+usort(
+	$comparisons,
+	function ( $a, $b ) {
+		if ( $a['speedup'] === $b['speedup'] ) {
+			return strcmp( $a['name'], $b['name'] );
+		}
+		return $a['speedup'] < $b['speedup'] ? 1 : -1;
+	}
+);
+
+$summary = array(
+	'generatedAt' => gmdate( 'c' ),
+	'command'     => 'php -d extension=extensions/native-apis/target/release/libwp_native_apis.so bin/benchmark-native-apis.php --iterations=50 --mode=both --disable-native-defaults --require-native',
+	'count'       => count( $comparisons ),
+	'top'         => array_slice( $comparisons, 0, 8 ),
+	'comparisons' => $comparisons,
+);
+
+$json = json_encode( $summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+if ( false === $json || false === file_put_contents( $output_path, $json . "\n" ) ) {
+	fwrite( STDERR, "Unable to write benchmark summary: {$output_path}\n" );
+	exit( 1 );
+}
+
+/**
+ * Convert a workload name into a short public label.
+ *
+ * @param string $name Workload name.
+ * @return string Human-friendly label.
+ */
+function wp_toolkit_native_api_benchmark_label( $name ) {
+	$labels = array(
+		'html-tag-processor'                         => 'HTML tag scan',
+		'html-tag-prefix-count'                      => 'HTML prefix count',
+		'html-tag-batch'                             => 'HTML tag batch',
+		'html-matching-tag-batch'                    => 'HTML matching tag batch',
+		'html-matching-tag-attribute-batch'          => 'HTML tag + attribute batch',
+		'html-matching-tag-attributes-batch'         => 'HTML tag + attributes batch',
+		'html-link-audit-summary'                    => 'HTML link audit summary',
+		'html-tag-inventory-summary'                 => 'HTML tag inventory',
+		'html-heading-inventory-summary'             => 'HTML heading inventory',
+		'html-id-inventory-summary'                  => 'HTML ID inventory',
+		'html-attribute-inventory-summary'           => 'HTML attribute inventory',
+		'html-data-attribute-inventory-summary'      => 'HTML data-* inventory',
+		'html-aria-attribute-inventory-summary'      => 'HTML ARIA inventory',
+		'html-class-inventory-summary'               => 'HTML class inventory',
+		'html-resource-inventory-summary'            => 'HTML resource inventory',
+		'html-image-inventory-summary'               => 'HTML image inventory',
+		'html-script-inventory-summary'              => 'HTML script inventory',
+		'html-form-inventory-summary'                => 'HTML form inventory',
+		'html-tag-prefix-batch'                      => 'HTML prefix batch',
+		'html-tag-prefix-count-batch'                => 'HTML prefix count batch',
+		'html-tag-prefix-summary'                    => 'HTML prefix summary',
+		'html-tag-sanitizer'                         => 'HTML sanitizer',
+		'html-processor'                             => 'HTML fragment processor',
+		'html-token-batch'                           => 'HTML token batch',
+		'xml-processor'                              => 'XML processor scan',
+		'xml-token-summary'                          => 'XML token summary',
+		'xml-document-inventory-summary'             => 'XML document inventory',
+		'xml-element-inventory-summary'              => 'XML element inventory',
+		'xml-depth-inventory-summary'                => 'XML depth inventory',
+		'xml-leaf-inventory-summary'                 => 'XML leaf inventory',
+		'xml-structural-inventory-summary'           => 'XML structural inventory',
+		'xml-attribute-inventory-summary'            => 'XML attribute inventory',
+		'xml-id-inventory-summary'                   => 'XML ID inventory',
+		'xml-namespace-inventory-summary'            => 'XML namespace inventory',
+		'xml-text-inventory-summary'                 => 'XML text inventory',
+		'xml-processing-instruction-inventory-summary' => 'XML processing instruction inventory',
+		'xml-comment-inventory-summary'              => 'XML comment inventory',
+		'xml-payload-inventory-summary'              => 'XML payload inventory',
+		'xml-content-inventory-summary'              => 'XML content inventory',
+		'xml-import-inventory-summary'               => 'XML import inventory',
+		'xml-token-batch'                            => 'XML token batch',
+		'xml-tag-summary'                            => 'XML tag summary',
+		'xml-tag-batch'                              => 'XML tag batch',
+		'xml-matching-tag-batch'                     => 'XML matching tag batch',
+		'xml-matching-tag-count-batch'               => 'XML matching tag count batch',
+		'xml-matching-tag-summary'                   => 'XML matching tag summary',
+		'xml-matching-tag-attributes-summary'        => 'XML matching tag attributes summary',
+		'xml-tag-count-batch'                        => 'XML tag count batch',
+		'xml-prefix-summary'                         => 'XML prefix summary',
+		'xml-prefix-sanitizer'                       => 'XML prefix sanitizer',
+		'url-in-text-processor'                      => 'URL-in-text scan',
+	);
+
+	if ( isset( $labels[ $name ] ) ) {
+		return $labels[ $name ];
+	}
+
+	return ucwords( str_replace( '-', ' ', $name ) );
+}
+
+/**
+ * Infer component name from workload name.
+ *
+ * @param string $name Workload name.
+ * @return string Component name.
+ */
+function wp_toolkit_native_api_benchmark_component( $name ) {
+	if ( 0 === strpos( $name, 'html-' ) ) {
+		return 'HTML';
+	}
+	if ( 0 === strpos( $name, 'xml-' ) ) {
+		return 'XML';
+	}
+	if ( 0 === strpos( $name, 'url-' ) ) {
+		return 'URL-in-text';
+	}
+	return 'Native APIs';
+}

--- a/components/Blueprints/Tests/Unit/Steps/InstallPluginStepTest.php
+++ b/components/Blueprints/Tests/Unit/Steps/InstallPluginStepTest.php
@@ -95,6 +95,7 @@ PHP
 			<<<'PHP'
 <?php
 require_once getenv('WP_CORE_DIR') . '/wp-load.php';
+require_once getenv('WP_CORE_DIR') . '/wp-admin/includes/plugin.php';
 
 // Get all installed plugins
 $all_plugins = get_plugins();

--- a/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
+++ b/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
@@ -64,9 +64,14 @@ class StepTestCase extends TestCase {
 			;
 		}
 
+		$blueprint = array( 'version' => 2 );
+		if ( PHP_VERSION_ID < 70400 ) {
+			$blueprint['wordpressVersion'] = '6.6.2';
+		}
+
 		file_put_contents(
 			wp_join_unix_paths( $this->execution_context_path, 'blueprint.json' ),
-			json_encode( [ "version" => 2 ] )
+			json_encode( $blueprint )
 		);
 
 		$config

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -608,7 +608,7 @@ main.landing .lede {
 
 .cta.primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); color: white; }
 
-.origins, .insight, .two-doors, .proofs, .how-runnable, .prereqs, .path, .canonical-artifact, .next, .ref-group {
+.origins, .insight, .two-doors, .native-promo, .proofs, .how-runnable, .prereqs, .path, .canonical-artifact, .next, .ref-group {
 	margin: 2.5rem 0;
 }
 
@@ -833,4 +833,94 @@ ol.chapters span { display: block; color: var(--muted); font-size: 0.93rem; }
 .callout.credit {
 	border-left-color: #8b5cf6;
 	background: linear-gradient(to right, rgba(139, 92, 246, 0.06), transparent);
+}
+
+/* ---------- Native APIs page ---------- */
+
+.native-page {
+	max-width: 960px;
+	margin: 0 auto;
+	padding: 4rem 1.5rem 3rem;
+}
+
+.native-hero {
+	padding: 0 0 1rem;
+}
+
+.eyebrow {
+	margin: 0 0 0.5rem;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	font-size: 0.78rem;
+	font-weight: 700;
+	color: var(--accent);
+}
+
+.native-page h1 {
+	font-size: 2.6rem;
+	line-height: 1.08;
+	letter-spacing: -0.03em;
+	margin: 0 0 1rem;
+}
+
+.native-page h2 {
+	font-size: 1.35rem;
+	margin: 3rem 0 1rem;
+	letter-spacing: -0.01em;
+}
+
+.native-page h3 {
+	margin: 0 0 0.35rem;
+}
+
+.native-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 1rem;
+	margin-top: 1rem;
+}
+
+.native-grid.two {
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.native-grid article,
+.callout {
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	padding: 1rem 1.1rem;
+	background: color-mix(in srgb, var(--code-bg) 55%, transparent);
+}
+
+.native-grid article p {
+	margin: 0.4rem 0 0.7rem;
+	color: var(--muted);
+}
+
+.callout.warning {
+	border-color: color-mix(in srgb, #f59e0b 45%, var(--border));
+	background: color-mix(in srgb, #f59e0b 10%, var(--bg));
+}
+
+.native-test ol {
+	padding-left: 1.3rem;
+}
+
+.native-benchmarks pre {
+	overflow-x: auto;
+	background: var(--code-bg);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	padding: 1rem;
+}
+
+@media (max-width: 760px) {
+	.native-grid,
+	.native-grid.two {
+		grid-template-columns: 1fr;
+	}
+
+	.native-page h1 {
+		font-size: 2rem;
+	}
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>PHP Toolkit — PHP libraries for WordPress and the open web</title>
 <meta name="description" content="A PHP toolkit for parsing HTML, reading and writing ZIP archives, streaming bytes, importing content, and a dozen other jobs that PHP often outsources to extensions. Runs on PHP 7.2+ and inside the browser via WordPress Playground.">
-<link rel="stylesheet" href="assets/style.css?v=20260429-credits">
+<link rel="stylesheet" href="assets/style.css?v=20260526-native-apis">
 </head>
 <body>
 <header class="site">
@@ -13,6 +13,7 @@
 	<nav>
 		<a href="learn/">Learn</a>
 		<a href="reference/">Reference</a>
+		<a href="native-apis.html">Native APIs</a>
 		<a class="github" href="https://github.com/WordPress/php-toolkit">GitHub</a>
 	</nav>
 </header>
@@ -45,6 +46,15 @@
 			<span>Eighteen component pages, each with a one-line definition, a minimal runnable example, refinements, the pitfalls people actually trip on, and links back to the tutorial chapters where the concept first appears.</span>
 			<em>Browse all components ↓</em>
 		</a>
+	</div>
+</section>
+
+<section class="native-promo">
+	<h2>Experimental native acceleration</h2>
+	<p>The toolkit stays dependency-free by default, but the experimental Native APIs extension explores faster HTML, XML, and URL-in-text workloads for environments that can load PHP extensions. Try the PHP.wasm smoke test in WordPress Playground, inspect published manifests, and compare CI benchmark snapshots.</p>
+	<div class="cta-row">
+		<a class="cta primary" href="native-apis.html">Explore Native APIs →</a>
+		<a class="cta" href="wp_native_apis-wasm-extension/">Release index</a>
 	</div>
 </section>
 

--- a/docs/learn/01-rewriting-html.html
+++ b/docs/learn/01-rewriting-html.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Chapter 1 — Rewriting HTML safely · PHP Toolkit</title>
 <meta name="description" content="Rewrite real-world HTML — lazy-load images, fix relative URLs, neutralize scripts and inline event handlers — using WP_HTML_Tag_Processor's cursor model. Chapter 1 of a tutorial that builds a content importer.">
-<link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
+<link rel="stylesheet" href="../assets/style.css?v=20260526-native-apis">
 <script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
 <script id="toolkit-setup" type="application/json"></script>
 <script src="../assets/page.js?v=20260429-rewrite" defer></script>
@@ -16,6 +16,7 @@
 	<nav>
 		<a href="./">Learn</a>
 		<a href="../reference/">Reference</a>
+		<a href="../native-apis.html">Native APIs</a>
 		<a class="github" href="https://github.com/WordPress/php-toolkit">GitHub</a>
 	</nav>
 </header>

--- a/docs/learn/02-streaming-archives.html
+++ b/docs/learn/02-streaming-archives.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Chapter 2 — Streaming archives · PHP Toolkit</title>
 <meta name="description" content="Read a ZIP archive without buffering it, mount it as a Filesystem, and stage entries in memory. Chapter 2 of the content-importer tutorial.">
-<link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
+<link rel="stylesheet" href="../assets/style.css?v=20260526-native-apis">
 <script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
 <script id="toolkit-setup" type="application/json"></script>
 <script src="../assets/page.js?v=20260429-rewrite" defer></script>
@@ -16,6 +16,7 @@
 	<nav>
 		<a href="./">Learn</a>
 		<a href="../reference/">Reference</a>
+		<a href="../native-apis.html">Native APIs</a>
 		<a class="github" href="https://github.com/WordPress/php-toolkit">GitHub</a>
 	</nav>
 </header>

--- a/docs/learn/03-importing-content.html
+++ b/docs/learn/03-importing-content.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Chapter 3 — Markdown to WXR · PHP Toolkit</title>
 <meta name="description" content="Convert Markdown posts to WordPress block markup, audit the result with BlockParser, and stream a WXR export with DataLiberation. Chapter 3 of the importer tutorial.">
-<link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
+<link rel="stylesheet" href="../assets/style.css?v=20260526-native-apis">
 <script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
 <script id="toolkit-setup" type="application/json"></script>
 <script src="../assets/page.js?v=20260429-rewrite" defer></script>
@@ -16,6 +16,7 @@
 	<nav>
 		<a href="./">Learn</a>
 		<a href="../reference/">Reference</a>
+		<a href="../native-apis.html">Native APIs</a>
 		<a class="github" href="https://github.com/WordPress/php-toolkit">GitHub</a>
 	</nav>
 </header>

--- a/docs/learn/04-talking-to-the-network.html
+++ b/docs/learn/04-talking-to-the-network.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Chapter 4 — Talking to the network · PHP Toolkit</title>
 <meta name="description" content="Frontload images, run a sliding window of concurrent downloads, and stream-unzip a remote archive — all without a mandatory curl dependency. Chapter 4 of the importer tutorial.">
-<link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
+<link rel="stylesheet" href="../assets/style.css?v=20260526-native-apis">
 <script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
 <script id="toolkit-setup" type="application/json"></script>
 <script src="../assets/page.js?v=20260429-rewrite" defer></script>
@@ -16,6 +16,7 @@
 	<nav>
 		<a href="./">Learn</a>
 		<a href="../reference/">Reference</a>
+		<a href="../native-apis.html">Native APIs</a>
 		<a class="github" href="https://github.com/WordPress/php-toolkit">GitHub</a>
 	</nav>
 </header>

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Learn — PHP Toolkit</title>
 <meta name="description" content="A four-chapter tutorial that builds a WordPress content importer using HTML, ZIP, Markdown, and DataLiberation. Most snippets run in the browser.">
-<link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
+<link rel="stylesheet" href="../assets/style.css?v=20260526-native-apis">
 </head>
 <body>
 <header class="site">
@@ -13,6 +13,7 @@
 	<nav>
 		<a href="./">Learn</a>
 		<a href="../reference/">Reference</a>
+		<a href="../native-apis.html">Native APIs</a>
 		<a class="github" href="https://github.com/WordPress/php-toolkit">GitHub</a>
 	</nav>
 </header>

--- a/docs/learn/quickstart.html
+++ b/docs/learn/quickstart.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Quickstart — PHP Toolkit</title>
 <meta name="description" content="Five minutes from zero to a runnable HTML rewrite using PHP Toolkit's HTML component.">
-<link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
+<link rel="stylesheet" href="../assets/style.css?v=20260526-native-apis">
 <script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
 <script id="toolkit-setup" type="application/json"></script>
 <script src="../assets/page.js?v=20260429-rewrite" defer></script>
@@ -16,6 +16,7 @@
 	<nav>
 		<a href="./">Learn</a>
 		<a href="../reference/">Reference</a>
+		<a href="../native-apis.html">Native APIs</a>
 		<a class="github" href="https://github.com/WordPress/php-toolkit">GitHub</a>
 	</nav>
 </header>

--- a/docs/learn/recap.html
+++ b/docs/learn/recap.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Recap · PHP Toolkit</title>
 <meta name="description" content="Where to go after the four-chapter tutorial — what the importer used, what the toolkit covers beyond it.">
-<link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
+<link rel="stylesheet" href="../assets/style.css?v=20260526-native-apis">
 </head>
 <body>
 <header class="site">
@@ -13,6 +13,7 @@
 	<nav>
 		<a href="./">Learn</a>
 		<a href="../reference/">Reference</a>
+		<a href="../native-apis.html">Native APIs</a>
 		<a class="github" href="https://github.com/WordPress/php-toolkit">GitHub</a>
 	</nav>
 </header>

--- a/docs/native-apis.html
+++ b/docs/native-apis.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Native APIs — PHP Toolkit</title>
+<meta name="description" content="Experimental Native APIs extension for PHP Toolkit. Test the PHP.wasm extension in WordPress Playground, inspect releases, and compare native benchmark results.">
+<link rel="stylesheet" href="assets/style.css?v=20260526-native-apis">
+</head>
+<body>
+<header class="site">
+	<a class="brand" href="./">PHP Toolkit</a>
+	<nav>
+		<a href="learn/">Learn</a>
+		<a href="reference/">Reference</a>
+		<a href="native-apis.html">Native APIs</a>
+		<a class="github" href="https://github.com/WordPress/php-toolkit">GitHub</a>
+	</nav>
+</header>
+
+<main class="native-page">
+
+<section class="native-hero">
+	<p class="eyebrow">Experimental performance preview</p>
+	<h1>Native APIs for the hottest toolkit paths.</h1>
+	<p class="lede">The Native APIs extension registers PHP extension classes for high-volume HTML, XML, and URL-in-text workloads. Public toolkit classes keep their PHP fallback behavior, so projects can try native acceleration without making the extension a hard dependency.</p>
+	<div class="cta-row">
+		<a class="cta primary" href="https://playground.wordpress.net/?php=8.4&amp;php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&amp;blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json">Test in Playground →</a>
+		<a class="cta" href="wp_native_apis-wasm-extension/">Browse releases</a>
+		<a class="cta" href="https://github.com/WordPress/php-toolkit/tree/trunk/extensions/native-apis">Build locally</a>
+	</div>
+</section>
+
+<section class="native-status">
+	<h2>Status</h2>
+	<div class="callout warning">
+		<strong>Experimental:</strong> the extension is useful for testing and benchmarking, but the packaging, release cadence, and accelerated surface are still evolving. Use immutable release manifests for reproducible Playground links.
+	</div>
+	<p>When the extension is loaded before the toolkit, wrappers may delegate covered operations to native classes. If the extension is missing, incompatible, or disabled with <code>WP_NATIVE_APIS_DISABLE_DEFAULTS</code>, the same public APIs continue through pure PHP implementations.</p>
+</section>
+
+<section class="native-grid-section">
+	<h2>What it accelerates</h2>
+	<div class="native-grid">
+		<article>
+			<h3>HTML</h3>
+			<p>Fast tag scans, fragment parsing, batch queries, and aggregate audits for common <code>WP_HTML_Tag_Processor</code> and fragment-processor workloads.</p>
+			<a href="reference/html.html">HTML reference →</a>
+		</article>
+		<article>
+			<h3>XML</h3>
+			<p>Streaming XML token, tag, namespace, attribute, and inventory summaries for export-sized documents without building a DOM tree.</p>
+			<a href="reference/xml.html">XML reference →</a>
+		</article>
+		<article>
+			<h3>URL-in-text</h3>
+			<p>A native candidate scanner for plain-text URL detection, while public URL handling still validates candidates through the existing WHATWG parser path.</p>
+			<a href="reference/dataliberation.html">DataLiberation reference →</a>
+		</article>
+	</div>
+</section>
+
+<section class="native-grid-section">
+	<h2>Two release targets</h2>
+	<div class="native-grid two">
+		<article>
+			<h3>Host PHP extension</h3>
+			<p>The Rust-backed extension is built with <code>ext-php-rs</code> for a specific host PHP ABI. A Linux PHP 8.3 build cannot be reused for PHP 8.4 or PHP 8.5.</p>
+			<p><a href="https://github.com/WordPress/php-toolkit/tree/trunk/extensions/native-apis">Build and verify locally →</a></p>
+		</article>
+		<article>
+			<h3>PHP.wasm extension for Playground</h3>
+			<p>Browser Playground loads a PHP.wasm side module through the <code>php-extension</code> URL parameter before PHP starts. The current Playground bundle is a smoke-testable extension path and should not be described as full Rust-backed host parity.</p>
+			<p><a href="wp_native_apis-wasm-extension/">Open release index →</a></p>
+		</article>
+	</div>
+</section>
+
+<section class="native-test">
+	<h2>Test the latest Playground build</h2>
+	<p>The smoke-test Blueprint writes a small PHP page into WordPress Playground and checks that the native classes are registered before running one HTML tag, HTML processor, XML, and URL-in-text operation.</p>
+	<ol>
+		<li>Open the Playground URL with <code>php=8.4</code> and the latest <code>wp_native_apis</code> manifest.</li>
+		<li>Wait for the Blueprint to create <code>/native-api-smoke.php</code>.</li>
+		<li>Confirm the page ends with <code>PASS: Native API extension classes are available.</code></li>
+	</ol>
+	<p><a class="cta primary" href="https://playground.wordpress.net/?php=8.4&amp;php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&amp;blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json">Run the smoke test in Playground →</a></p>
+</section>
+
+<section class="native-benchmarks">
+	<h2>Benchmarks</h2>
+	<p>The release workflow also builds the host Rust-backed extension and runs the repository benchmark harness against the same workloads in PHP and native modes. The release page publishes raw JSON plus a summarized view with wall-clock speedups.</p>
+	<pre><code>php -d extension=extensions/native-apis/target/release/libwp_native_apis.so \
+	bin/benchmark-native-apis.php --iterations=50 --mode=both --disable-native-defaults --require-native</code></pre>
+	<p>Benchmark numbers are machine- and workflow-run-specific. Treat them as directional evidence for which workflows benefit from native batching, not as universal throughput guarantees.</p>
+</section>
+
+</main>
+
+<footer class="site">
+	<a href="https://github.com/WordPress/php-toolkit">WordPress/php-toolkit</a> · <a href="wp_native_apis-wasm-extension/">Native API releases</a>
+</footer>
+</body>
+</html>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Reference — PHP Toolkit</title>
 <meta name="description" content="Per-component reference pages for PHP Toolkit. Each page has a one-line definition, a minimal runnable example, refinements, and pitfalls.">
-<link rel="stylesheet" href="../assets/style.css?v=20260429-rewrite">
+<link rel="stylesheet" href="../assets/style.css?v=20260526-native-apis">
 </head>
 <body>
 <header class="site">
@@ -13,6 +13,7 @@
 	<nav>
 		<a href="../learn/">Learn</a>
 		<a href="./">Reference</a>
+		<a href="../native-apis.html">Native APIs</a>
 		<a class="github" href="https://github.com/WordPress/php-toolkit">GitHub</a>
 	</nav>
 </header>
@@ -63,6 +64,12 @@
 		<li><a href="blueprints.html"><strong>Blueprints</strong><span>Versioned recipes for spinning up a WordPress site with a known plugin set, content, and config.</span></a></li>
 		<li><a href="coding-standards.html"><strong>ToolkitCodingStandards</strong><span>PHPCS sniffs that encode the project's review feedback as enforceable rules.</span></a></li>
 	</ul>
+</section>
+
+<section class="ref-group native-promo">
+	<h2>Experimental Native APIs</h2>
+	<p>Testing the native extension? The Native APIs page explains the accelerated HTML, XML, and URL-in-text paths, links to Playground releases, and shows benchmark summaries from CI.</p>
+	<p><a class="cta" href="../native-apis.html">Open Native APIs docs →</a></p>
 </section>
 
 </main>

--- a/extensions/native-apis/README.md
+++ b/extensions/native-apis/README.md
@@ -5,6 +5,12 @@ native HTML, XML, and URL-in-text API work. It registers native classes that the
 PHP wrappers can use when the extension is loaded, while preserving PHP-only
 fallback behavior when it is unavailable or explicitly disabled.
 
+Public docs and releases:
+
+- User-facing overview: <https://wordpress.github.io/php-toolkit/native-apis.html>
+- Playground release index: <https://wordpress.github.io/php-toolkit/wp_native_apis-wasm-extension/>
+- Latest Playground smoke test: <https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json>
+
 ## Native Classes
 
 - `WP_HTML_Native_Tag_Processor`


### PR DESCRIPTION
## What it does

Makes the experimental Native APIs extension visible from the main docs path instead of leaving it buried in implementation notes.

The README and GitHub Pages now point users to:

- a public `docs/native-apis.html` landing page;
- a `Test in Playground` flow for the PHP.wasm extension manifest;
- the generated Playground extension release index;
- the lower-level extension README for build details.

## Rationale

The Native APIs extension is a performance preview for HTML, XML, and URL-in-text workloads, but the previous release page was mostly an artifact table. Users needed a clear explanation of what is accelerated, what is experimental, and how host PHP differs from the PHP.wasm Playground shim.

This keeps pure-PHP behavior as the default-safe path while making the optional native path easier to evaluate.

## Implementation

Adds a user-facing Native APIs docs page and links it from the docs nav, homepage cards, learn pages, and reference pages.

Reworks `.github/workflows/native-apis-playground-extension.yml` so the generated Pages release index includes:

- a latest-release hero and `Test in Playground` CTA;
- manifest, checksum, commit, workflow, PHP version, and artifact links;
- immutable commit-specific manifests and Blueprint URLs;
- backward-compatible `releases.json` entries with optional benchmark fields;
- benchmark cards generated from a new host-extension benchmark summary.

Adds `bin/summarize-native-api-benchmark.php` and a CI benchmark job that builds the host extension, runs `bin/benchmark-native-apis.php --iterations=50 --mode=both --disable-native-defaults --require-native`, and publishes raw plus summarized benchmark JSON.

Also fixes two deterministic Blueprint test failures that showed up in CI:

- old-PHP jobs now pin Blueprint step tests to WordPress `6.6.2` instead of latest WordPress;
- the plugin install test loads `wp-admin/includes/plugin.php` before calling `get_plugins()`.

## Testing instructions

Already run locally:

```bash
composer install
php bin/build-reference.php
php -l bin/build-reference.php
php -l bin/summarize-native-api-benchmark.php
vendor/bin/phpcs -d memory_limit=1G bin/build-reference.php bin/summarize-native-api-benchmark.php -n
php bin/summarize-native-api-benchmark.php # with representative benchmark JSON
php bin/benchmark-native-apis.php --iterations=1 --component=url --mode=php
vendor/bin/phpunit components/Blueprints/Tests/Unit/Steps/WriteFilesStepTest.php
vendor/bin/phpunit components/Blueprints/Tests/Unit/Steps/InstallPluginStepTest.php
```

Also verified workflow YAML parsing, extracted workflow Node heredocs with `node --check`, simulated release-page generation with fake release/benchmark data, and ran `git diff --check`.

CI is green on the PR. `Publish static extension bundle to GitHub Pages` is skipped on PRs and should run after merging to `trunk`.
