### PR TITLE
Move Native APIs speed claim to docs

### DIFF
--- a/.github/workflows/native-apis-playground-extension.yml
+++ b/.github/workflows/native-apis-playground-extension.yml
@@ -39,6 +39,8 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
+    env:
+      PHP_WASM_VERSIONS: '8.0,8.1,8.2,8.3,8.4,8.5'
 
     steps:
       - uses: actions/checkout@v4
@@ -80,19 +82,30 @@ jobs:
           if (manifest.mode !== 'php-extension') {
             throw new Error(`Unexpected manifest mode: ${manifest.mode}`);
           }
-          if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length !== 1) {
-            throw new Error('Expected one PHP 8.4 artifact.');
+          const expectedPhpVersions = process.env.PHP_WASM_VERSIONS.split(',').map((version) => version.trim()).filter(Boolean);
+          if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length !== expectedPhpVersions.length) {
+            throw new Error(`Expected PHP.wasm artifacts for ${expectedPhpVersions.join(', ')}.`);
           }
+          const seenPhpVersions = new Set();
           for (const artifact of manifest.artifacts) {
-            if (artifact.phpVersion !== '8.4' || !artifact.sourcePath) {
+            if (!artifact || typeof artifact.phpVersion !== 'string' || !expectedPhpVersions.includes(artifact.phpVersion) || !artifact.sourcePath) {
               throw new Error(`Invalid artifact entry: ${JSON.stringify(artifact)}`);
             }
+            if (seenPhpVersions.has(artifact.phpVersion)) {
+              throw new Error(`Duplicate artifact for PHP ${artifact.phpVersion}.`);
+            }
+            seenPhpVersions.add(artifact.phpVersion);
             if ('file' in artifact || 'sha256' in artifact) {
               throw new Error(`Manifest uses retired pre-PR-3580 fields: ${JSON.stringify(artifact)}`);
             }
             const artifactPath = path.join(root, artifact.sourcePath);
             if (!fs.existsSync(artifactPath)) {
               throw new Error(`Manifest references missing artifact: ${artifactPath}`);
+            }
+          }
+          for (const phpVersion of expectedPhpVersions) {
+            if (!seenPhpVersions.has(phpVersion)) {
+              throw new Error(`Missing artifact for PHP ${phpVersion}.`);
             }
           }
           NODE
@@ -290,6 +303,12 @@ jobs:
               .replace(/"/g, '&quot;');
           }
 
+          function comparePhpVersions(left, right) {
+            const leftParts = String(left).split('.').map((part) => Number.parseInt(part, 10) || 0);
+            const rightParts = String(right).split('.').map((part) => Number.parseInt(part, 10) || 0);
+            return (leftParts[0] - rightParts[0]) || (leftParts[1] - rightParts[1]);
+          }
+
           function lastPublishedAt(relativeManifestPath) {
             try {
               return childProcess.execFileSync(
@@ -413,16 +432,16 @@ jobs:
               const benchmarkSummaryPath = path.join(root, version, 'benchmarks', 'benchmark-summary.json');
               const benchmarkSummary = readJson(benchmarkSummaryPath, null);
               const blueprintUrl = `https://raw.githubusercontent.com/${repository}/${version}/extensions/native-apis/playground/blueprint.json`;
-              const phpVersion = Array.isArray(manifest.artifacts) && manifest.artifacts[0] && manifest.artifacts[0].phpVersion
-                ? manifest.artifacts[0].phpVersion
-                : '8.4';
+              const playgroundUrl = (phpVersion) => `https://playground.wordpress.net/?php=${encodeURIComponent(phpVersion)}&php-extension=${encodeURIComponent(manifestUrl)}&blueprint-url=${encodeURIComponent(blueprintUrl)}`;
               const artifacts = Array.isArray(manifest.artifacts)
                 ? manifest.artifacts.map((artifact) => ({
                     phpVersion: artifact.phpVersion,
                     sourcePath: artifact.sourcePath,
                     url: `${rootUrl}/${version}/${artifact.sourcePath}`,
-                  }))
+                    testInPlayground: playgroundUrl(artifact.phpVersion),
+                  })).sort((left, right) => comparePhpVersions(left.phpVersion, right.phpVersion))
                 : [];
+              const preferredArtifact = artifacts[artifacts.length - 1] || null;
 
               return {
                 version,
@@ -447,7 +466,7 @@ jobs:
                 benchmarkSummary: benchmarkSummary && Array.isArray(benchmarkSummary.top)
                   ? benchmarkSummary.top
                   : existing.benchmarkSummary || [],
-                testInPlayground: `https://playground.wordpress.net/?php=${encodeURIComponent(phpVersion)}&php-extension=${encodeURIComponent(manifestUrl)}&blueprint-url=${encodeURIComponent(blueprintUrl)}`,
+                testInPlayground: preferredArtifact ? preferredArtifact.testInPlayground : '',
               };
             })
             .sort((a, b) => {
@@ -501,11 +520,18 @@ jobs:
           }
 
           function renderArtifactLinks(release) {
+            const artifacts = Array.isArray(release.artifacts) ? release.artifacts : [];
+            const testLinks = artifacts.map((artifact) =>
+              `<a href="${escapeHtml(artifact.testInPlayground)}">PHP ${escapeHtml(artifact.phpVersion)}</a>`
+            ).join(', ');
+            const downloadLinks = artifacts.map((artifact) =>
+              `<a href="${escapeHtml(artifact.url)}">PHP ${escapeHtml(artifact.phpVersion)}</a>`
+            ).join(', ');
+
             return [
               `<a href="${escapeHtml(release.manifest)}">Manifest</a>`,
-              Array.isArray(release.artifacts) && release.artifacts[0]
-                ? `<a href="${escapeHtml(release.artifacts[0].url)}">Download .so</a>`
-                : '',
+              testLinks ? `Test: ${testLinks}` : '',
+              downloadLinks ? `Download: ${downloadLinks}` : '',
               `<a href="${escapeHtml(release.checksums)}">SHA256</a>`,
             ].filter(Boolean).join(' · ');
           }
@@ -516,7 +542,7 @@ jobs:
               <td><span>${escapeHtml(formatDate(release.publishedAt))}</span><br>${index === 0 ? '<span class="badge">Latest</span>' : ''}</td>
               <td>${escapeHtml(release.phpVersions.join(', ') || 'unknown')}</td>
               <td>${renderBenchmarkSummary(release)}</td>
-              <td><a href="${escapeHtml(release.testInPlayground)}">Test in Playground web</a> · ${renderArtifactLinks(release)}</td>
+              <td>${release.testInPlayground ? `<a href="${escapeHtml(release.testInPlayground)}">Test latest PHP</a> · ` : ''}${renderArtifactLinks(release)}</td>
             </tr>
           `).join('');
 
@@ -664,10 +690,10 @@ jobs:
             </header>
             <main>
               <section class="hero">
-                <h1>10x the php-toolkit speed</h1>
+                <h1>Native APIs Playground releases</h1>
                 <p>
-                  <strong>The <code>wp_native_apis</code> PHP extension implements the hot <code>php-toolkit</code> code paths in Rust.</strong>
-                  Install it and enjoy the native speed of <code>WP_HTML_Processor</code>, <code>XMLProcessor</code>, <code>URLInTextProcessor</code> and other classes!
+                  Published PHP.wasm builds of the experimental <code>wp_native_apis</code> extension for WordPress Playground.
+                  Use this page to test the latest build, pin an immutable manifest, or inspect release artifacts.
                 </p>
                 <div class="cta-row">
                   ${latestRelease ? `<a class="button primary" href="${escapeHtml(latestRelease.testInPlayground)}">Test in Playground →</a>` : ''}
@@ -676,7 +702,7 @@ jobs:
               </section>
 
               <section>
-                <h2>WASM Builds for Playground Web and CLI</h2>
+                <h2>PHP.wasm builds for Playground Web and CLI</h2>
               </section>
 
               <section>
@@ -684,7 +710,7 @@ jobs:
                   <thead>
                     <tr>
                       <th>Released on</th>
-                      <th>Supported PHP versions</th>
+                      <th>Playground PHP versions</th>
                       <th>CI speed snapshot</th>
                       <th>Links</th>
                     </tr>

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The toolkit now publishes an experimental Native APIs extension for performance-
 
 - [Native APIs docs](https://wordpress.github.io/php-toolkit/native-apis.html) explain what is accelerated and how the fallback model works.
 - [Compile the host PHP extension](https://wordpress.github.io/php-toolkit/native-php-extension.html) when you want to benchmark the Rust-backed implementation locally.
-- [Test the latest PHP.wasm extension in WordPress Playground](https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json).
-- [Browse Playground extension releases](https://wordpress.github.io/php-toolkit/wp_native_apis-wasm-extension/) for manifests, checksums, immutable test links, and benchmark summaries.
+- [Test the latest PHP.wasm extension in WordPress Playground](https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json).
+- [Browse Playground extension releases](https://wordpress.github.io/php-toolkit/wp_native_apis-wasm-extension/) for manifests, checksums, PHP 8.0–8.5 test links, and benchmark summaries.
 - [Read the extension README](extensions/native-apis/README.md) for lower-level design notes and release checklists.
 
 ### Components

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -844,7 +844,13 @@ ol.chapters span { display: block; color: var(--muted); font-size: 0.93rem; }
 }
 
 .native-hero {
-	padding: 0 0 1rem;
+	padding: 0 0 0.5rem;
+}
+
+.native-hero .lede {
+	font-size: 1.18rem;
+	line-height: 1.55;
+	max-width: 62rem;
 }
 
 .eyebrow {
@@ -892,6 +898,29 @@ ol.chapters span { display: block; color: var(--muted); font-size: 0.93rem; }
 	background: color-mix(in srgb, var(--code-bg) 55%, transparent);
 }
 
+.native-quick-start .quick-card {
+	padding: clamp(1.1rem, 2.5vw, 1.6rem);
+}
+
+.native-quick-start .primary-card {
+	border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+	background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+}
+
+.native-quick-start pre,
+.native-benchmarks pre {
+	overflow-x: auto;
+	background: var(--code-bg);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	padding: 1rem;
+}
+
+.native-quick-start pre code,
+.native-benchmarks pre code {
+	white-space: pre;
+}
+
 .native-grid article p {
 	margin: 0.4rem 0 0.7rem;
 	color: var(--muted);
@@ -902,16 +931,10 @@ ol.chapters span { display: block; color: var(--muted); font-size: 0.93rem; }
 	background: color-mix(in srgb, #f59e0b 10%, var(--bg));
 }
 
-.native-test ol {
-	padding-left: 1.3rem;
-}
-
-.native-benchmarks pre {
-	overflow-x: auto;
-	background: var(--code-bg);
-	border: 1px solid var(--border);
-	border-radius: 8px;
-	padding: 1rem;
+.callout.success {
+	margin-top: 1rem;
+	border-color: color-mix(in srgb, #10b981 40%, var(--border));
+	background: color-mix(in srgb, #10b981 8%, var(--bg));
 }
 
 @media (max-width: 760px) {

--- a/docs/native-apis.html
+++ b/docs/native-apis.html
@@ -22,77 +22,79 @@
 
 <section class="native-hero">
 	<p class="eyebrow">Experimental performance preview</p>
-	<h1>Native APIs for the hottest toolkit paths.</h1>
-	<p class="lede">The Native APIs extension registers PHP extension classes for high-volume HTML, XML, and URL-in-text workloads. Public toolkit classes keep their PHP fallback behavior, so projects can try native acceleration without making the extension a hard dependency.</p>
-	<div class="cta-row">
-		<a class="cta primary" href="https://playground.wordpress.net/?php=8.4&amp;php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&amp;blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json">Test in Playground →</a>
-		<a class="cta" href="wp_native_apis-wasm-extension/">Browse releases</a>
-		<a class="cta" href="native-php-extension.html">Compile for native PHP</a>
-	</div>
+	<h1>10x the php-toolkit speed</h1>
+	<p class="lede">Try the experimental <code>wp_native_apis</code> extension in WordPress Playground first. It loads before PHP starts, confirms the WASM extension was registered, and shows quick browser-side timing numbers for hot HTML, XML, and URL-in-text paths.</p>
 </section>
 
-<section class="native-status">
-	<h2>Status</h2>
-	<div class="callout warning">
-		<strong>Experimental:</strong> the extension is useful for testing and benchmarking, but the packaging, release cadence, and accelerated surface are still evolving. Use immutable release manifests for reproducible Playground links.
+<section class="native-quick-start">
+	<h2>Quick start</h2>
+	<div class="native-grid two">
+		<article class="quick-card primary-card">
+			<h3>Try in Playground web</h3>
+			<p>Open a ready-made Playground that loads the latest PHP.wasm manifest with <code>php-extension</code>, installs the smoke-test Blueprint, and lands on <code>/native-api-smoke.php</code>.</p>
+			<p><a class="cta primary" href="https://playground.wordpress.net/?php=8.5&amp;php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&amp;blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json">Test in Playground →</a></p>
+		</article>
+		<article class="quick-card">
+			<h3>Try in Playground CLI</h3>
+			<p>Use the same manifest locally. The extension flag must be passed before PHP starts.</p>
+			<pre><code>npx @wp-playground/cli@latest server \
+  --php=8.5 \
+  --php-extension=https://wordpress.github.io/php-toolkit/wp_native_apis-wasm-extension/latest/manifest.json \
+  --blueprint=https://raw.githubusercontent.com/WordPress/php-toolkit/trunk/extensions/native-apis/playground/blueprint.json</code></pre>
+		</article>
 	</div>
-	<p>When the extension is loaded before the toolkit, wrappers may delegate covered operations to native classes. If the extension is missing, incompatible, or disabled with <code>WP_NATIVE_APIS_DISABLE_DEFAULTS</code>, the same public APIs continue through pure PHP implementations.</p>
+	<div class="callout success">
+		<strong>What you should see:</strong> the Playground page says <code>wp_native_apis WASM extension loaded</code>, then shows whether native classes are available and a few quick timing cards.
+	</div>
 </section>
 
 <section class="native-grid-section">
-	<h2>What it accelerates</h2>
+	<h2>What this accelerates</h2>
 	<div class="native-grid">
 		<article>
 			<h3>HTML</h3>
-			<p>Fast tag scans, fragment parsing, batch queries, and aggregate audits for common <code>WP_HTML_Tag_Processor</code> and fragment-processor workloads.</p>
+			<p>Fast scans and aggregate checks for common <code>WP_HTML_Tag_Processor</code> and fragment-processor workloads.</p>
 			<a href="reference/html.html">HTML reference →</a>
 		</article>
 		<article>
 			<h3>XML</h3>
-			<p>Streaming XML token, tag, namespace, attribute, and inventory summaries for export-sized documents without building a DOM tree.</p>
+			<p>Streaming XML token, tag, namespace, attribute, and inventory summaries without building a DOM tree.</p>
 			<a href="reference/xml.html">XML reference →</a>
 		</article>
 		<article>
 			<h3>URL-in-text</h3>
-			<p>A native candidate scanner for plain-text URL detection, while public URL handling still validates candidates through the existing WHATWG parser path.</p>
+			<p>A native candidate scanner for plain-text URL detection, with public URL handling still validating through the existing parser path.</p>
 			<a href="reference/dataliberation.html">DataLiberation reference →</a>
 		</article>
 	</div>
 </section>
 
-<section class="native-grid-section">
-	<h2>Two release targets</h2>
-	<div class="native-grid two">
-		<article>
-			<h3>Host PHP extension</h3>
-			<p>The Rust-backed extension is built with <code>ext-php-rs</code> for a specific host PHP ABI. A Linux PHP 8.3 build cannot be reused for PHP 8.4 or PHP 8.5.</p>
-			<p><a href="native-php-extension.html">Build and verify locally →</a></p>
-		</article>
-		<article>
-			<h3>PHP.wasm extension for Playground</h3>
-			<p>Browser Playground loads a PHP.wasm side module through the <code>php-extension</code> URL parameter before PHP starts. The current Playground bundle is a smoke-testable extension path and should not be described as full Rust-backed host parity.</p>
-			<p><a href="wp_native_apis-wasm-extension/">Open release index →</a></p>
-		</article>
+<section class="native-status">
+	<h2>Status and fallback behavior</h2>
+	<div class="callout warning">
+		<strong>Experimental:</strong> the packaging, release cadence, and accelerated surface are still evolving. The PHP Toolkit APIs remain safe to use without the extension.
 	</div>
+	<p>When <code>wp_native_apis</code> is loaded before the toolkit, wrappers may delegate covered operations to native classes. If the extension is missing, incompatible, or disabled with <code>WP_NATIVE_APIS_DISABLE_DEFAULTS</code>, the same public APIs continue through pure-PHP implementations.</p>
 </section>
 
-<section class="native-test">
-	<h2>Test the latest Playground build</h2>
-	<p>The smoke-test Blueprint writes a small PHP landing page into WordPress Playground. It checks that the native classes were registered before PHP started, runs a few representative operations, and shows quick browser-side timing numbers.</p>
-	<ol>
-		<li>Open the Playground URL with <code>php=8.4</code> and the latest <code>wp_native_apis</code> manifest.</li>
-		<li>Wait for the Blueprint to open <code>/native-api-smoke.php</code>.</li>
-		<li>Confirm the page says <code>wp_native_apis WASM extension loaded</code>, then review the timing cards.</li>
-	</ol>
-	<p><a class="cta primary" href="https://playground.wordpress.net/?php=8.4&amp;php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&amp;blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json">Test in Playground →</a></p>
+<section class="native-releases">
+	<h2>Playground releases</h2>
+	<p>The release index is for pinned manifests, checksums, and exact Playground links. Use <code>latest</code> for a quick trial; use a commit-specific manifest when you need a reproducible demo.</p>
+	<p><a class="cta" href="wp_native_apis-wasm-extension/">Browse Playground releases →</a></p>
 </section>
 
 <section class="native-benchmarks">
 	<h2>Benchmarks</h2>
-	<p>The release workflow also builds the host Rust-backed extension and runs the repository benchmark harness against the same workloads in PHP and native modes. The release page publishes raw JSON plus a summarized view with wall-clock speedups.</p>
+	<p>The 10x claim comes from CI benchmark snapshots for the host Rust-backed extension. Playground is the easiest way to see that the extension loads and to get quick browser-side timing numbers; host PHP benchmarks are the better signal for Rust-backed throughput.</p>
 	<pre><code>php -d extension=extensions/native-apis/target/release/libwp_native_apis.so \
 	bin/benchmark-native-apis.php --iterations=50 --mode=both --disable-native-defaults --require-native</code></pre>
 	<p>Benchmark numbers are machine- and workflow-run-specific. Treat them as directional evidence for which workflows benefit from native batching, not as universal throughput guarantees.</p>
+</section>
+
+<section class="native-build-secondary">
+	<h2>Compile for native PHP</h2>
+	<p>After trying Playground, build the Rust-backed extension for your local host PHP ABI when you want the real native implementation and benchmark numbers. A build made for one PHP ABI cannot be reused for another.</p>
+	<p><a class="cta" href="native-php-extension.html">Build the native PHP extension →</a></p>
 </section>
 
 </main>

--- a/extensions/native-apis/README.md
+++ b/extensions/native-apis/README.md
@@ -9,7 +9,7 @@ Public docs and releases:
 
 - User-facing overview: <https://wordpress.github.io/php-toolkit/native-apis.html>
 - Playground release index: <https://wordpress.github.io/php-toolkit/wp_native_apis-wasm-extension/>
-- Latest Playground smoke test: <https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json>
+- Latest Playground smoke test: <https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json>
 
 ## Native Classes
 
@@ -216,6 +216,14 @@ by `build-playground-extension.sh` before claiming Playground support:
 extensions/native-apis/build-playground-extension.sh
 ```
 
+By default this builds one side module per Playground PHP 8.x runtime from
+PHP 8.0 through PHP 8.5. To build a smaller local matrix, pass a comma-separated
+list:
+
+```bash
+PHP_WASM_VERSIONS=8.3,8.4 extensions/native-apis/build-playground-extension.sh
+```
+
 The host PHP extension is Rust-backed through `ext-php-rs`. The Playground
 bundle currently uses `native_apis_shim.c` instead, because Playground's
 PHP.wasm runtime only exports the PHP C ABI symbols needed by regular C
@@ -261,11 +269,15 @@ wp_native_apis-wasm-extension/
 |-- latest/
 |   |-- manifest.json
 |   |-- SHA256SUMS
-|   `-- wp_native_apis-php8.4-jspi.so
+|   |-- wp_native_apis-php8.0-jspi.so
+|   |-- ...
+|   `-- wp_native_apis-php8.5-jspi.so
 `-- <commit-sha>/
     |-- manifest.json
     |-- SHA256SUMS
-    `-- wp_native_apis-php8.4-jspi.so
+    |-- wp_native_apis-php8.0-jspi.so
+    |-- ...
+    `-- wp_native_apis-php8.5-jspi.so
 ```
 
 When the workflow first sees older SHA-named directories in the release-history
@@ -279,17 +291,18 @@ Use the Blueprint smoke test together with the Playground Query API
 extensions load before PHP starts; the Blueprint only writes and runs the smoke
 test.
 
-After publishing the PHP.wasm `manifest.json`, open the main Playground URL with
-both the extension manifest and the Blueprint URL:
+After publishing the PHP.wasm `manifest.json`, open the main Playground URL
+with a PHP version included in the manifest, the extension manifest, and the
+Blueprint URL:
 
 ```text
-https://playground.wordpress.net/?php=8.4&php-extension=<url-encoded-manifest-url>&blueprint-url=<url-encoded-blueprint-url>
+https://playground.wordpress.net/?php=8.5&php-extension=<url-encoded-manifest-url>&blueprint-url=<url-encoded-blueprint-url>
 ```
 
 For example, a release URL will look like:
 
 ```text
-https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json
+https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json
 ```
 
 Expected output:

--- a/extensions/native-apis/build-playground-extension.sh
+++ b/extensions/native-apis/build-playground-extension.sh
@@ -4,21 +4,20 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../.." && pwd)"
 
-php_versions="${PHP_WASM_VERSIONS:-8.4}"
-php_version="${php_versions%%,*}"
+php_versions="${PHP_WASM_VERSIONS:-8.0,8.1,8.2,8.3,8.4,8.5}"
 out_dir="${1:-${repo_root}/build/wp_native_apis-wasm-extension}"
 
 cd "${repo_root}"
 
 npx --yes @php-wasm/compile-extension \
 	--prepare-image \
-	--php-versions "${php_version}" \
+	--php-versions "${php_versions}" \
 	--jobs 1
 
 npx --yes @php-wasm/compile-extension \
 	--source ./extensions/native-apis \
 	--name wp_native_apis \
-	--php-versions "${php_version}" \
+	--php-versions "${php_versions}" \
 	--out "${out_dir}" \
 	--jobs 1
 

--- a/extensions/native-apis/native_apis_shim.c
+++ b/extensions/native-apis/native_apis_shim.c
@@ -24,6 +24,7 @@ static zend_class_entry *wp_native_xml_processor_ce;
 static zend_class_entry *wp_native_url_processor_ce;
 static zend_object_handlers wp_native_smoke_object_handlers;
 
+
 static zend_bool
 wp_native_ascii_is_space( char c ) {
 	return ' ' == c || '\t' == c || '\n' == c || '\r' == c || '\f' == c;
@@ -621,19 +622,19 @@ PHP_MINIT_FUNCTION( wp_native_apis ) {
 	wp_native_smoke_object_handlers.clone_obj = NULL;
 
 	INIT_CLASS_ENTRY( class_entry, "WP_HTML_Native_Tag_Processor", wp_native_html_tag_processor_methods );
-	wp_native_html_tag_processor_ce                = zend_register_internal_class_with_flags( &class_entry, NULL, 0 );
+	wp_native_html_tag_processor_ce                = zend_register_internal_class_ex( &class_entry, NULL );
 	wp_native_html_tag_processor_ce->create_object = wp_native_smoke_create_object;
 
 	INIT_CLASS_ENTRY( class_entry, "WP_HTML_Native_Processor", wp_native_html_processor_methods );
-	wp_native_html_processor_ce                = zend_register_internal_class_with_flags( &class_entry, NULL, 0 );
+	wp_native_html_processor_ce                = zend_register_internal_class_ex( &class_entry, NULL );
 	wp_native_html_processor_ce->create_object = wp_native_smoke_create_object;
 
 	INIT_NS_CLASS_ENTRY( class_entry, "WordPress\\XML", "NativeXMLProcessor", wp_native_xml_processor_methods );
-	wp_native_xml_processor_ce                = zend_register_internal_class_with_flags( &class_entry, NULL, 0 );
+	wp_native_xml_processor_ce                = zend_register_internal_class_ex( &class_entry, NULL );
 	wp_native_xml_processor_ce->create_object = wp_native_smoke_create_object;
 
 	INIT_NS_CLASS_ENTRY( class_entry, "WordPress\\DataLiberation\\URL", "NativeURLInTextProcessor", wp_native_url_processor_methods );
-	wp_native_url_processor_ce                = zend_register_internal_class_with_flags( &class_entry, NULL, 0 );
+	wp_native_url_processor_ce                = zend_register_internal_class_ex( &class_entry, NULL );
 	wp_native_url_processor_ce->create_object = wp_native_smoke_create_object;
 
 	return SUCCESS;


### PR DESCRIPTION
## Summary
- move the “10x the php-toolkit speed” claim onto the public Native APIs docs page
- restructure `native-apis.html` around a Playground-first quick start, with Playground web/CLI instructions and expected smoke-test output
- make native PHP compilation secondary, while keeping links to pinned Playground releases and benchmark context
- simplify the generated Playground release page so it talks about releases, manifests, and artifacts instead of carrying the marketing pitch
- publish/update Playground links for the PHP.wasm release matrix across PHP 8.0–8.5
- keep the Playground C shim compatible with PHP 8.0 while compiling the wider PHP.wasm matrix

## Validation
- workflow YAML parses with Python
- extracted workflow `node <<'NODE'` scripts pass `node --check`
- `php bin/build-reference.php`
- `git diff --check`
- `composer lint` was run locally; it exits non-zero on pre-existing warnings in unchanged PHP files
