### PR TITLE
Rename Playground release copy

### DIFF
--- a/.github/workflows/native-apis-playground-extension.yml
+++ b/.github/workflows/native-apis-playground-extension.yml
@@ -690,7 +690,7 @@ jobs:
             </header>
             <main>
               <section class="hero">
-                <h1>Native APIs Playground releases</h1>
+                <h1>Native APIs WASM releases for Playground</h1>
                 <p>
                   Published PHP.wasm builds of the experimental <code>wp_native_apis</code> extension for WordPress Playground.
                   Use this page to test the latest build, pin an immutable manifest, or inspect release artifacts.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Standalone, dependency-free PHP libraries for use in WordPress plugins and stand
 
 ### Experimental Native APIs extension
 
-The toolkit now publishes an experimental Native APIs extension for performance-sensitive HTML, XML, and URL-in-text workloads. Public PHP APIs keep their pure-PHP fallback behavior when the extension is absent, incompatible, or disabled with `WP_NATIVE_APIS_DISABLE_DEFAULTS`.
+The toolkit now publishes an experimental Native APIs extension for performance-sensitive `WP_HTML_Tag_Processor`, `XMLProcessor`, and `URLInTextProcessor` workloads. Public PHP APIs keep their pure-PHP fallback behavior when the extension is absent, incompatible, or disabled with `WP_NATIVE_APIS_DISABLE_DEFAULTS`.
 
-- [Native APIs docs](https://wordpress.github.io/php-toolkit/native-apis.html) explain what is accelerated and how the fallback model works.
+- [Native APIs docs](https://wordpress.github.io/php-toolkit/native-apis.html) explain which APIs are accelerated and how the fallback model works.
 - [Compile the host PHP extension](https://wordpress.github.io/php-toolkit/native-php-extension.html) when you want to benchmark the Rust-backed implementation locally.
 - [Test the latest PHP.wasm extension in WordPress Playground](https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fwordpress.github.io%2Fphp-toolkit%2Fwp_native_apis-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fphp-toolkit%2Ftrunk%2Fextensions%2Fnative-apis%2Fplayground%2Fblueprint.json).
-- [Browse Playground extension releases](https://wordpress.github.io/php-toolkit/wp_native_apis-wasm-extension/) for manifests, checksums, PHP 8.0–8.5 test links, and benchmark summaries.
+- [Browse WASM releases for Playground](https://wordpress.github.io/php-toolkit/wp_native_apis-wasm-extension/) for manifests, checksums, PHP 8.0–8.5 test links, and benchmark summaries.
 - [Read the extension README](extensions/native-apis/README.md) for lower-level design notes and release checklists.
 
 ### Components

--- a/docs/native-apis.html
+++ b/docs/native-apis.html
@@ -78,9 +78,9 @@
 </section>
 
 <section class="native-releases">
-	<h2>Playground releases</h2>
+	<h2>WASM releases for Playground</h2>
 	<p>The release index is for pinned manifests, checksums, and exact Playground links. Use <code>latest</code> for a quick trial; use a commit-specific manifest when you need a reproducible demo.</p>
-	<p><a class="cta" href="wp_native_apis-wasm-extension/">Browse Playground releases →</a></p>
+	<p><a class="cta" href="wp_native_apis-wasm-extension/">Browse WASM releases for Playground →</a></p>
 </section>
 
 <section class="native-benchmarks">

--- a/docs/native-php-extension.html
+++ b/docs/native-php-extension.html
@@ -27,13 +27,13 @@
 	<div class="cta-row">
 		<a class="cta primary" href="#build">Build it →</a>
 		<a class="cta" href="native-apis.html">Native APIs overview</a>
-		<a class="cta" href="wp_native_apis-wasm-extension/">Playground releases</a>
+		<a class="cta" href="wp_native_apis-wasm-extension/">WASM releases for Playground</a>
 	</div>
 </section>
 
 <section>
 	<h2>What you will build</h2>
-	<p>The host PHP extension is the Rust-backed implementation built with <code>ext-php-rs</code>. When it is loaded before the toolkit bootstrap, covered HTML, XML, and URL-in-text classes can delegate hot paths to native code. If the extension is absent, incompatible, or disabled, the public PHP APIs keep using their pure-PHP fallback implementations.</p>
+	<p>The host PHP extension is the Rust-backed implementation built with <code>ext-php-rs</code>. When it is loaded before the toolkit bootstrap, covered <code>WP_HTML_Tag_Processor</code>, <code>XMLProcessor</code>, and <code>URLInTextProcessor</code> classes can delegate hot paths to native code. If the extension is absent, incompatible, or disabled, the public PHP APIs keep using their pure-PHP fallback implementations.</p>
 	<div class="callout warning">
 		<strong>Not the Playground build:</strong> WordPress Playground uses a PHP.wasm extension bundle. This page is for native host PHP, such as a local Linux PHP CLI with development headers.
 	</div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -68,7 +68,7 @@
 
 <section class="ref-group native-promo">
 	<h2>Experimental Native APIs</h2>
-	<p>Testing the native extension? The Native APIs page explains the accelerated HTML, XML, and URL-in-text paths, links to Playground releases, and shows benchmark summaries from CI.</p>
+	<p>Testing the native extension? The Native APIs page explains the accelerated <code>WP_HTML_Tag_Processor</code>, <code>XMLProcessor</code>, and <code>URLInTextProcessor</code> paths, links to WASM releases for Playground, and shows benchmark summaries from CI.</p>
 	<p><a class="cta" href="../native-apis.html">Open Native APIs docs →</a></p>
 </section>
 


### PR DESCRIPTION
## Summary
- rename public “Playground releases” copy to “WASM releases for Playground”
- use concrete Native APIs names in nearby README/docs copy
- update the generated WASM release page heading

## Validation
- `php bin/build-reference.php`
- `git diff --check`
- `composer lint` was run locally; it exits non-zero on pre-existing warnings in unchanged PHP files