### PR TITLE
Add Svn component: a pure-PHP Subversion client

### DIFF
--- a/components/Svn/LICENSE.md
+++ b/components/Svn/LICENSE.md
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/components/Svn/Protocol/class-davsession.php
+++ b/components/Svn/Protocol/class-davsession.php
@@ -1,0 +1,865 @@
+<?php
+
+namespace WordPress\Svn\Protocol;
+
+use WordPress\ByteStream\MemoryPipe;
+use WordPress\HttpClient\Client;
+use WordPress\HttpClient\Request;
+use WordPress\Svn\SvnEditor;
+use WordPress\Svn\SvnException;
+use WordPress\Svn\SvnSession;
+use WordPress\XML\XMLProcessor;
+
+/**
+ * Subversion repository access over http:// and https:// (mod_dav_svn).
+ *
+ * Uses Subversion's "HTTP protocol v2", available since Subversion 1.7
+ * (2011). An OPTIONS request discovers the stable URI stubs the server
+ * exposes; everything else is plain HTTP against those stubs:
+ *
+ *  - Reads address `{rev-root-stub}/{revision}/{path}` resources with
+ *    GET and PROPFIND.
+ *  - Checkouts and updates POST an update-report REPORT and stream the
+ *    response (see DavUpdateReportParser).
+ *  - Commits create a server-side transaction (POST create-txn), build
+ *    it with PUT/MKCOL/DELETE/PROPPATCH against the transaction tree,
+ *    and commit it with MERGE.
+ *
+ * Credentials are sent as HTTP Basic authentication. Servers older than
+ * Subversion 1.7 (which lack the v2 stubs) are rejected at connect time.
+ */
+class DavSession implements SvnSession {
+	const SVN_PROP_NAMESPACE    = 'http://subversion.tigris.org/xmlns/svn/';
+	const CUSTOM_PROP_NAMESPACE = 'http://subversion.tigris.org/xmlns/custom/';
+	const SVN_DAV_NAMESPACE     = 'http://subversion.tigris.org/xmlns/dav/';
+	const SVN_APACHE_NAMESPACE  = 'http://apache.org/dav/xmlns';
+	const DAV_NAMESPACE         = 'DAV:';
+
+	/**
+	 * @var Client
+	 */
+	private $http_client;
+
+	/**
+	 * Canonical session URL without credentials.
+	 *
+	 * @var string
+	 */
+	private $url;
+
+	/**
+	 * Scheme plus authority, e.g. "https://develop.svn.wordpress.org".
+	 *
+	 * @var string
+	 */
+	private $server_base;
+
+	/**
+	 * Server-absolute path of the session URL, e.g. "/repos/repo1/trunk".
+	 *
+	 * @var string
+	 */
+	private $session_path;
+
+	/**
+	 * Server-absolute path of the repository root, e.g. "/repos/repo1".
+	 *
+	 * @var string
+	 */
+	private $root_path;
+
+	/**
+	 * Session path relative to the repository root, e.g. "trunk".
+	 *
+	 * @var string
+	 */
+	private $session_relative_path;
+
+	/**
+	 * Server-absolute v2 protocol stubs discovered via OPTIONS.
+	 *
+	 * @var string
+	 */
+	private $me_resource;
+	private $rev_root_stub;
+	private $txn_root_stub;
+	private $txn_stub;
+
+	/**
+	 * @var string
+	 */
+	private $uuid;
+
+	/**
+	 * Youngest revision as of the last OPTIONS exchange.
+	 *
+	 * @var int
+	 */
+	private $youngest_revision;
+
+	/**
+	 * @var string|null
+	 */
+	private $username;
+
+	/**
+	 * @var string|null
+	 */
+	private $password;
+
+	private function __construct() {
+	}
+
+	/**
+	 * Opens a session against an http:// or https:// repository URL.
+	 *
+	 * @param  string $url      Repository URL, e.g. "https://develop.svn.wordpress.org/trunk".
+	 * @param  array  $options  {
+	 *     @type string $username     Username for HTTP Basic authentication.
+	 *     @type string $password     Password for HTTP Basic authentication.
+	 *     @type int    $timeout_ms   Network timeout. Default 60000.
+	 *     @type Client $http_client  A custom HttpClient\Client instance.
+	 * }
+	 * @return DavSession
+	 * @throws SvnException When the URL is invalid or the server does not
+	 *                      speak HTTP protocol v2 (Subversion 1.7+).
+	 */
+	public static function connect( $url, $options = array() ) {
+		$parts = parse_url( $url );
+		if ( false === $parts || ! isset( $parts['scheme'], $parts['host'] ) || ! in_array( $parts['scheme'], array( 'http', 'https' ), true ) ) {
+			throw new SvnException( "Not a valid http(s):// URL: {$url}" );
+		}
+
+		$session              = new DavSession();
+		$session->username    = isset( $options['username'] ) ? $options['username'] : ( isset( $parts['user'] ) ? rawurldecode( $parts['user'] ) : null );
+		$session->password    = isset( $options['password'] ) ? $options['password'] : ( isset( $parts['pass'] ) ? rawurldecode( $parts['pass'] ) : null );
+		$session->server_base = $parts['scheme'] . '://' . $parts['host'] . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' );
+
+		$session->session_path = isset( $parts['path'] ) ? rtrim( $parts['path'], '/' ) : '';
+		$session->url          = $session->server_base . $session->session_path;
+		$session->http_client  = isset( $options['http_client'] ) ? $options['http_client'] : new Client(
+			array(
+				'timeout_ms' => isset( $options['timeout_ms'] ) ? $options['timeout_ms'] : 60000,
+			)
+		);
+
+		$session->discover_capabilities();
+
+		return $session;
+	}
+
+	public function get_session_url() {
+		return $this->url;
+	}
+
+	public function get_repository_root() {
+		return $this->server_base . $this->root_path;
+	}
+
+	public function get_uuid() {
+		return $this->uuid;
+	}
+
+	public function get_latest_revision() {
+		// Re-run the discovery so long-lived sessions see new commits.
+		$this->discover_capabilities();
+
+		return $this->youngest_revision;
+	}
+
+	public function check_path( $path, $revision = null ) {
+		$response = $this->request(
+			'PROPFIND',
+			$this->revision_resource_url( $path, $revision ),
+			array(
+				'Depth'        => '0',
+				'Content-Type' => 'text/xml',
+			),
+			'<?xml version="1.0" encoding="utf-8"?><D:propfind xmlns:D="DAV:"><D:prop><D:resourcetype/></D:prop></D:propfind>',
+			array( 207, 404 )
+		);
+		$status   = $response['response']->status_code;
+		if ( 404 === $status ) {
+			return 'none';
+		}
+
+		$is_directory = false;
+		$xml          = XMLProcessor::create_from_string( $response['body'] );
+		while ( $xml->next_tag() ) {
+			if ( 'collection' === $xml->get_tag_local_name() && self::DAV_NAMESPACE === $xml->get_tag_namespace() ) {
+				$is_directory = true;
+			}
+		}
+
+		return $is_directory ? 'dir' : 'file';
+	}
+
+	public function list_directory( $path, $revision = null ) {
+		$response = $this->request(
+			'PROPFIND',
+			$this->revision_resource_url( $path, $revision ),
+			array(
+				'Depth'        => '1',
+				'Content-Type' => 'text/xml',
+			),
+			'<?xml version="1.0" encoding="utf-8"?><D:propfind xmlns:D="DAV:"><D:prop><D:resourcetype/><D:getcontentlength/><D:version-name/></D:prop></D:propfind>',
+			array( 207 )
+		);
+
+		$entries = array();
+		foreach ( $this->parse_multistatus( $response['body'] ) as $resource ) {
+			if ( $resource['is_self'] ) {
+				continue;
+			}
+			$entries[] = array(
+				'name'        => $resource['name'],
+				'kind'        => $resource['is_collection'] ? 'dir' : 'file',
+				'size'        => isset( $resource['dav_props']['getcontentlength'] ) ? (int) $resource['dav_props']['getcontentlength'] : 0,
+				'created_rev' => isset( $resource['dav_props']['version-name'] ) ? (int) $resource['dav_props']['version-name'] : 0,
+			);
+		}
+
+		return $entries;
+	}
+
+	public function get_file( $path, $revision = null ) {
+		$revision = $this->resolve_revision( $revision );
+		$get      = $this->request( 'GET', $this->revision_resource_url( $path, $revision ), array(), null, array( 200 ) );
+
+		$propfind  = $this->request(
+			'PROPFIND',
+			$this->revision_resource_url( $path, $revision ),
+			array(
+				'Depth'        => '0',
+				'Content-Type' => 'text/xml',
+			),
+			'<?xml version="1.0" encoding="utf-8"?><D:propfind xmlns:D="DAV:"><D:allprop/></D:propfind>',
+			array( 207 )
+		);
+		$resources = $this->parse_multistatus( $propfind['body'] );
+		$resource  = count( $resources ) > 0 ? $resources[0] : array(
+			'svn_props' => array(),
+			'dav_props' => array(),
+		);
+
+		return array(
+			'contents'   => $get['body'],
+			'checksum'   => isset( $resource['dav_props']['md5-checksum'] ) ? $resource['dav_props']['md5-checksum'] : null,
+			'properties' => $resource['svn_props'],
+		);
+	}
+
+	public function get_properties( $path, $revision = null ) {
+		$response  = $this->request(
+			'PROPFIND',
+			$this->revision_resource_url( $path, $revision ),
+			array(
+				'Depth'        => '0',
+				'Content-Type' => 'text/xml',
+			),
+			'<?xml version="1.0" encoding="utf-8"?><D:propfind xmlns:D="DAV:"><D:allprop/></D:propfind>',
+			array( 207 )
+		);
+		$resources = $this->parse_multistatus( $response['body'] );
+
+		return count( $resources ) > 0 ? $resources[0]['svn_props'] : array();
+	}
+
+	public function drive_update( $target_revision, $report, SvnEditor $editor, $options = array() ) {
+		$depth = isset( $options['depth'] ) ? $options['depth'] : 'infinity';
+
+		$body  = '<S:update-report xmlns:S="svn:" send-all="true">';
+		$body .= '<S:src-path>' . $this->escape_xml( $this->session_path ) . '</S:src-path>';
+		$body .= '<S:target-revision>' . (int) $target_revision . '</S:target-revision>';
+		$body .= '<S:depth>' . $this->escape_xml( $depth ) . '</S:depth>';
+		$body .= '<S:include-props>yes</S:include-props>';
+		foreach ( $report as $report_entry ) {
+			$entry_depth = isset( $report_entry['depth'] ) ? $report_entry['depth'] : 'infinity';
+			$body       .= '<S:entry rev="' . (int) $report_entry['revision'] . '" depth="' . $this->escape_xml( $entry_depth ) . '"';
+			if ( ! empty( $report_entry['start_empty'] ) ) {
+				$body .= ' start-empty="true"';
+			}
+			$body .= '>' . $this->escape_xml( $report_entry['path'] ) . '</S:entry>';
+		}
+		$body .= '</S:update-report>';
+
+		$request = new Request(
+			$this->server_base . $this->me_resource,
+			array(
+				'method'      => 'REPORT',
+				'headers'     => $this->build_headers(
+					array(
+						'Content-Type' => 'text/xml',
+						'Depth'        => '0',
+					)
+				),
+				'body_stream' => new MemoryPipe( $body ),
+			)
+		);
+
+		$stream   = $this->http_client->fetch( $request );
+		$response = $stream->await_response();
+		if ( 200 !== $response->status_code ) {
+			throw $this->error_from_response( 'REPORT', $this->server_base . $this->me_resource, $response->status_code, $stream->consume_all() );
+		}
+
+		$parser = new DavUpdateReportParser( $editor );
+		while ( ! $stream->reached_end_of_data() ) {
+			$pulled = $stream->pull( 65536 );
+			if ( 0 === $pulled ) {
+				continue;
+			}
+			$parser->append_bytes( $stream->consume( $pulled ) );
+		}
+		$parser->finish();
+	}
+
+	public function commit( $message, $operations ) {
+		$transaction_name = $this->create_transaction();
+		try {
+			$this->set_transaction_property( $transaction_name, 'svn:log', $message );
+
+			// Deletes go first so replaced paths drive correctly, parents
+			// before children so MKCOL works, all sorted for determinism.
+			$sorted = $operations;
+			usort(
+				$sorted,
+				function ( $a, $b ) {
+					$a_is_delete = 'delete' === $a['op'] ? 0 : 1;
+					$b_is_delete = 'delete' === $b['op'] ? 0 : 1;
+					if ( $a_is_delete !== $b_is_delete ) {
+						return $a_is_delete - $b_is_delete;
+					}
+
+					return strcmp( $a['path'], $b['path'] );
+				}
+			);
+
+			foreach ( $sorted as $operation ) {
+				$this->apply_commit_operation( $transaction_name, $operation );
+			}
+
+			return $this->merge_transaction( $transaction_name );
+		} catch ( SvnException $exception ) {
+			$this->abort_transaction( $transaction_name );
+			throw $exception;
+		}
+	}
+
+	public function close() {
+		// HTTP is stateless; there is nothing to tear down.
+	}
+
+	/**
+	 * Issues the OPTIONS request that discovers the protocol v2 stubs,
+	 * the repository UUID, and the youngest revision.
+	 *
+	 * @throws SvnException When the server does not speak HTTP protocol v2.
+	 */
+	private function discover_capabilities() {
+		$response = $this->request(
+			'OPTIONS',
+			$this->url,
+			array( 'Content-Type' => 'text/xml' ),
+			'<?xml version="1.0" encoding="utf-8"?><D:options xmlns:D="DAV:"><D:activity-collection-set/></D:options>',
+			array( 200 )
+		);
+		$headers  = $response['response'];
+
+		$rev_root_stub = $headers->get_header( 'SVN-Rev-Root-Stub' );
+		$me_resource   = $headers->get_header( 'SVN-Me-Resource' );
+		if ( null === $rev_root_stub || null === $me_resource ) {
+			throw new SvnException(
+				"The server at {$this->url} does not support Subversion's HTTP protocol v2. " .
+				'Servers running Subversion 1.7 (2011) or newer are required.'
+			);
+		}
+
+		$this->rev_root_stub = $rev_root_stub;
+		$this->me_resource   = $me_resource;
+		$this->txn_root_stub = $headers->get_header( 'SVN-Txn-Root-Stub' );
+		$this->txn_stub      = $headers->get_header( 'SVN-Txn-Stub' );
+		$this->uuid          = $headers->get_header( 'SVN-Repository-UUID' );
+
+		$youngest = $headers->get_header( 'SVN-Youngest-Rev' );
+		if ( null !== $youngest ) {
+			$this->youngest_revision = (int) trim( $youngest );
+		}
+
+		// The stubs are server-absolute and always end in "/!svn/<stub>",
+		// which makes them the most reliable way to find the repository
+		// root path – more so than the SVN-Repository-Root header, which
+		// some proxies drop.
+		$stub_position   = strrpos( $rev_root_stub, '/!svn/' );
+		$this->root_path = false === $stub_position ? '' : substr( $rev_root_stub, 0, $stub_position );
+
+		if ( 0 !== strpos( $this->session_path . '/', $this->root_path . '/' ) ) {
+			throw new SvnException( "The session URL {$this->url} lies outside the repository root {$this->server_base}{$this->root_path}." );
+		}
+		$this->session_relative_path = trim( substr( $this->session_path, strlen( $this->root_path ) ), '/' );
+	}
+
+	/**
+	 * Builds the URL of a path at a revision under the rev-root stub.
+	 *
+	 * @param  string   $path      Path relative to the session URL.
+	 * @param  int|null $revision  The revision, or null for the latest.
+	 * @return string The absolute URL.
+	 */
+	private function revision_resource_url( $path, $revision ) {
+		$revision  = $this->resolve_revision( $revision );
+		$full_path = $this->session_relative_path;
+		if ( '' !== $path ) {
+			$full_path = '' === $full_path ? $path : $full_path . '/' . $path;
+		}
+
+		return $this->server_base . $this->rev_root_stub . '/' . $revision . ( '' === $full_path ? '' : '/' . $this->encode_url_path( $full_path ) );
+	}
+
+	private function resolve_revision( $revision ) {
+		if ( null !== $revision ) {
+			return (int) $revision;
+		}
+		if ( null === $this->youngest_revision ) {
+			$this->discover_capabilities();
+		}
+
+		return $this->youngest_revision;
+	}
+
+	/**
+	 * Percent-encodes a path for use in a URL, segment by segment.
+	 *
+	 * @param  string $path  A forward-slash path.
+	 * @return string The encoded path.
+	 */
+	private function encode_url_path( $path ) {
+		$segments = array();
+		foreach ( explode( '/', $path ) as $segment ) {
+			$segments[] = rawurlencode( $segment );
+		}
+
+		return implode( '/', $segments );
+	}
+
+	/**
+	 * Performs a buffered HTTP request.
+	 *
+	 * @param  string      $method            The HTTP method.
+	 * @param  string      $url               The absolute URL.
+	 * @param  array       $headers           Extra request headers.
+	 * @param  string|null $body              The request body, if any.
+	 * @param  int[]       $expected_statuses Status codes that are not errors.
+	 * @return array { @type Response $response  @type string $body }
+	 * @throws SvnException When the response status is unexpected.
+	 */
+	private function request( $method, $url, $headers = array(), $body = null, $expected_statuses = array( 200 ) ) {
+		$request_info = array(
+			'method'  => $method,
+			'headers' => $this->build_headers( $headers ),
+		);
+		if ( null !== $body ) {
+			$request_info['body_stream'] = new MemoryPipe( $body );
+		}
+
+		$stream   = $this->http_client->fetch( new Request( $url, $request_info ) );
+		$response = $stream->await_response();
+		$contents = $stream->consume_all();
+
+		if ( ! in_array( $response->status_code, $expected_statuses, true ) ) {
+			throw $this->error_from_response( $method, $url, $response->status_code, $contents );
+		}
+
+		return array(
+			'response' => $response,
+			'body'     => $contents,
+		);
+	}
+
+	private function build_headers( $headers ) {
+		$headers['User-Agent'] = 'php-toolkit-svn/1.0';
+		if ( null !== $this->username && null !== $this->password ) {
+			$headers['Authorization'] = 'Basic ' . base64_encode( $this->username . ':' . $this->password ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- HTTP Basic authentication.
+		}
+
+		return $headers;
+	}
+
+	/**
+	 * Builds a useful exception from an HTTP error response, surfacing
+	 * the human-readable message mod_dav_svn embeds in error bodies.
+	 *
+	 * @param  string $method       The request method.
+	 * @param  string $url          The request URL.
+	 * @param  int    $status_code  The response status.
+	 * @param  string $body         The response body.
+	 * @return SvnException
+	 */
+	private function error_from_response( $method, $url, $status_code, $body ) {
+		$detail = '';
+		if ( '' !== $body && false !== strpos( $body, 'human-readable' ) ) {
+			$xml = XMLProcessor::create_from_string( $body );
+			while ( $xml->next_tag() ) {
+				if ( 'human-readable' === $xml->get_tag_local_name() ) {
+					$xml->next_token();
+					$detail = trim( $xml->get_modifiable_text() );
+					break;
+				}
+			}
+		}
+		if ( 401 === $status_code && '' === $detail ) {
+			$detail = null === $this->username
+				? 'The server requires authentication. Provide a username and a password.'
+				: 'The server rejected the provided credentials.';
+		}
+
+		return new SvnException(
+			"{$method} {$url} failed with HTTP {$status_code}" . ( '' !== $detail ? ": {$detail}" : '.' )
+		);
+	}
+
+	/**
+	 * Parses a DAV multistatus response.
+	 *
+	 * @param  string $body  The 207 response body.
+	 * @return array[] One entry per resource: {
+	 *     @type string $name           Resource basename ('' for the root).
+	 *     @type bool   $is_self        Whether this is the requested resource itself.
+	 *     @type bool   $is_collection  Whether the resource is a directory.
+	 *     @type array  $svn_props      Versioned svn properties, name => value.
+	 *     @type array  $dav_props      DAV-level properties, local name => value.
+	 * }
+	 */
+	private function parse_multistatus( $body ) {
+		$resources = array();
+		$xml       = XMLProcessor::create_from_string( $body );
+
+		$resource         = null;
+		$first_href       = null;
+		$collecting       = null;
+		$collecting_value = '';
+		$prop_is_base64   = false;
+
+		while ( $xml->next_token() ) {
+			$token_type = $xml->get_token_type();
+			if ( '#text' === $token_type || '#cdata-section' === $token_type ) {
+				if ( null !== $collecting ) {
+					$collecting_value .= $xml->get_modifiable_text();
+				}
+				continue;
+			}
+			if ( '#tag' !== $token_type ) {
+				continue;
+			}
+
+			$xml_namespace = $xml->get_tag_namespace();
+			$local_name    = $xml->get_tag_local_name();
+			// Empty elements such as <D:collection/> report neither
+			// is_tag_opener() nor is_tag_closer(); they act as both.
+			$is_opener = $xml->is_tag_opener() || $xml->is_empty_element();
+			$is_closer = $xml->is_tag_closer() || $xml->is_empty_element();
+
+			if ( self::DAV_NAMESPACE === $xml_namespace && 'response' === $local_name ) {
+				if ( $is_opener && ! $xml->is_empty_element() ) {
+					$resource = array(
+						'href'          => '',
+						'is_collection' => false,
+						'svn_props'     => array(),
+						'dav_props'     => array(),
+					);
+				}
+				if ( $is_closer && null !== $resource ) {
+					if ( null === $first_href ) {
+						$first_href = $resource['href'];
+					}
+					$href                = rtrim( $resource['href'], '/' );
+					$resource['is_self'] = rtrim( $first_href, '/' ) === $href && 0 === count( $resources );
+					$basename            = strrpos( $href, '/' );
+					$resource['name']    = rawurldecode( false === $basename ? $href : substr( $href, $basename + 1 ) );
+					$resources[]         = $resource;
+					$resource            = null;
+				}
+				continue;
+			}
+			if ( null === $resource ) {
+				continue;
+			}
+
+			if ( $is_opener && self::DAV_NAMESPACE === $xml_namespace && 'collection' === $local_name ) {
+				$resource['is_collection'] = true;
+				continue;
+			}
+
+			if ( $is_opener && ! $xml->is_empty_element() ) {
+				if ( self::DAV_NAMESPACE === $xml_namespace && 'href' === $local_name && '' === $resource['href'] ) {
+					$collecting       = array( 'href', null );
+					$collecting_value = '';
+					continue;
+				}
+				if ( self::SVN_PROP_NAMESPACE === $xml_namespace || self::CUSTOM_PROP_NAMESPACE === $xml_namespace ) {
+					$prop_name        = self::SVN_PROP_NAMESPACE === $xml_namespace ? 'svn:' . $local_name : $local_name;
+					$collecting       = array( 'svn_prop', $prop_name );
+					$collecting_value = '';
+					$prop_is_base64   = 'base64' === $xml->get_attribute( self::SVN_DAV_NAMESPACE, 'encoding' );
+					continue;
+				}
+				if ( self::DAV_NAMESPACE === $xml_namespace || self::SVN_DAV_NAMESPACE === $xml_namespace ) {
+					$collecting       = array( 'dav_prop', $local_name );
+					$collecting_value = '';
+					continue;
+				}
+			}
+
+			if ( $is_closer && null !== $collecting ) {
+				list( $kind, $prop_name ) = $collecting;
+				if ( 'href' === $kind && 'href' === $local_name ) {
+					$resource['href'] = trim( $collecting_value );
+				} elseif ( 'svn_prop' === $kind && ( self::SVN_PROP_NAMESPACE === $xml_namespace || self::CUSTOM_PROP_NAMESPACE === $xml_namespace ) ) {
+					$value = $collecting_value;
+					if ( $prop_is_base64 ) {
+						$value = base64_decode( $value ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- decoding wire data, not code.
+					}
+					$resource['svn_props'][ $prop_name ] = $value;
+				} elseif ( 'dav_prop' === $kind && ( self::DAV_NAMESPACE === $xml_namespace || self::SVN_DAV_NAMESPACE === $xml_namespace ) ) {
+					if ( ! isset( $resource['dav_props'][ $prop_name ] ) || '' !== trim( $collecting_value ) ) {
+						$resource['dav_props'][ $prop_name ] = trim( $collecting_value );
+					}
+				}
+				$collecting       = null;
+				$collecting_value = '';
+				$prop_is_base64   = false;
+			}
+		}
+
+		return $resources;
+	}
+
+	/**
+	 * POSTs a create-txn request and returns the new transaction's name.
+	 *
+	 * @return string The transaction name from the SVN-Txn-Name header.
+	 */
+	private function create_transaction() {
+		if ( null === $this->txn_root_stub || null === $this->txn_stub ) {
+			throw new SvnException( 'The server does not expose transaction stubs; commits over HTTP are not possible.' );
+		}
+		$response         = $this->request(
+			'POST',
+			$this->server_base . $this->me_resource,
+			array( 'Content-Type' => 'application/vnd.svn-skel' ),
+			'( create-txn )',
+			array( 201 )
+		);
+		$transaction_name = $response['response']->get_header( 'SVN-Txn-Name' );
+		if ( null === $transaction_name ) {
+			throw new SvnException( 'The server accepted the transaction but did not return an SVN-Txn-Name header.' );
+		}
+
+		return trim( $transaction_name );
+	}
+
+	/**
+	 * Sets a revision property (such as svn:log) on an open transaction.
+	 *
+	 * @param string $transaction_name  The transaction to modify.
+	 * @param string $name              Property name, e.g. "svn:log".
+	 * @param string $value             Property value.
+	 */
+	private function set_transaction_property( $transaction_name, $name, $value ) {
+		$this->request(
+			'PROPPATCH',
+			$this->server_base . $this->txn_stub . '/' . $transaction_name,
+			array( 'Content-Type' => 'text/xml' ),
+			'<?xml version="1.0" encoding="utf-8"?><D:propertyupdate xmlns:D="DAV:"><D:set><D:prop>' .
+				$this->property_xml( $name, $value ) .
+			'</D:prop></D:set></D:propertyupdate>',
+			array( 207 )
+		);
+	}
+
+	/**
+	 * Applies one commit operation to the transaction tree.
+	 *
+	 * @param string $transaction_name  The open transaction.
+	 * @param array  $operation         See SvnSession::commit().
+	 */
+	private function apply_commit_operation( $transaction_name, $operation ) {
+		$url = $this->server_base . $this->txn_root_stub . '/' . $transaction_name . '/' .
+			$this->encode_url_path(
+				'' === $this->session_relative_path
+					? $operation['path']
+					: $this->session_relative_path . '/' . $operation['path']
+			);
+
+		switch ( $operation['op'] ) {
+			case 'delete':
+				$headers = array();
+				if ( isset( $operation['base_revision'] ) ) {
+					$headers['X-SVN-Version-Name'] = (string) (int) $operation['base_revision'];
+				}
+				$this->request( 'DELETE', $url, $headers, null, array( 204 ) );
+				break;
+
+			case 'add-directory':
+				$this->request( 'MKCOL', $url, array(), null, array( 201 ) );
+				$this->apply_property_changes( $url, isset( $operation['properties'] ) ? $operation['properties'] : array() );
+				break;
+
+			case 'add-file':
+			case 'modify-file':
+				$headers = array( 'Content-Type' => 'application/octet-stream' );
+				if ( 'modify-file' === $operation['op'] && isset( $operation['base_revision'] ) ) {
+					$headers['X-SVN-Version-Name'] = (string) (int) $operation['base_revision'];
+				}
+				$this->request( 'PUT', $url, $headers, $operation['contents'], array( 201, 204 ) );
+				$this->apply_property_changes( $url, isset( $operation['properties'] ) ? $operation['properties'] : array() );
+				break;
+
+			case 'modify-properties':
+				$this->apply_property_changes( $url, $operation['properties'] );
+				break;
+
+			default:
+				throw new SvnException( "Unknown commit operation '{$operation['op']}'." );
+		}
+	}
+
+	/**
+	 * PROPPATCHes versioned property changes onto a transaction resource.
+	 *
+	 * @param string $url         The transaction resource URL.
+	 * @param array  $properties  Property name => value, null value deletes.
+	 */
+	private function apply_property_changes( $url, $properties ) {
+		if ( 0 === count( $properties ) ) {
+			return;
+		}
+		$sets    = '';
+		$removes = '';
+		foreach ( $properties as $name => $value ) {
+			if ( null === $value ) {
+				$removes .= $this->property_xml( $name, null );
+			} else {
+				$sets .= $this->property_xml( $name, $value );
+			}
+		}
+		$body = '<?xml version="1.0" encoding="utf-8"?><D:propertyupdate xmlns:D="DAV:">';
+		if ( '' !== $sets ) {
+			$body .= '<D:set><D:prop>' . $sets . '</D:prop></D:set>';
+		}
+		if ( '' !== $removes ) {
+			$body .= '<D:remove><D:prop>' . $removes . '</D:prop></D:remove>';
+		}
+		$body .= '</D:propertyupdate>';
+
+		$this->request( 'PROPPATCH', $url, array( 'Content-Type' => 'text/xml' ), $body, array( 207 ) );
+	}
+
+	/**
+	 * Serializes one property for a PROPPATCH body. svn:* properties live
+	 * in the svn property namespace, everything else in the custom one.
+	 *
+	 * @param  string      $name   Property name, e.g. "svn:eol-style".
+	 * @param  string|null $value  Property value; null emits an empty element for D:remove.
+	 * @return string The XML fragment.
+	 */
+	private function property_xml( $name, $value ) {
+		if ( 0 === strpos( $name, 'svn:' ) ) {
+			$element_namespace = self::SVN_PROP_NAMESPACE;
+			$local_name        = substr( $name, 4 );
+		} else {
+			$element_namespace = self::CUSTOM_PROP_NAMESPACE;
+			$local_name        = $name;
+		}
+		if ( null === $value ) {
+			return '<P:' . $local_name . ' xmlns:P="' . $element_namespace . '"/>';
+		}
+
+		return '<P:' . $local_name . ' xmlns:P="' . $element_namespace . '">' . $this->escape_xml( $value ) . '</P:' . $local_name . '>';
+	}
+
+	/**
+	 * MERGEs a transaction into the repository, creating the revision.
+	 *
+	 * @param  string $transaction_name  The transaction to commit.
+	 * @return array { @type int $revision  @type string|null $author  @type string|null $date }
+	 */
+	private function merge_transaction( $transaction_name ) {
+		$response = $this->request(
+			'MERGE',
+			$this->server_base . ( '' === $this->session_path ? '/' : $this->session_path ),
+			array( 'Content-Type' => 'text/xml' ),
+			'<?xml version="1.0" encoding="utf-8"?><D:merge xmlns:D="DAV:"><D:source><D:href>' .
+				$this->escape_xml( $this->txn_stub . '/' . $transaction_name ) .
+			'</D:href></D:source><D:no-auto-merge/><D:no-checkout/><D:prop>' .
+			'<D:checked-in/><D:version-name/><D:resourcetype/><D:creationdate/><D:creator-displayname/>' .
+			'</D:prop></D:merge>',
+			array( 200 )
+		);
+
+		$revision   = null;
+		$date       = null;
+		$author     = null;
+		$xml        = XMLProcessor::create_from_string( $response['body'] );
+		$collecting = null;
+		while ( $xml->next_token() ) {
+			if ( '#text' === $xml->get_token_type() ) {
+				if ( null !== $collecting ) {
+					$value = trim( $xml->get_modifiable_text() );
+					if ( 'version-name' === $collecting && null === $revision && '' !== $value ) {
+						$revision = (int) $value;
+					}
+					if ( 'creationdate' === $collecting && null === $date && '' !== $value ) {
+						$date = $value;
+					}
+					if ( 'creator-displayname' === $collecting && null === $author && '' !== $value ) {
+						$author = $value;
+					}
+				}
+				continue;
+			}
+			if ( '#tag' !== $xml->get_token_type() ) {
+				continue;
+			}
+			if ( $xml->is_tag_opener() && in_array( $xml->get_tag_local_name(), array( 'version-name', 'creationdate', 'creator-displayname' ), true ) ) {
+				$collecting = $xml->get_tag_local_name();
+			} elseif ( $xml->is_tag_closer() ) {
+				$collecting = null;
+			}
+		}
+		if ( null === $revision ) {
+			throw new SvnException( 'The server merged the transaction but reported no new revision number.' );
+		}
+
+		return array(
+			'revision' => $revision,
+			'author'   => null !== $author ? $author : $this->username,
+			'date'     => $date,
+		);
+	}
+
+	/**
+	 * Deletes a transaction after a failed commit so the server can
+	 * reclaim it.
+	 *
+	 * @param string $transaction_name  The transaction to abort.
+	 */
+	private function abort_transaction( $transaction_name ) {
+		try {
+			$this->request(
+				'DELETE',
+				$this->server_base . $this->txn_stub . '/' . $transaction_name,
+				array(),
+				null,
+				array( 204 )
+			);
+		} catch ( SvnException $exception ) {
+			// The commit error is the interesting one; a failed cleanup
+			// only leaves a stray transaction behind on the server.
+		}
+	}
+
+	private function escape_xml( $value ) {
+		return htmlspecialchars( $value, ENT_QUOTES | ENT_XML1, 'UTF-8' );
+	}
+}

--- a/components/Svn/Protocol/class-davupdatereportparser.php
+++ b/components/Svn/Protocol/class-davupdatereportparser.php
@@ -6,6 +6,8 @@ use WordPress\Svn\SvnEditor;
 use WordPress\Svn\SvnException;
 use WordPress\XML\XMLProcessor;
 
+use function WordPress\Svn\svn_normalize_relative_path;
+
 /**
  * Streaming parser for mod_dav_svn's update-report response.
  *
@@ -383,6 +385,9 @@ class DavUpdateReportParser {
 	private function child_path( $name ) {
 		$parent = end( $this->directory_stack );
 
-		return '' === $parent || false === $parent ? $name : $parent . '/' . $name;
+		return svn_normalize_relative_path(
+			'' === $parent || false === $parent ? $name : $parent . '/' . $name,
+			false
+		);
 	}
 }

--- a/components/Svn/Protocol/class-davupdatereportparser.php
+++ b/components/Svn/Protocol/class-davupdatereportparser.php
@@ -1,0 +1,388 @@
+<?php
+
+namespace WordPress\Svn\Protocol;
+
+use WordPress\Svn\SvnEditor;
+use WordPress\Svn\SvnException;
+use WordPress\XML\XMLProcessor;
+
+/**
+ * Streaming parser for mod_dav_svn's update-report response.
+ *
+ * The response is the HTTP twin of the svn:// editor drive: an XML
+ * document describing tree changes, with file contents inlined as
+ * base64-encoded svndiff data:
+ *
+ *     <S:update-report xmlns:S="svn:" send-all="true" inline-props="true">
+ *       <S:target-revision rev="62480"/>
+ *       <S:open-directory rev="62480">
+ *         <S:set-prop name="svn:ignore">*.css</S:set-prop>
+ *         <S:add-directory name="sub">
+ *           <S:add-file name="a.txt">
+ *             <S:txdelta>U1ZOAAAADAEMjG5l...</S:txdelta>
+ *             <S:prop><V:md5-checksum>a4717…</V:md5-checksum></S:prop>
+ *           </S:add-file>
+ *         </S:add-directory>
+ *         <S:open-file name="b.txt" rev="62454">…</S:open-file>
+ *         <S:delete-entry name="old.txt"/>
+ *       </S:open-directory>
+ *     </S:update-report>
+ *
+ * Feed response bytes with append_bytes() as they arrive; editor calls
+ * are emitted as soon as the relevant XML is complete.
+ */
+class DavUpdateReportParser {
+	const SVN_NAMESPACE = 'svn:';
+	const DAV_NAMESPACE = 'http://subversion.tigris.org/xmlns/dav/';
+
+	/**
+	 * @var SvnEditor
+	 */
+	private $editor;
+
+	/**
+	 * @var XMLProcessor
+	 */
+	private $xml;
+
+	/**
+	 * Stack of open directory paths; the working copy root is ''.
+	 *
+	 * @var string[]
+	 */
+	private $directory_stack = array();
+
+	/**
+	 * Path of the file element being parsed, or null outside files.
+	 *
+	 * @var string|null
+	 */
+	private $current_file;
+
+	/**
+	 * MD5 announced via <V:md5-checksum> for the current file.
+	 *
+	 * @var string|null
+	 */
+	private $current_file_md5;
+
+	/**
+	 * Name of the element whose text content matters right now:
+	 * 'txdelta', 'set-prop', or 'md5-checksum'. Null otherwise.
+	 *
+	 * @var string|null
+	 */
+	private $collecting;
+
+	/**
+	 * Accumulated text of the element being collected.
+	 *
+	 * @var string
+	 */
+	private $collected_text = '';
+
+	/**
+	 * Property name of the <S:set-prop> being collected.
+	 *
+	 * @var string|null
+	 */
+	private $collected_prop_name;
+
+	/**
+	 * Whether the collected property value is base64-encoded.
+	 *
+	 * @var bool
+	 */
+	private $collected_prop_base64 = false;
+
+	/**
+	 * Whether the document ended and close_edit() was called.
+	 *
+	 * @var bool
+	 */
+	private $finished = false;
+
+	/**
+	 * Bytes buffered until the XML declaration is complete. XMLProcessor
+	 * cannot pause mid-declaration (it bails as "unsupported" instead of
+	 * waiting for more input), so the first bytes are held back until
+	 * the first '>' arrived.
+	 *
+	 * @TODO: Teach XMLProcessor to pause on incomplete XML declarations,
+	 * then drop this buffer.
+	 *
+	 * @var string|null Null once the prelude was forwarded.
+	 */
+	private $prelude = '';
+
+	public function __construct( SvnEditor $editor ) {
+		$this->editor = $editor;
+		$this->xml    = XMLProcessor::create_for_streaming();
+
+		/*
+		 * Checking out something like wordpress-develop streams hundreds
+		 * of megabytes of XML through this parser. XMLProcessor only
+		 * forgets already-processed bytes once its internal buffer
+		 * exceeds its memory budget, which defaults to 1 GiB – far too
+		 * high for this forward-only parse. Lower it so large checkouts
+		 * run in tens of megabytes of memory.
+		 *
+		 * @TODO: Expose the memory budget as a public XMLProcessor option
+		 * and drop this reflection.
+		 */
+		try {
+			$budget_property = new \ReflectionProperty( get_class( $this->xml ), 'memory_budget' );
+			$budget_property->setAccessible( true );
+			$budget_property->setValue( $this->xml, 8 * 1024 * 1024 );
+		} catch ( \ReflectionException $exception ) {
+			// A processor without the property manages its own memory.
+		}
+	}
+
+	/**
+	 * Feeds the next chunk of the HTTP response body.
+	 *
+	 * @param  string $bytes  Response bytes; boundaries are arbitrary.
+	 * @throws SvnException When the response is not a valid update-report.
+	 */
+	public function append_bytes( $bytes ) {
+		if ( null !== $this->prelude ) {
+			$this->prelude .= $bytes;
+			if ( false === strpos( $this->prelude, '>' ) ) {
+				return;
+			}
+			$bytes         = $this->prelude;
+			$this->prelude = null;
+		}
+		$this->xml->append_bytes( $bytes );
+		$this->process_available_tokens();
+	}
+
+	/**
+	 * Signals the end of the HTTP response.
+	 *
+	 * @throws SvnException When the response ended mid-document.
+	 */
+	public function finish() {
+		if ( null !== $this->prelude ) {
+			$this->xml->append_bytes( $this->prelude );
+			$this->prelude = null;
+		}
+		$this->xml->input_finished();
+		$this->process_available_tokens();
+		if ( ! $this->finished ) {
+			throw new SvnException( 'The update-report response ended unexpectedly: ' . ( $this->xml->get_last_error() ? $this->xml->get_last_error() : 'truncated document.' ) );
+		}
+	}
+
+	private function process_available_tokens() {
+		while ( $this->xml->next_token() ) {
+			$token_type = $this->xml->get_token_type();
+			if ( '#text' === $token_type || '#cdata-section' === $token_type ) {
+				if ( null !== $this->collecting ) {
+					$this->collected_text .= $this->xml->get_modifiable_text();
+				}
+				continue;
+			}
+			if ( '#tag' !== $token_type ) {
+				continue;
+			}
+
+			// Empty elements such as <S:target-revision rev="4"/> report
+			// neither is_tag_opener() nor is_tag_closer(); they act as both.
+			if ( $this->xml->is_tag_opener() || $this->xml->is_empty_element() ) {
+				$this->handle_element_open();
+				if ( $this->xml->is_empty_element() ) {
+					$this->handle_element_close();
+				}
+			} elseif ( $this->xml->is_tag_closer() ) {
+				$this->handle_element_close();
+			}
+		}
+
+		if ( $this->xml->is_paused_at_incomplete_input() ) {
+			return;
+		}
+		if ( null !== $this->xml->get_last_error() ) {
+			throw new SvnException( 'Malformed update-report response: ' . $this->xml->get_last_error() );
+		}
+	}
+
+	private function handle_element_open() {
+		$xml_namespace = $this->xml->get_tag_namespace();
+		$local_name    = $this->xml->get_tag_local_name();
+
+		if ( self::DAV_NAMESPACE === $xml_namespace && 'md5-checksum' === $local_name && null !== $this->current_file ) {
+			$this->start_collecting( 'md5-checksum' );
+
+			return;
+		}
+
+		if ( self::SVN_NAMESPACE !== $xml_namespace ) {
+			return;
+		}
+
+		switch ( $local_name ) {
+			case 'target-revision':
+				$this->editor->set_target_revision( (int) $this->xml->get_attribute( '', 'rev' ) );
+				break;
+
+			case 'open-directory':
+				if ( 0 === count( $this->directory_stack ) ) {
+					$this->editor->open_root();
+					$this->directory_stack[] = '';
+				} else {
+					$path = $this->child_path( $this->require_name_attribute( 'open-directory' ) );
+					$this->editor->open_directory( $path );
+					$this->directory_stack[] = $path;
+				}
+				break;
+
+			case 'add-directory':
+				$path = $this->child_path( $this->require_name_attribute( 'add-directory' ) );
+				$this->editor->add_directory( $path );
+				$this->directory_stack[] = $path;
+				break;
+
+			case 'open-file':
+				$this->current_file     = $this->child_path( $this->require_name_attribute( 'open-file' ) );
+				$this->current_file_md5 = null;
+				$this->editor->open_file( $this->current_file );
+				break;
+
+			case 'add-file':
+				$this->current_file     = $this->child_path( $this->require_name_attribute( 'add-file' ) );
+				$this->current_file_md5 = null;
+				$this->editor->add_file( $this->current_file );
+				break;
+
+			case 'txdelta':
+				$base_checksum = $this->xml->get_attribute( '', 'base-checksum' );
+				$this->editor->apply_textdelta( $this->current_file, is_string( $base_checksum ) ? $base_checksum : null );
+				$this->start_collecting( 'txdelta' );
+				break;
+
+			case 'set-prop':
+				$this->start_collecting( 'set-prop' );
+				$this->collected_prop_name   = $this->require_name_attribute( 'set-prop' );
+				$this->collected_prop_base64 = 'base64' === $this->xml->get_attribute( self::DAV_NAMESPACE, 'encoding' );
+				break;
+
+			case 'remove-prop':
+				$this->change_property( $this->require_name_attribute( 'remove-prop' ), null );
+				break;
+
+			case 'delete-entry':
+				$this->editor->delete_entry( $this->child_path( $this->require_name_attribute( 'delete-entry' ) ) );
+				break;
+
+			case 'absent-directory':
+			case 'absent-file':
+				// Hidden by authorization rules; nothing to materialize.
+				break;
+		}
+	}
+
+	private function handle_element_close() {
+		$xml_namespace = $this->xml->get_tag_namespace();
+		$local_name    = $this->xml->get_tag_local_name();
+
+		if ( self::DAV_NAMESPACE === $xml_namespace && 'md5-checksum' === $local_name && 'md5-checksum' === $this->collecting ) {
+			$this->current_file_md5 = trim( $this->collected_text );
+			$this->stop_collecting();
+
+			return;
+		}
+
+		if ( self::SVN_NAMESPACE !== $xml_namespace ) {
+			return;
+		}
+
+		switch ( $local_name ) {
+			case 'open-directory':
+			case 'add-directory':
+				$path = array_pop( $this->directory_stack );
+				$this->editor->close_directory( $path );
+				break;
+
+			case 'open-file':
+			case 'add-file':
+				$this->editor->close_file( $this->current_file, $this->current_file_md5 );
+				$this->current_file     = null;
+				$this->current_file_md5 = null;
+				break;
+
+			case 'txdelta':
+				$svndiff = base64_decode( $this->collected_text ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- decoding wire data, not code.
+				$this->stop_collecting();
+				if ( false === $svndiff ) {
+					throw new SvnException( 'Malformed update-report response: invalid base64 in a txdelta element.' );
+				}
+				$this->editor->write_textdelta_chunk( $this->current_file, $svndiff );
+				$this->editor->textdelta_end( $this->current_file );
+				break;
+
+			case 'set-prop':
+				$value = $this->collected_text;
+				if ( $this->collected_prop_base64 ) {
+					$value = base64_decode( $value ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- decoding wire data, not code.
+					if ( false === $value ) {
+						throw new SvnException( 'Malformed update-report response: invalid base64 in a set-prop element.' );
+					}
+				}
+				$this->change_property( $this->collected_prop_name, $value );
+				$this->stop_collecting();
+				break;
+
+			case 'update-report':
+				$this->editor->close_edit();
+				$this->finished = true;
+				break;
+		}
+	}
+
+	/**
+	 * Routes a property change to the current file or directory,
+	 * dropping svn:entry:* and svn:wc:* bookkeeping properties.
+	 *
+	 * @param string      $name   The property name.
+	 * @param string|null $value  The property value, or null to delete.
+	 */
+	private function change_property( $name, $value ) {
+		if ( 0 === strpos( $name, 'svn:entry:' ) || 0 === strpos( $name, 'svn:wc:' ) ) {
+			return;
+		}
+		if ( null !== $this->current_file ) {
+			$this->editor->change_file_property( $this->current_file, $name, $value );
+		} else {
+			$this->editor->change_directory_property( end( $this->directory_stack ), $name, $value );
+		}
+	}
+
+	private function start_collecting( $what ) {
+		$this->collecting     = $what;
+		$this->collected_text = '';
+	}
+
+	private function stop_collecting() {
+		$this->collecting            = null;
+		$this->collected_text        = '';
+		$this->collected_prop_name   = null;
+		$this->collected_prop_base64 = false;
+	}
+
+	private function require_name_attribute( $element ) {
+		$name = $this->xml->get_attribute( '', 'name' );
+		if ( null === $name || false === $name ) {
+			throw new SvnException( "Malformed update-report response: <S:{$element}> without a name attribute." );
+		}
+
+		return $name;
+	}
+
+	private function child_path( $name ) {
+		$parent = end( $this->directory_stack );
+
+		return '' === $parent || false === $parent ? $name : $parent . '/' . $name;
+	}
+}

--- a/components/Svn/Protocol/class-rasvnconnection.php
+++ b/components/Svn/Protocol/class-rasvnconnection.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace WordPress\Svn\Protocol;
+
+use WordPress\Svn\SvnException;
+
+/**
+ * Reads and writes ra_svn protocol items over a stream.
+ *
+ * This is the lowest layer of svn:// support: it knows how to tokenize
+ * the wire format documented in Subversion's libsvn_ra_svn/protocol but
+ * has no idea what the items mean. RaSvnSession builds the actual
+ * client on top of it.
+ *
+ * The connection works on any PHP stream, which keeps it testable with
+ * php://memory streams – no server required.
+ */
+class RaSvnConnection {
+	/**
+	 * @var resource
+	 */
+	private $stream;
+
+	/**
+	 * Receive buffer.
+	 *
+	 * @var string
+	 */
+	private $buffer = '';
+
+	/**
+	 * Parse offset into $buffer.
+	 *
+	 * @var int
+	 */
+	private $offset = 0;
+
+	/**
+	 * @param resource $stream  An open, connected stream.
+	 */
+	public function __construct( $stream ) {
+		$this->stream = $stream;
+	}
+
+	/**
+	 * Opens a TCP connection to an svn:// URL.
+	 *
+	 * @param  string $host        Server hostname.
+	 * @param  int    $port        Server port, usually 3690.
+	 * @param  array  $options     {
+	 *     @type int $connect_timeout_ms  Connection timeout. Default 10000.
+	 *     @type int $timeout_ms          Read timeout. Default 60000.
+	 * }
+	 * @return RaSvnConnection
+	 * @throws SvnException When the connection cannot be established.
+	 */
+	public static function connect( $host, $port, $options = array() ) {
+		$connect_timeout_ms = isset( $options['connect_timeout_ms'] ) ? $options['connect_timeout_ms'] : 10000;
+		$timeout_ms         = isset( $options['timeout_ms'] ) ? $options['timeout_ms'] : 60000;
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- connection failures are reported via exceptions below.
+		$stream = @stream_socket_client(
+			'tcp://' . $host . ':' . $port,
+			$error_code,
+			$error_message,
+			$connect_timeout_ms / 1000
+		);
+		if ( false === $stream ) {
+			throw new SvnException( "Could not connect to svn://{$host}:{$port}: {$error_message}" );
+		}
+		stream_set_timeout( $stream, (int) ( $timeout_ms / 1000 ), (int) ( $timeout_ms % 1000 ) * 1000 );
+
+		return new RaSvnConnection( $stream );
+	}
+
+	/**
+	 * Reads the next protocol item.
+	 *
+	 * @return RaSvnItem
+	 * @throws SvnException When the connection drops or the data is malformed.
+	 */
+	public function read_item() {
+		$this->skip_whitespace();
+		$char = $this->peek_char();
+
+		if ( '(' === $char ) {
+			++$this->offset;
+			$items = array();
+			while ( true ) {
+				$this->skip_whitespace();
+				if ( ')' === $this->peek_char() ) {
+					++$this->offset;
+
+					return new RaSvnItem( RaSvnItem::TYPE_LIST, $items );
+				}
+				$items[] = $this->read_item();
+			}
+		}
+
+		if ( $char >= '0' && $char <= '9' ) {
+			$digits = '';
+			while ( true ) {
+				$char = $this->next_char();
+				if ( $char >= '0' && $char <= '9' ) {
+					$digits .= $char;
+					continue;
+				}
+				if ( ':' === $char ) {
+					return new RaSvnItem( RaSvnItem::TYPE_STRING, $this->read_exact( (int) $digits ) );
+				}
+				if ( ' ' === $char || "\n" === $char ) {
+					return new RaSvnItem( RaSvnItem::TYPE_NUMBER, (int) $digits );
+				}
+				throw new SvnException( 'Protocol error: malformed number on the wire.' );
+			}
+		}
+
+		$word = '';
+		while ( true ) {
+			$char = $this->next_char();
+			if ( ' ' === $char || "\n" === $char ) {
+				if ( '' === $word ) {
+					throw new SvnException( 'Protocol error: empty word on the wire.' );
+				}
+
+				return new RaSvnItem( RaSvnItem::TYPE_WORD, $word );
+			}
+			$word .= $char;
+		}
+	}
+
+	/**
+	 * Writes raw, already-encoded protocol bytes.
+	 *
+	 * @param  string $bytes  The bytes to send.
+	 * @throws SvnException When the connection drops mid-write.
+	 */
+	public function write( $bytes ) {
+		$written_total = 0;
+		$length        = strlen( $bytes );
+		while ( $written_total < $length ) {
+			$written = @fwrite( $this->stream, substr( $bytes, $written_total ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- write failures are reported via exceptions below.
+			if ( false === $written || 0 === $written ) {
+				throw new SvnException( 'The svn:// connection was closed while sending data.' );
+			}
+			$written_total += $written;
+		}
+	}
+
+	/**
+	 * Encodes a string in the length-prefixed wire format.
+	 *
+	 * @param  string $value  Arbitrary bytes.
+	 * @return string The encoded string, e.g. "5:hello".
+	 */
+	public static function encode_string( $value ) {
+		return strlen( $value ) . ':' . $value;
+	}
+
+	/**
+	 * Encodes a boolean as a protocol word.
+	 *
+	 * @param  bool $value  The boolean to encode.
+	 * @return string Either "true" or "false".
+	 */
+	public static function encode_boolean( $value ) {
+		return $value ? 'true' : 'false';
+	}
+
+	public function close() {
+		if ( is_resource( $this->stream ) ) {
+			fclose( $this->stream );
+		}
+	}
+
+	private function fill_buffer() {
+		$chunk = fread( $this->stream, 65536 );
+		if ( '' === $chunk || false === $chunk ) {
+			$meta = stream_get_meta_data( $this->stream );
+			if ( ! empty( $meta['timed_out'] ) ) {
+				throw new SvnException( 'Timed out while waiting for data on the svn:// connection.' );
+			}
+			throw new SvnException( 'The svn:// connection was closed by the server.' );
+		}
+		$this->buffer = substr( $this->buffer, $this->offset ) . $chunk;
+		$this->offset = 0;
+	}
+
+	private function next_char() {
+		if ( $this->offset >= strlen( $this->buffer ) ) {
+			$this->fill_buffer();
+		}
+
+		return $this->buffer[ $this->offset++ ];
+	}
+
+	private function peek_char() {
+		if ( $this->offset >= strlen( $this->buffer ) ) {
+			$this->fill_buffer();
+		}
+
+		return $this->buffer[ $this->offset ];
+	}
+
+	private function read_exact( $length ) {
+		while ( strlen( $this->buffer ) - $this->offset < $length ) {
+			$this->fill_buffer();
+		}
+		$bytes         = substr( $this->buffer, $this->offset, $length );
+		$this->offset += $length;
+
+		return $bytes;
+	}
+
+	private function skip_whitespace() {
+		while ( true ) {
+			$char = $this->peek_char();
+			if ( ' ' === $char || "\n" === $char ) {
+				++$this->offset;
+				continue;
+			}
+
+			return;
+		}
+	}
+}

--- a/components/Svn/Protocol/class-rasvnitem.php
+++ b/components/Svn/Protocol/class-rasvnitem.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace WordPress\Svn\Protocol;
+
+use WordPress\Svn\SvnException;
+
+/**
+ * A single value decoded from the svn:// (ra_svn) wire protocol.
+ *
+ * The protocol encodes four data types:
+ *
+ *     word    – bare token, e.g. `success` or `edit-pipeline`
+ *     number  – ASCII digits terminated by whitespace, e.g. `42 `
+ *     string  – length-prefixed bytes, e.g. `5:hello`
+ *     list    – parenthesized sequence of items, e.g. `( 1 2:hi word )`
+ *
+ * Lists are represented as PHP arrays of RaSvnItem instances.
+ */
+class RaSvnItem {
+	const TYPE_WORD   = 'word';
+	const TYPE_NUMBER = 'number';
+	const TYPE_STRING = 'string';
+	const TYPE_LIST   = 'list';
+
+	/**
+	 * One of the TYPE_* constants.
+	 *
+	 * @var string
+	 */
+	public $type;
+
+	/**
+	 * The decoded value: string for words and strings, int for
+	 * numbers, RaSvnItem[] for lists.
+	 *
+	 * @var string|int|RaSvnItem[]
+	 */
+	public $value;
+
+	public function __construct( $type, $value ) {
+		$this->type  = $type;
+		$this->value = $value;
+	}
+
+	/**
+	 * @param  string $word  The expected word, or null to accept any word.
+	 * @return bool Whether this item is the given word.
+	 */
+	public function is_word( $word = null ) {
+		return self::TYPE_WORD === $this->type && ( null === $word || $this->value === $word );
+	}
+
+	/**
+	 * @return string
+	 * @throws SvnException When the item is not a word.
+	 */
+	public function get_word() {
+		if ( self::TYPE_WORD !== $this->type ) {
+			throw new SvnException( "Protocol error: expected a word, got a {$this->type}." );
+		}
+
+		return $this->value;
+	}
+
+	/**
+	 * @return string
+	 * @throws SvnException When the item is not a string.
+	 */
+	public function get_string() {
+		if ( self::TYPE_STRING !== $this->type ) {
+			throw new SvnException( "Protocol error: expected a string, got a {$this->type}." );
+		}
+
+		return $this->value;
+	}
+
+	/**
+	 * Reads the item as a string, also accepting words. A few servers
+	 * emit words where strings are expected, e.g. for author names.
+	 *
+	 * @return string
+	 * @throws SvnException When the item is neither a string nor a word.
+	 */
+	public function get_string_or_word() {
+		if ( self::TYPE_STRING !== $this->type && self::TYPE_WORD !== $this->type ) {
+			throw new SvnException( "Protocol error: expected a string or a word, got a {$this->type}." );
+		}
+
+		return $this->value;
+	}
+
+	/**
+	 * @return int
+	 * @throws SvnException When the item is not a number.
+	 */
+	public function get_number() {
+		if ( self::TYPE_NUMBER !== $this->type ) {
+			throw new SvnException( "Protocol error: expected a number, got a {$this->type}." );
+		}
+
+		return $this->value;
+	}
+
+	/**
+	 * @return RaSvnItem[]
+	 * @throws SvnException When the item is not a list.
+	 */
+	public function get_list() {
+		if ( self::TYPE_LIST !== $this->type ) {
+			throw new SvnException( "Protocol error: expected a list, got a {$this->type}." );
+		}
+
+		return $this->value;
+	}
+
+	/**
+	 * Reads a protocol boolean – the words `true` or `false`.
+	 *
+	 * @return bool
+	 * @throws SvnException When the item is not a boolean word.
+	 */
+	public function get_boolean() {
+		$word = $this->get_word();
+		if ( 'true' === $word ) {
+			return true;
+		}
+		if ( 'false' === $word ) {
+			return false;
+		}
+		throw new SvnException( "Protocol error: expected a boolean word, got '{$word}'." );
+	}
+
+	/**
+	 * Unwraps the protocol idiom for optional values: a list that is
+	 * either empty or holds exactly one item, e.g. `( )` or `( 42 )`.
+	 *
+	 * @return RaSvnItem|null The single item, or null when the list is empty.
+	 */
+	public function get_optional() {
+		$list = $this->get_list();
+		if ( 0 === count( $list ) ) {
+			return null;
+		}
+
+		return $list[0];
+	}
+}

--- a/components/Svn/Protocol/class-rasvnsession.php
+++ b/components/Svn/Protocol/class-rasvnsession.php
@@ -7,6 +7,8 @@ use WordPress\Svn\SvnEditor;
 use WordPress\Svn\SvnException;
 use WordPress\Svn\SvnSession;
 
+use function WordPress\Svn\svn_normalize_relative_path;
+
 /**
  * Subversion repository access over the svn:// protocol (ra_svn).
  *
@@ -512,13 +514,21 @@ class RaSvnSession implements SvnSession {
 					break;
 
 				case 'add-dir':
-					$path                                        = $params[0]->get_string();
+					$path = svn_normalize_relative_path(
+						$params[0]->get_string(),
+						false
+					);
+
 					$directory_paths[ $params[2]->get_string() ] = $path;
 					$editor->add_directory( $path );
 					break;
 
 				case 'open-dir':
-					$path                                        = $params[0]->get_string();
+					$path = svn_normalize_relative_path(
+						$params[0]->get_string(),
+						false
+					);
+
 					$directory_paths[ $params[2]->get_string() ] = $path;
 					$editor->open_directory( $path );
 					break;
@@ -542,13 +552,21 @@ class RaSvnSession implements SvnSession {
 					break;
 
 				case 'add-file':
-					$path                                   = $params[0]->get_string();
+					$path = svn_normalize_relative_path(
+						$params[0]->get_string(),
+						false
+					);
+
 					$file_paths[ $params[2]->get_string() ] = $path;
 					$editor->add_file( $path );
 					break;
 
 				case 'open-file':
-					$path                                   = $params[0]->get_string();
+					$path = svn_normalize_relative_path(
+						$params[0]->get_string(),
+						false
+					);
+
 					$file_paths[ $params[2]->get_string() ] = $path;
 					$editor->open_file( $path );
 					break;
@@ -595,7 +613,12 @@ class RaSvnSession implements SvnSession {
 					break;
 
 				case 'delete-entry':
-					$editor->delete_entry( $params[0]->get_string() );
+					$editor->delete_entry(
+						svn_normalize_relative_path(
+							$params[0]->get_string(),
+							false
+						)
+					);
 					break;
 
 				case 'absent-dir':

--- a/components/Svn/Protocol/class-rasvnsession.php
+++ b/components/Svn/Protocol/class-rasvnsession.php
@@ -1,0 +1,968 @@
+<?php
+
+namespace WordPress\Svn\Protocol;
+
+use WordPress\Svn\SvnDiff;
+use WordPress\Svn\SvnEditor;
+use WordPress\Svn\SvnException;
+use WordPress\Svn\SvnSession;
+
+/**
+ * Subversion repository access over the svn:// protocol (ra_svn).
+ *
+ * Speaks the wire protocol documented in Subversion's
+ * subversion/libsvn_ra_svn/protocol file:
+ *
+ *  1. The server greets with the protocol versions and capabilities it
+ *     supports, the client responds with its own version, capabilities,
+ *     and the URL it wants to talk about.
+ *  2. The server requests authentication. ANONYMOUS and CRAM-MD5
+ *     mechanisms are supported here, which is what stock svnserve
+ *     installations offer (SASL mechanisms are not implemented).
+ *  3. Commands flow as `( command-name ( args ) )` tuples. Every
+ *     command response is preceded by an auth request, which is almost
+ *     always the trivial "no authentication needed" form.
+ *
+ * Reads (checkout/update) arrive as an "editor drive": the server sends
+ * a stream of tree-change commands which this class dispatches onto an
+ * SvnEditor. Writes (commits) are the mirror image: this class drives
+ * the server's editor with the local changes.
+ */
+class RaSvnSession implements SvnSession {
+	/**
+	 * @var RaSvnConnection
+	 */
+	private $connection;
+
+	/**
+	 * @var string
+	 */
+	private $url;
+
+	/**
+	 * @var string|null
+	 */
+	private $username;
+
+	/**
+	 * @var string|null
+	 */
+	private $password;
+
+	/**
+	 * @var string
+	 */
+	private $repository_root;
+
+	/**
+	 * @var string
+	 */
+	private $uuid;
+
+	/**
+	 * Counter backing allocate_token().
+	 *
+	 * @var int
+	 */
+	private $next_token = 0;
+
+	private function __construct( RaSvnConnection $connection, $url, $username, $password ) {
+		$this->connection = $connection;
+		$this->url        = $url;
+		$this->username   = $username;
+		$this->password   = $password;
+	}
+
+	/**
+	 * Opens a session against an svn:// URL.
+	 *
+	 * @param  string $url      Repository URL, e.g. "svn://example.com/repo/trunk".
+	 * @param  array  $options  {
+	 *     @type string $username            Username for CRAM-MD5 authentication.
+	 *     @type string $password            Password for CRAM-MD5 authentication.
+	 *     @type int    $timeout_ms          Socket read timeout. Default 60000.
+	 *     @type int    $connect_timeout_ms  Connection timeout. Default 10000.
+	 * }
+	 * @return RaSvnSession
+	 * @throws SvnException When the URL is invalid, the server is unreachable,
+	 *                      or the handshake fails.
+	 */
+	public static function connect( $url, $options = array() ) {
+		$parts = parse_url( $url );
+		if ( false === $parts || ! isset( $parts['scheme'], $parts['host'] ) || 'svn' !== $parts['scheme'] ) {
+			throw new SvnException( "Not a valid svn:// URL: {$url}" );
+		}
+
+		$username = isset( $options['username'] ) ? $options['username'] : ( isset( $parts['user'] ) ? rawurldecode( $parts['user'] ) : null );
+		$password = isset( $options['password'] ) ? $options['password'] : ( isset( $parts['pass'] ) ? rawurldecode( $parts['pass'] ) : null );
+
+		$port          = isset( $parts['port'] ) ? $parts['port'] : 3690;
+		$path          = isset( $parts['path'] ) ? rtrim( $parts['path'], '/' ) : '';
+		$canonical_url = 'svn://' . $parts['host'] . ( 3690 === $port ? '' : ':' . $port ) . $path;
+
+		$connection = RaSvnConnection::connect( $parts['host'], $port, $options );
+		$session    = new RaSvnSession( $connection, $canonical_url, $username, $password );
+		$session->handshake();
+
+		return $session;
+	}
+
+	public function get_session_url() {
+		return $this->url;
+	}
+
+	public function get_repository_root() {
+		return $this->repository_root;
+	}
+
+	public function get_uuid() {
+		return $this->uuid;
+	}
+
+	public function get_latest_revision() {
+		$this->send_command( 'get-latest-rev', '' );
+		$params = $this->read_command_response();
+
+		return $params[0]->get_number();
+	}
+
+	public function check_path( $path, $revision = null ) {
+		$this->send_command(
+			'check-path',
+			RaSvnConnection::encode_string( $path ) . ' ' . $this->encode_optional_revision( $revision )
+		);
+		$params = $this->read_command_response();
+
+		return $params[0]->get_word();
+	}
+
+	public function list_directory( $path, $revision = null ) {
+		$this->send_command(
+			'get-dir',
+			RaSvnConnection::encode_string( $path ) . ' ' .
+			$this->encode_optional_revision( $revision ) .
+			' false true ( kind size has-props created-rev time last-author )'
+		);
+		$params = $this->read_command_response();
+
+		$entries = array();
+		foreach ( $params[2]->get_list() as $entry_item ) {
+			$entry     = $entry_item->get_list();
+			$entries[] = array(
+				'name'        => $entry[0]->get_string(),
+				'kind'        => $entry[1]->get_word(),
+				'size'        => $entry[2]->get_number(),
+				'created_rev' => $entry[4]->get_number(),
+			);
+		}
+
+		return $entries;
+	}
+
+	public function get_file( $path, $revision = null ) {
+		$this->send_command(
+			'get-file',
+			RaSvnConnection::encode_string( $path ) . ' ' . $this->encode_optional_revision( $revision ) . ' true true'
+		);
+		$params   = $this->read_command_response();
+		$checksum = $params[0]->get_optional();
+		$contents = '';
+		while ( true ) {
+			$chunk = $this->connection->read_item()->get_string();
+			if ( '' === $chunk ) {
+				break;
+			}
+			$contents .= $chunk;
+		}
+		// The content stream is followed by a closing command response.
+		$this->read_response_tuple();
+
+		return array(
+			'contents'   => $contents,
+			'checksum'   => null === $checksum ? null : $checksum->get_string(),
+			'properties' => $this->parse_versioned_properties( $params[2] ),
+		);
+	}
+
+	public function get_properties( $path, $revision = null ) {
+		$kind = $this->check_path( $path, $revision );
+		if ( 'dir' === $kind ) {
+			$this->send_command(
+				'get-dir',
+				RaSvnConnection::encode_string( $path ) . ' ' . $this->encode_optional_revision( $revision ) . ' true false ( )'
+			);
+			$params = $this->read_command_response();
+
+			return $this->parse_versioned_properties( $params[1] );
+		}
+		if ( 'file' === $kind ) {
+			$this->send_command(
+				'get-file',
+				RaSvnConnection::encode_string( $path ) . ' ' . $this->encode_optional_revision( $revision ) . ' true false'
+			);
+			$params = $this->read_command_response();
+
+			return $this->parse_versioned_properties( $params[2] );
+		}
+
+		throw new SvnException( "Path '{$path}' does not exist in the repository." );
+	}
+
+	public function drive_update( $target_revision, $report, SvnEditor $editor, $options = array() ) {
+		$depth = isset( $options['depth'] ) ? $options['depth'] : 'infinity';
+
+		// Pipeline the update command and the working copy report, then
+		// consume the server's editor drive.
+		$this->send_command(
+			'update',
+			'( ' . (int) $target_revision . ' ) ' .
+			RaSvnConnection::encode_string( '' ) . ' true ' . $depth . ' false false'
+		);
+		foreach ( $report as $report_entry ) {
+			$entry_depth = isset( $report_entry['depth'] ) ? $report_entry['depth'] : 'infinity';
+			$this->send_command(
+				'set-path',
+				RaSvnConnection::encode_string( $report_entry['path'] ) . ' ' .
+				(int) $report_entry['revision'] . ' ' .
+				RaSvnConnection::encode_boolean( ! empty( $report_entry['start_empty'] ) ) .
+				' ( ) ' . $entry_depth
+			);
+		}
+		$this->send_command( 'finish-report', '' );
+
+		$this->consume_editor_drive( $editor );
+	}
+
+	public function commit( $message, $operations ) {
+		$this->send_command( 'commit', RaSvnConnection::encode_string( $message ) );
+		$this->read_command_response();
+
+		try {
+			$this->drive_commit_editor( $operations );
+		} catch ( SvnException $exception ) {
+			// The server may have rejected an editor command and already
+			// hung up; surface the queued failure when there is one.
+			throw $this->read_pending_commit_failure( $exception );
+		}
+
+		return $this->read_commit_info();
+	}
+
+	public function close() {
+		$this->connection->close();
+	}
+
+	/**
+	 * Performs the protocol handshake: greeting exchange, authentication,
+	 * and the repository information announcement.
+	 */
+	private function handshake() {
+		$greeting = $this->read_response_tuple();
+		$min      = $greeting[0]->get_number();
+		$max      = $greeting[1]->get_number();
+		if ( $min > 2 || $max < 2 ) {
+			throw new SvnException( "The server speaks ra_svn protocol versions {$min}-{$max}; only version 2 is supported." );
+		}
+
+		$this->connection->write(
+			'( 2 ( edit-pipeline svndiff1 absent-entries depth ) ' .
+			RaSvnConnection::encode_string( $this->url ) . ' ' .
+			RaSvnConnection::encode_string( 'php-toolkit-svn/1.0' ) .
+			' ( ) ) '
+		);
+
+		$auth_request = $this->read_response_tuple();
+		$this->authenticate( $auth_request );
+
+		$repository_info       = $this->read_response_tuple();
+		$this->uuid            = $repository_info[0]->get_string();
+		$this->repository_root = $repository_info[1]->get_string();
+	}
+
+	/**
+	 * Answers an authentication request.
+	 *
+	 * @param  RaSvnItem[] $auth_request_params  The ( ( mech... ) realm ) tuple.
+	 * @throws SvnException When no supported mechanism is available or
+	 *                      the credentials are rejected.
+	 */
+	private function authenticate( $auth_request_params ) {
+		$mechanisms = array();
+		foreach ( $auth_request_params[0]->get_list() as $mechanism ) {
+			$mechanisms[] = $mechanism->get_word();
+		}
+		$realm = $auth_request_params[1]->get_string();
+
+		if ( 0 === count( $mechanisms ) ) {
+			// Trivial auth request: nothing to do.
+			return;
+		}
+
+		if ( null !== $this->username && null !== $this->password && in_array( 'CRAM-MD5', $mechanisms, true ) ) {
+			$this->connection->write( '( CRAM-MD5 ( ) ) ' );
+			$step = $this->connection->read_item()->get_list();
+			if ( ! $step[0]->is_word( 'step' ) ) {
+				throw $this->failure_to_exception( $step );
+			}
+			$challenge = $step[1]->get_list()[0]->get_string();
+			$digest    = hash_hmac( 'md5', $challenge, $this->password );
+			$this->connection->write( RaSvnConnection::encode_string( $this->username . ' ' . $digest ) . ' ' );
+			$this->read_auth_outcome( $realm );
+
+			return;
+		}
+
+		if ( in_array( 'ANONYMOUS', $mechanisms, true ) ) {
+			$this->connection->write( '( ANONYMOUS ( ' . RaSvnConnection::encode_string( base64_encode( 'anonymous' ) ) . ' ) ) ' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- the wire protocol wants a base64 token.
+			$this->read_auth_outcome( $realm );
+
+			return;
+		}
+
+		throw new SvnException(
+			'The server offers no supported authentication mechanism (offered: ' . implode( ', ', $mechanisms ) . '). ' .
+			( null === $this->username ? 'Provide a username and a password to use CRAM-MD5.' : 'Only ANONYMOUS and CRAM-MD5 are supported.' )
+		);
+	}
+
+	/**
+	 * Reads the final success/failure of an authentication exchange.
+	 *
+	 * @param  string $realm  The authentication realm, used in error messages.
+	 * @throws SvnException When authentication failed.
+	 */
+	private function read_auth_outcome( $realm ) {
+		$outcome = $this->connection->read_item()->get_list();
+		if ( $outcome[0]->is_word( 'success' ) ) {
+			return;
+		}
+		if ( $outcome[0]->is_word( 'failure' ) ) {
+			$messages = array();
+			foreach ( $outcome[1]->get_list() as $message ) {
+				$messages[] = $message->get_string();
+			}
+
+			throw new SvnException( "Authentication failed for realm '{$realm}': " . implode( '; ', $messages ) );
+		}
+
+		throw new SvnException( 'Protocol error: unexpected authentication outcome.' );
+	}
+
+	/**
+	 * Sends one command tuple.
+	 *
+	 * @param string $name          The command name.
+	 * @param string $encoded_args  Already-encoded argument items.
+	 */
+	private function send_command( $name, $encoded_args ) {
+		$this->connection->write( '( ' . $name . ' ( ' . $encoded_args . ' ) ) ' );
+	}
+
+	/**
+	 * Reads a command response: the per-command auth request followed by
+	 * the `( success ( params ) )` or `( failure ( errors ) )` tuple.
+	 *
+	 * @return RaSvnItem[] The success params.
+	 * @throws SvnException When the server reports a failure.
+	 */
+	private function read_command_response() {
+		$this->consume_auth_request();
+
+		return $this->read_response_tuple();
+	}
+
+	/**
+	 * Reads a `( success ( params ) )` tuple and returns the params,
+	 * converting failures into exceptions.
+	 *
+	 * @return RaSvnItem[]
+	 * @throws SvnException When the server reports a failure.
+	 */
+	private function read_response_tuple() {
+		$tuple = $this->connection->read_item()->get_list();
+		if ( $tuple[0]->is_word( 'success' ) ) {
+			return $tuple[1]->get_list();
+		}
+		if ( $tuple[0]->is_word( 'failure' ) ) {
+			throw $this->failure_to_exception( $tuple );
+		}
+
+		throw new SvnException( "Protocol error: expected a command response, got '{$tuple[0]->get_word()}'." );
+	}
+
+	/**
+	 * Consumes the auth request the server sends before every command
+	 * response, re-authenticating when the server asks for it.
+	 */
+	private function consume_auth_request() {
+		$tuple = $this->connection->read_item()->get_list();
+		if ( $tuple[0]->is_word( 'failure' ) ) {
+			throw $this->failure_to_exception( $tuple );
+		}
+		if ( ! $tuple[0]->is_word( 'success' ) ) {
+			throw new SvnException( 'Protocol error: expected an auth request.' );
+		}
+		$this->authenticate( $tuple[1]->get_list() );
+	}
+
+	/**
+	 * Converts a `( failure ( ( apr-err message file line ) ... ) )`
+	 * tuple into an exception.
+	 *
+	 * @param  RaSvnItem[] $tuple  The failure tuple items.
+	 * @return SvnException
+	 */
+	private function failure_to_exception( $tuple ) {
+		$messages = array();
+		foreach ( $tuple[1]->get_list() as $error ) {
+			$error_parts = $error->get_list();
+			$message     = $error_parts[1]->get_string();
+			if ( '' !== $message ) {
+				$messages[] = $message . ' (SVN error ' . $error_parts[0]->get_number() . ')';
+			}
+		}
+		if ( 0 === count( $messages ) ) {
+			$messages[] = 'The server reported an unspecified error.';
+		}
+
+		return new SvnException( implode( '; ', $messages ) );
+	}
+
+	/**
+	 * Encodes an optional revision argument: `( N )` or `( )` for "latest".
+	 *
+	 * @param  int|null $revision  The revision, or null for the latest.
+	 * @return string
+	 */
+	private function encode_optional_revision( $revision ) {
+		return null === $revision ? '( )' : '( ' . (int) $revision . ' )';
+	}
+
+	/**
+	 * Extracts versioned properties from a wire proplist, dropping the
+	 * unversioned svn:entry:* and svn:wc:* bookkeeping properties.
+	 *
+	 * @param  RaSvnItem $proplist_item  A list of ( name value ) tuples.
+	 * @return array Property name => value.
+	 */
+	private function parse_versioned_properties( $proplist_item ) {
+		$properties = array();
+		foreach ( $proplist_item->get_list() as $pair_item ) {
+			$pair = $pair_item->get_list();
+			$name = $pair[0]->get_string();
+			if ( 0 === strpos( $name, 'svn:entry:' ) || 0 === strpos( $name, 'svn:wc:' ) ) {
+				continue;
+			}
+			$properties[ $name ] = $pair[1]->get_string();
+		}
+
+		return $properties;
+	}
+
+	/**
+	 * Returns true for property names the working copy must not store,
+	 * such as svn:entry:committed-rev.
+	 *
+	 * @param  string $name  The property name.
+	 * @return bool
+	 */
+	private function is_entry_property( $name ) {
+		return 0 === strpos( $name, 'svn:entry:' ) || 0 === strpos( $name, 'svn:wc:' );
+	}
+
+	/**
+	 * Reads editor commands from the server and dispatches them onto the
+	 * editor until the drive completes.
+	 *
+	 * @param  SvnEditor $editor  The editor to drive.
+	 * @throws SvnException When the server reports a failure.
+	 */
+	private function consume_editor_drive( SvnEditor $editor ) {
+		// Token => path maps. The wire protocol addresses open files and
+		// directories by server-chosen tokens; the editor interface uses paths.
+		$directory_paths = array();
+		$file_paths      = array();
+
+		while ( true ) {
+			$tuple   = $this->connection->read_item()->get_list();
+			$command = $tuple[0]->get_word();
+			$params  = isset( $tuple[1] ) ? $tuple[1]->get_list() : array();
+
+			switch ( $command ) {
+				case 'success':
+					// Auth requests interleave with the drive; the trivial
+					// form needs no action and the non-trivial one is
+					// handled by authenticate().
+					if ( 2 === count( $params ) && RaSvnItem::TYPE_LIST === $params[0]->type && RaSvnItem::TYPE_STRING === $params[1]->type ) {
+						$this->authenticate( $params );
+					}
+					break;
+
+				case 'failure':
+					$editor->abort_edit();
+					throw $this->failure_to_exception( $tuple );
+
+				case 'target-rev':
+					$editor->set_target_revision( $params[0]->get_number() );
+					break;
+
+				case 'open-root':
+					$directory_paths[ $params[1]->get_string() ] = '';
+					$editor->open_root();
+					break;
+
+				case 'add-dir':
+					$path                                        = $params[0]->get_string();
+					$directory_paths[ $params[2]->get_string() ] = $path;
+					$editor->add_directory( $path );
+					break;
+
+				case 'open-dir':
+					$path                                        = $params[0]->get_string();
+					$directory_paths[ $params[2]->get_string() ] = $path;
+					$editor->open_directory( $path );
+					break;
+
+				case 'change-dir-prop':
+					$name = $params[1]->get_string();
+					if ( ! $this->is_entry_property( $name ) ) {
+						$value = $params[2]->get_optional();
+						$editor->change_directory_property(
+							$directory_paths[ $params[0]->get_string() ],
+							$name,
+							null === $value ? null : $value->get_string()
+						);
+					}
+					break;
+
+				case 'close-dir':
+					$token = $params[0]->get_string();
+					$editor->close_directory( $directory_paths[ $token ] );
+					unset( $directory_paths[ $token ] );
+					break;
+
+				case 'add-file':
+					$path                                   = $params[0]->get_string();
+					$file_paths[ $params[2]->get_string() ] = $path;
+					$editor->add_file( $path );
+					break;
+
+				case 'open-file':
+					$path                                   = $params[0]->get_string();
+					$file_paths[ $params[2]->get_string() ] = $path;
+					$editor->open_file( $path );
+					break;
+
+				case 'change-file-prop':
+					$name = $params[1]->get_string();
+					if ( ! $this->is_entry_property( $name ) ) {
+						$value = $params[2]->get_optional();
+						$editor->change_file_property(
+							$file_paths[ $params[0]->get_string() ],
+							$name,
+							null === $value ? null : $value->get_string()
+						);
+					}
+					break;
+
+				case 'apply-textdelta':
+					$base_checksum = $params[1]->get_optional();
+					$editor->apply_textdelta(
+						$file_paths[ $params[0]->get_string() ],
+						null === $base_checksum ? null : $base_checksum->get_string()
+					);
+					break;
+
+				case 'textdelta-chunk':
+					$editor->write_textdelta_chunk(
+						$file_paths[ $params[0]->get_string() ],
+						$params[1]->get_string()
+					);
+					break;
+
+				case 'textdelta-end':
+					$editor->textdelta_end( $file_paths[ $params[0]->get_string() ] );
+					break;
+
+				case 'close-file':
+					$token         = $params[0]->get_string();
+					$text_checksum = $params[1]->get_optional();
+					$editor->close_file(
+						$file_paths[ $token ],
+						null === $text_checksum ? null : $text_checksum->get_string()
+					);
+					unset( $file_paths[ $token ] );
+					break;
+
+				case 'delete-entry':
+					$editor->delete_entry( $params[0]->get_string() );
+					break;
+
+				case 'absent-dir':
+				case 'absent-file':
+					// The server cannot show us this entry (typically due to
+					// path-based authorization). There is nothing to do.
+					break;
+
+				case 'close-edit':
+					// Acknowledge the drive, consume the final command
+					// response, and finish.
+					$this->connection->write( '( success ( ) ) ' );
+					$this->read_final_drive_response();
+					$editor->close_edit();
+
+					return;
+
+				case 'abort-edit':
+					$editor->abort_edit();
+					throw new SvnException( 'The server aborted the update before it completed.' );
+
+				default:
+					throw new SvnException( "Protocol error: unknown editor command '{$command}'." );
+			}
+		}
+	}
+
+	/**
+	 * Reads the command response that concludes an editor drive. Unlike
+	 * regular command responses it is not necessarily preceded by an
+	 * auth request, so both forms are tolerated.
+	 *
+	 * @throws SvnException When the server reports a failure.
+	 */
+	private function read_final_drive_response() {
+		while ( true ) {
+			$tuple = $this->connection->read_item()->get_list();
+			if ( $tuple[0]->is_word( 'failure' ) ) {
+				throw $this->failure_to_exception( $tuple );
+			}
+			if ( ! $tuple[0]->is_word( 'success' ) ) {
+				throw new SvnException( "Protocol error: expected the final update response, got '{$tuple[0]->get_word()}'." );
+			}
+			$params = $tuple[1]->get_list();
+			if ( 2 === count( $params ) && RaSvnItem::TYPE_LIST === $params[0]->type && RaSvnItem::TYPE_STRING === $params[1]->type ) {
+				// An interleaved auth request.
+				$this->authenticate( $params );
+				continue;
+			}
+
+			return;
+		}
+	}
+
+	/**
+	 * Drives the server's commit editor with a set of changes.
+	 *
+	 * @param  array[] $operations  See SvnSession::commit().
+	 * @throws SvnException When the operations are inconsistent.
+	 */
+	private function drive_commit_editor( $operations ) {
+		$operations_by_parent = $this->group_operations_by_parent( $operations );
+		$this->next_token     = 0;
+
+		$root_token = $this->allocate_token( 'd' );
+		$this->connection->write( '( open-root ( ( ) ' . RaSvnConnection::encode_string( $root_token ) . ' ) ) ' );
+		$this->drive_commit_directory( '', $root_token, $operations_by_parent );
+		$this->connection->write( '( close-dir ( ' . RaSvnConnection::encode_string( $root_token ) . ' ) ) ' );
+		$this->connection->write( '( close-edit ( ) ) ' );
+	}
+
+	/**
+	 * @param  string $prefix  'd' for directories, 'f' for files.
+	 * @return string A token unique within the current editor drive.
+	 */
+	private function allocate_token( $prefix ) {
+		return $prefix . ( $this->next_token++ );
+	}
+
+	/**
+	 * Groups commit operations by the directory that contains them and
+	 * registers every ancestor directory that must be opened.
+	 *
+	 * @param  array[] $operations  See SvnSession::commit().
+	 * @return array Map of directory path => list of operations on its direct children.
+	 */
+	private function group_operations_by_parent( $operations ) {
+		$by_parent = array( '' => array() );
+		foreach ( $operations as $operation ) {
+			if ( ! isset( $operation['op'], $operation['path'] ) ) {
+				throw new SvnException( 'Each commit operation needs an "op" and a "path".' );
+			}
+			$path = trim( $operation['path'], '/' );
+			if ( '' === $path ) {
+				throw new SvnException( 'Commit operations cannot target the session root itself.' );
+			}
+			$operation['path'] = $path;
+
+			$parent = self::parent_path( $path );
+			if ( ! isset( $by_parent[ $parent ] ) ) {
+				$by_parent[ $parent ] = array();
+			}
+			$by_parent[ $parent ][] = $operation;
+
+			// Register all ancestors so the drive knows to descend into them.
+			$ancestor = $parent;
+			while ( '' !== $ancestor ) {
+				$ancestor = self::parent_path( $ancestor );
+				if ( ! isset( $by_parent[ $ancestor ] ) ) {
+					$by_parent[ $ancestor ] = array();
+				}
+			}
+		}
+
+		return $by_parent;
+	}
+
+	/**
+	 * @param  string $path  A relative path.
+	 * @return string The parent path, '' for top-level entries.
+	 */
+	private static function parent_path( $path ) {
+		$slash_position = strrpos( $path, '/' );
+
+		return false === $slash_position ? '' : substr( $path, 0, $slash_position );
+	}
+
+	/**
+	 * Emits the editor commands for one directory level, then recurses.
+	 *
+	 * @param string $directory_path        The directory being driven, '' for the root.
+	 * @param string $directory_token       The wire token of the open directory.
+	 * @param array  $operations_by_parent  See group_operations_by_parent().
+	 */
+	private function drive_commit_directory( $directory_path, $directory_token, $operations_by_parent ) {
+		$operations = isset( $operations_by_parent[ $directory_path ] ) ? $operations_by_parent[ $directory_path ] : array();
+
+		// Deletes first so that replacements (delete + add of the same
+		// path) drive correctly.
+		usort(
+			$operations,
+			function ( $a, $b ) {
+				$a_is_delete = 'delete' === $a['op'] ? 0 : 1;
+				$b_is_delete = 'delete' === $b['op'] ? 0 : 1;
+				if ( $a_is_delete !== $b_is_delete ) {
+					return $a_is_delete - $b_is_delete;
+				}
+
+				return strcmp( $a['path'], $b['path'] );
+			}
+		);
+
+		$added_directories = array();
+		foreach ( $operations as $operation ) {
+			switch ( $operation['op'] ) {
+				case 'delete':
+					$this->connection->write(
+						'( delete-entry ( ' .
+						RaSvnConnection::encode_string( $operation['path'] ) . ' ' .
+						( isset( $operation['base_revision'] ) ? '( ' . (int) $operation['base_revision'] . ' )' : '( )' ) . ' ' .
+						RaSvnConnection::encode_string( $directory_token ) .
+						' ) ) '
+					);
+					break;
+
+				case 'add-directory':
+					$token = $this->allocate_token( 'd' );
+					$this->connection->write(
+						'( add-dir ( ' .
+						RaSvnConnection::encode_string( $operation['path'] ) . ' ' .
+						RaSvnConnection::encode_string( $directory_token ) . ' ' .
+						RaSvnConnection::encode_string( $token ) .
+						' ( ) ) ) '
+					);
+					$this->write_property_changes( 'change-dir-prop', $token, isset( $operation['properties'] ) ? $operation['properties'] : array() );
+					$this->drive_commit_directory( $operation['path'], $token, $operations_by_parent );
+					$this->connection->write( '( close-dir ( ' . RaSvnConnection::encode_string( $token ) . ' ) ) ' );
+					$added_directories[ $operation['path'] ] = true;
+					break;
+
+				case 'add-file':
+				case 'modify-file':
+					$token = $this->allocate_token( 'f' );
+					if ( 'add-file' === $operation['op'] ) {
+						$this->connection->write(
+							'( add-file ( ' .
+							RaSvnConnection::encode_string( $operation['path'] ) . ' ' .
+							RaSvnConnection::encode_string( $directory_token ) . ' ' .
+							RaSvnConnection::encode_string( $token ) .
+							' ( ) ) ) '
+						);
+					} else {
+						$this->connection->write(
+							'( open-file ( ' .
+							RaSvnConnection::encode_string( $operation['path'] ) . ' ' .
+							RaSvnConnection::encode_string( $directory_token ) . ' ' .
+							RaSvnConnection::encode_string( $token ) . ' ' .
+							( isset( $operation['base_revision'] ) ? '( ' . (int) $operation['base_revision'] . ' )' : '( )' ) .
+							' ) ) '
+						);
+					}
+					$this->write_file_contents( $token, $operation['contents'] );
+					$this->write_property_changes( 'change-file-prop', $token, isset( $operation['properties'] ) ? $operation['properties'] : array() );
+					$this->connection->write(
+						'( close-file ( ' .
+						RaSvnConnection::encode_string( $token ) .
+						' ( ' . RaSvnConnection::encode_string( md5( $operation['contents'] ) ) . ' ) ) ) '
+					);
+					break;
+
+				case 'modify-properties':
+					$token = $this->allocate_token( isset( $operation['kind'] ) && 'dir' === $operation['kind'] ? 'd' : 'f' );
+					if ( isset( $operation['kind'] ) && 'dir' === $operation['kind'] ) {
+						$this->connection->write(
+							'( open-dir ( ' .
+							RaSvnConnection::encode_string( $operation['path'] ) . ' ' .
+							RaSvnConnection::encode_string( $directory_token ) . ' ' .
+							RaSvnConnection::encode_string( $token ) . ' ' .
+							( isset( $operation['base_revision'] ) ? '( ' . (int) $operation['base_revision'] . ' )' : '( )' ) .
+							' ) ) '
+						);
+						$this->write_property_changes( 'change-dir-prop', $token, $operation['properties'] );
+						$this->drive_commit_directory( $operation['path'], $token, $operations_by_parent );
+						$this->connection->write( '( close-dir ( ' . RaSvnConnection::encode_string( $token ) . ' ) ) ' );
+						$added_directories[ $operation['path'] ] = true;
+					} else {
+						$this->connection->write(
+							'( open-file ( ' .
+							RaSvnConnection::encode_string( $operation['path'] ) . ' ' .
+							RaSvnConnection::encode_string( $directory_token ) . ' ' .
+							RaSvnConnection::encode_string( $token ) . ' ' .
+							( isset( $operation['base_revision'] ) ? '( ' . (int) $operation['base_revision'] . ' )' : '( )' ) .
+							' ) ) '
+						);
+						$this->write_property_changes( 'change-file-prop', $token, $operation['properties'] );
+						$this->connection->write( '( close-file ( ' . RaSvnConnection::encode_string( $token ) . ' ( ) ) ) ' );
+					}
+					break;
+
+				default:
+					throw new SvnException( "Unknown commit operation '{$operation['op']}'." );
+			}
+		}
+
+		// Descend into directories that only contain nested operations.
+		foreach ( $operations_by_parent as $path => $unused ) {
+			if ( '' === $path || isset( $added_directories[ $path ] ) ) {
+				continue;
+			}
+			if ( self::parent_path( $path ) !== $directory_path ) {
+				continue;
+			}
+			$has_direct_operation = false;
+			foreach ( $operations as $operation ) {
+				if ( $operation['path'] === $path && 'delete' !== $operation['op'] ) {
+					$has_direct_operation = true;
+					break;
+				}
+			}
+			if ( $has_direct_operation ) {
+				continue;
+			}
+			$token = $this->allocate_token( 'd' );
+			$this->connection->write(
+				'( open-dir ( ' .
+				RaSvnConnection::encode_string( $path ) . ' ' .
+				RaSvnConnection::encode_string( $directory_token ) . ' ' .
+				RaSvnConnection::encode_string( $token ) .
+				' ( ) ) ) '
+			);
+			$this->drive_commit_directory( $path, $token, $operations_by_parent );
+			$this->connection->write( '( close-dir ( ' . RaSvnConnection::encode_string( $token ) . ' ) ) ' );
+		}
+	}
+
+	/**
+	 * Sends a file's full contents as an svndiff0 delta against an empty base.
+	 *
+	 * @param string $token     The open file's wire token.
+	 * @param string $contents  The new full text of the file.
+	 */
+	private function write_file_contents( $token, $contents ) {
+		$encoded_token = RaSvnConnection::encode_string( $token );
+		$this->connection->write( '( apply-textdelta ( ' . $encoded_token . ' ( ) ) ) ' );
+		$svndiff = SvnDiff::encode_fulltext( $contents );
+		$offset  = 0;
+		$length  = strlen( $svndiff );
+		while ( $offset < $length ) {
+			$chunk = substr( $svndiff, $offset, 131072 );
+			$this->connection->write( '( textdelta-chunk ( ' . $encoded_token . ' ' . RaSvnConnection::encode_string( $chunk ) . ' ) ) ' );
+			$offset += strlen( $chunk );
+		}
+		$this->connection->write( '( textdelta-end ( ' . $encoded_token . ' ) ) ' );
+	}
+
+	/**
+	 * Emits change-file-prop / change-dir-prop commands.
+	 *
+	 * @param string $command     'change-file-prop' or 'change-dir-prop'.
+	 * @param string $token       The open node's wire token.
+	 * @param array  $properties  Property name => value, null value deletes.
+	 */
+	private function write_property_changes( $command, $token, $properties ) {
+		foreach ( $properties as $name => $value ) {
+			$this->connection->write(
+				'( ' . $command . ' ( ' .
+				RaSvnConnection::encode_string( $token ) . ' ' .
+				RaSvnConnection::encode_string( $name ) . ' ' .
+				( null === $value ? '( )' : '( ' . RaSvnConnection::encode_string( $value ) . ' )' ) .
+				' ) ) '
+			);
+		}
+	}
+
+	/**
+	 * Reads the post-drive commit outcome: the close-edit acknowledgment,
+	 * an auth request, and the ( new-rev date author ) commit info.
+	 *
+	 * @return array { @type int $revision  @type string|null $author  @type string|null $date }
+	 * @throws SvnException When the commit was rejected.
+	 */
+	private function read_commit_info() {
+		while ( true ) {
+			$item = $this->connection->read_item();
+			$list = $item->get_list();
+			if ( count( $list ) > 0 && RaSvnItem::TYPE_WORD === $list[0]->type ) {
+				if ( $list[0]->is_word( 'failure' ) ) {
+					throw $this->failure_to_exception( $list );
+				}
+				if ( $list[0]->is_word( 'success' ) ) {
+					// Either the close-edit acknowledgment or an interleaved
+					// auth request; both need no action here.
+					continue;
+				}
+				throw new SvnException( "Protocol error: unexpected '{$list[0]->get_word()}' while waiting for commit info." );
+			}
+
+			// A bare list: ( new-rev ( date ) ( author ) ( post-commit-errors ) ).
+			$date   = $list[1]->get_optional();
+			$author = $list[2]->get_optional();
+
+			return array(
+				'revision' => $list[0]->get_number(),
+				'author'   => null === $author ? null : $author->get_string_or_word(),
+				'date'     => null === $date ? null : $date->get_string(),
+			);
+		}
+	}
+
+	/**
+	 * After a mid-drive write error, the server has usually already
+	 * queued a failure response explaining what it rejected. Prefer that
+	 * message over the generic broken-pipe error.
+	 *
+	 * @param  SvnException $fallback  The exception to throw when no failure is queued.
+	 * @return SvnException
+	 */
+	private function read_pending_commit_failure( SvnException $fallback ) {
+		try {
+			while ( true ) {
+				$list = $this->connection->read_item()->get_list();
+				if ( count( $list ) > 0 && $list[0]->is_word( 'failure' ) ) {
+					return $this->failure_to_exception( $list );
+				}
+			}
+		} catch ( SvnException $exception ) {
+			return $fallback;
+		}
+	}
+}

--- a/components/Svn/README.md
+++ b/components/Svn/README.md
@@ -1,0 +1,124 @@
+---
+slug: svn
+title: Svn
+install: wp-php-toolkit/svn
+
+see_also:
+  - git | Git | Work with Git repositories through the same pure-PHP philosophy.
+  - filesystem | Filesystem | Place working copies on disk, in memory, or in other backends.
+  - http-client | HttpClient | The transport behind http:// and https:// repository access.
+  - xml | XML | The streaming parser behind the DAV protocol support.
+---
+
+A Subversion client in pure PHP. Check out, update, and commit to SVN repositories – including WordPress.org's – over both <code>svn://</code> and <code>http(s)://</code>, without the <code>svn</code> binary or any PHP extension.
+
+## Why this exists
+
+<p>WordPress itself lives in Subversion: core development happens in <code>develop.svn.wordpress.org</code> and every plugin and theme ships through <code>plugins.svn.wordpress.org</code> and <code>themes.svn.wordpress.org</code>. Automating anything around that ecosystem – deploying a plugin release, mirroring core, building developer tooling – traditionally requires shelling out to the <code>svn</code> binary, which hosted environments rarely provide.</p>
+
+<p>This component implements the client side of both Subversion protocols in PHP: the custom <code>svn://</code> wire protocol (ra_svn) and the HTTP-based one (mod_dav_svn, HTTP protocol v2). Checkouts and updates stream the server's "editor drive" – the same tree-delta mechanism the official client uses – so a full <code>wordpress-develop</code> checkout arrives in a single HTTP response and runs in tens of megabytes of memory.</p>
+
+<p><code>svn:externals</code> definitions are honored: referenced repositories are checked out as nested working copies, updated alongside their parent, and skipped by status and commit – matching the official client's behavior.</p>
+
+<p>One caveat: working copies use this component's own <code>.svn</code> metadata format (JSON plus a pristine store), not the SQLite database of the official client. The repositories themselves are fully interoperable – commits made here are indistinguishable from commits made with <code>svn</code> – but a working copy created by one client cannot be operated on by the other.</p>
+
+## Check out a plugin from WordPress.org
+
+<p>Point <code>checkout()</code> at any repository URL. The revision, the depth, and <code>svn:externals</code> handling are controlled per call.</p>
+
+<!-- snippet:
+filename: checkout-plugin.php
+runnable: false
+-->
+```php
+<?php
+require '/php-toolkit/vendor/autoload.php';
+
+use WordPress\Svn\SvnClient;
+
+$client = new SvnClient();
+$result = $client->checkout(
+	'https://plugins.svn.wordpress.org/hello-dolly/trunk',
+	'/tmp/hello-dolly'
+);
+
+echo "checked out r{$result['revision']}\n";
+echo file_get_contents( '/tmp/hello-dolly/hello.php' );
+```
+
+## Make a commit
+
+<p>Edit files, schedule additions and deletions, commit. Locally modified files that changed upstream too are marked conflicted on update and refuse to commit until <code>resolved()</code>.</p>
+
+<!-- snippet:
+filename: commit-changes.php
+runnable: false
+-->
+```php
+<?php
+require '/php-toolkit/vendor/autoload.php';
+
+use WordPress\Svn\SvnClient;
+
+$client = new SvnClient( array(
+	'username' => 'my-wporg-login',
+	'password' => getenv( 'SVN_PASSWORD' ),
+) );
+
+$wc = '/tmp/my-plugin';
+$client->checkout( 'https://plugins.svn.wordpress.org/my-plugin/trunk', $wc );
+
+file_put_contents( "$wc/readme.txt", "= My Plugin 1.1 =\n" );
+file_put_contents( "$wc/new-feature.php", "<?php // ...\n" );
+$client->add( $wc, 'new-feature.php' );
+$client->delete( $wc, 'deprecated.php' );
+
+print_r( $client->status( $wc ) );
+
+$info = $client->commit( $wc, 'Release 1.1.' );
+echo "committed r{$info['revision']}\n";
+```
+
+## Talk to a repository without a working copy
+
+<p><code>open_session()</code> exposes the repository primitives both protocols share: list directories, fetch files and properties, inspect revisions, or commit a changeset built in memory.</p>
+
+<!-- snippet:
+filename: repository-session.php
+runnable: false
+-->
+```php
+<?php
+require '/php-toolkit/vendor/autoload.php';
+
+use WordPress\Svn\SvnClient;
+
+$client  = new SvnClient();
+$session = $client->open_session( 'https://develop.svn.wordpress.org/trunk' );
+
+echo "HEAD is r{$session->get_latest_revision()}\n";
+foreach ( $session->list_directory( 'src/wp-includes/blocks' ) as $entry ) {
+	echo "{$entry['kind']}\t{$entry['name']}\n";
+}
+
+$file = $session->get_file( 'wp-config-sample.php' );
+echo $file['contents'];
+
+$session->close();
+```
+
+## Supported and not supported
+
+<p>Supported: checkout (any depth), update (with per-file conflict
+detection), status, add, delete, revert, resolved, commit (files,
+directories, and property changes), <code>svn:externals</code> (including
+<code>^/</code>, <code>../</code>, <code>//</code>, and <code>/</code> relative
+URLs, pinned revisions, and the pre-1.5 syntax), <code>svn:eol-style</code>
+translation, anonymous and password authentication (HTTP Basic over
+http(s), CRAM-MD5 over svn://).</p>
+
+<p>Not supported (yet): <code>file://</code> and <code>svn+ssh://</code>
+URLs, locks, <code>svn:keywords</code> expansion, <code>svn:special</code>
+symlinks, merge tracking, mixed-depth sparse checkouts, and working
+copies shared with the official client. HTTP servers must run
+Subversion 1.7 or newer (HTTP protocol v2).</p>

--- a/components/Svn/Tests/DavClientTest.php
+++ b/components/Svn/Tests/DavClientTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WordPress\Svn\Tests\SvnClientBehaviorTrait;
+use WordPress\Svn\Tests\SvnTestServer;
+
+require_once __DIR__ . '/SvnTestServer.php';
+require_once __DIR__ . '/SvnClientBehaviorTrait.php';
+
+/**
+ * Runs the client scenarios over http:// against a real Apache +
+ * mod_dav_svn server in a Docker container (see Tests/http-server/).
+ * Skipped when no Docker daemon is available.
+ */
+class DavClientTest extends TestCase {
+	use SvnClientBehaviorTrait;
+
+	/**
+	 * @var SvnTestServer|null
+	 */
+	private static $dav_server;
+
+	/**
+	 * @beforeClass
+	 */
+	public static function start_server() {
+		if ( ! SvnTestServer::docker_available() ) {
+			self::markTestSkipped( 'Docker is not available; skipping the mod_dav_svn integration tests.' );
+		}
+		self::$dav_server = SvnTestServer::start_dav();
+	}
+
+	/**
+	 * @afterClass
+	 */
+	public static function stop_server() {
+		if ( null !== self::$dav_server ) {
+			self::$dav_server->stop();
+			self::$dav_server = null;
+		}
+	}
+
+	protected function server() {
+		return self::$dav_server;
+	}
+}

--- a/components/Svn/Tests/DavUpdateReportParserTest.php
+++ b/components/Svn/Tests/DavUpdateReportParserTest.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WordPress\Svn\Protocol\DavUpdateReportParser;
+use WordPress\Svn\SvnException;
+use WordPress\Svn\Tests\RecordingEditor;
+
+require_once __DIR__ . '/RecordingEditor.php';
+
+class DavUpdateReportParserTest extends TestCase {
+	public function test_parses_checkout_report_captured_from_mod_dav_svn() {
+		$editor = new RecordingEditor();
+		$parser = new DavUpdateReportParser( $editor );
+		$parser->append_bytes( file_get_contents( __DIR__ . '/fixtures/update-report-checkout.xml' ) );
+		$parser->finish();
+
+		$this->assertSame( 2, $editor->target_revision );
+		$this->assertContains( 'open-root', $editor->events );
+		$this->assertContains( 'add-directory: sub', $editor->events );
+		$this->assertContains( 'add-directory: sub/deep', $editor->events );
+		$this->assertContains( 'add-file: sub/deep/nested.txt', $editor->events );
+		$this->assertContains( 'close-file: sub/deep/nested.txt (checksum ok)', $editor->events );
+		$this->assertContains( 'close-edit', $editor->events );
+
+		$this->assertSame( "hello world\n", $editor->files['hello.txt'] );
+		// multi.txt has svn:eol-style CRLF, and Subversion stores fixed
+		// eol-style files with that line ending in the repository.
+		$this->assertSame( "line1\r\nline2\r\nline3\r\n", $editor->files['multi.txt'] );
+		$this->assertSame( "nested file\n", $editor->files['sub/deep/nested.txt'] );
+
+		// The svn:entry:* bookkeeping properties must not leak through,
+		// real versioned properties must.
+		$this->assertSame( array( 'svn:eol-style' => 'CRLF' ), $editor->properties['multi.txt'] );
+		$this->assertArrayNotHasKey( 'hello.txt', $editor->properties );
+	}
+
+	public function test_chunked_feeding_produces_identical_results() {
+		$fixture = file_get_contents( __DIR__ . '/fixtures/update-report-checkout.xml' );
+
+		$editor = new RecordingEditor();
+		$parser = new DavUpdateReportParser( $editor );
+		foreach ( str_split( $fixture, 7 ) as $chunk ) {
+			$parser->append_bytes( $chunk );
+		}
+		$parser->finish();
+
+		$reference_editor = new RecordingEditor();
+		$reference_parser = new DavUpdateReportParser( $reference_editor );
+		$reference_parser->append_bytes( $fixture );
+		$reference_parser->finish();
+
+		$this->assertSame( $reference_editor->events, $editor->events );
+		$this->assertSame( $reference_editor->files, $editor->files );
+	}
+
+	public function test_parses_update_with_deletes_and_prop_changes() {
+		$xml = '<?xml version="1.0" encoding="utf-8"?>' . "\n" .
+			'<S:update-report xmlns:S="svn:" xmlns:V="http://subversion.tigris.org/xmlns/dav/" xmlns:D="DAV:" send-all="true" inline-props="true">' .
+			'<S:target-revision rev="9"/>' .
+			'<S:open-directory rev="7">' .
+			'<S:delete-entry name="gone.txt"/>' .
+			'<S:open-directory name="sub" rev="7">' .
+			'<S:set-prop name="svn:ignore">*.tmp</S:set-prop>' .
+			'<S:remove-prop name="custom:flag"/>' .
+			'</S:open-directory>' .
+			'<S:open-file name="changed.txt" rev="7">' .
+			'<S:txdelta>' . base64_encode( "SVN\x00" . "\x00\x00\x03\x01\x03" . "\x83" . 'new' ) . '</S:txdelta>' .
+			'<S:prop><V:md5-checksum>' . md5( 'new' ) . '</V:md5-checksum></S:prop>' .
+			'</S:open-file>' .
+			'</S:open-directory>' .
+			'</S:update-report>';
+
+		$editor = new RecordingEditor();
+		$parser = new DavUpdateReportParser( $editor );
+		$parser->append_bytes( $xml );
+		$parser->finish();
+
+		$this->assertContains( 'delete-entry: gone.txt', $editor->events );
+		$this->assertContains( 'open-directory: sub', $editor->events );
+		$this->assertContains( 'open-file: changed.txt', $editor->events );
+		$this->assertContains( 'close-file: changed.txt (checksum ok)', $editor->events );
+		$this->assertSame( 'new', $editor->files['changed.txt'] );
+		$this->assertSame( array( 'svn:ignore' => '*.tmp', 'custom:flag' => null ), $editor->properties['sub'] );
+	}
+
+	public function test_decodes_base64_encoded_property_values() {
+		$xml = '<?xml version="1.0" encoding="utf-8"?>' .
+			'<S:update-report xmlns:S="svn:" xmlns:V="http://subversion.tigris.org/xmlns/dav/" send-all="true">' .
+			'<S:target-revision rev="1"/>' .
+			'<S:open-directory rev="1">' .
+			'<S:set-prop name="custom:binary" V:encoding="base64">' . base64_encode( "\x00\xff binary" ) . '</S:set-prop>' .
+			'</S:open-directory>' .
+			'</S:update-report>';
+
+		$editor = new RecordingEditor();
+		$parser = new DavUpdateReportParser( $editor );
+		$parser->append_bytes( $xml );
+		$parser->finish();
+
+		$this->assertSame( "\x00\xff binary", $editor->properties['']['custom:binary'] );
+	}
+
+	public function test_finish_throws_on_truncated_document() {
+		$this->expectException( SvnException::class );
+		$parser = new DavUpdateReportParser( new RecordingEditor() );
+		$parser->append_bytes( '<S:update-report xmlns:S="svn:"><S:target-revision rev="1"/>' );
+		$parser->finish();
+	}
+}

--- a/components/Svn/Tests/DavUpdateReportParserTest.php
+++ b/components/Svn/Tests/DavUpdateReportParserTest.php
@@ -84,6 +84,22 @@ class DavUpdateReportParserTest extends TestCase {
 		$this->assertSame( array( 'svn:ignore' => '*.tmp', 'custom:flag' => null ), $editor->properties['sub'] );
 	}
 
+	public function test_rejects_update_paths_that_escape_the_working_copy() {
+		$this->expectException( SvnException::class );
+
+		$xml = '<?xml version="1.0" encoding="utf-8"?>' .
+			'<S:update-report xmlns:S="svn:" send-all="true">' .
+			'<S:target-revision rev="1"/>' .
+			'<S:open-directory rev="1">' .
+			'<S:add-directory name="../escape"/>' .
+			'</S:open-directory>' .
+			'</S:update-report>';
+
+		$parser = new DavUpdateReportParser( new RecordingEditor() );
+		$parser->append_bytes( $xml );
+		$parser->finish();
+	}
+
 	public function test_decodes_base64_encoded_property_values() {
 		$xml = '<?xml version="1.0" encoding="utf-8"?>' .
 			'<S:update-report xmlns:S="svn:" xmlns:V="http://subversion.tigris.org/xmlns/dav/" send-all="true">' .

--- a/components/Svn/Tests/RaSvnConnectionTest.php
+++ b/components/Svn/Tests/RaSvnConnectionTest.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WordPress\Svn\Protocol\RaSvnConnection;
+use WordPress\Svn\Protocol\RaSvnItem;
+use WordPress\Svn\SvnException;
+
+class RaSvnConnectionTest extends TestCase {
+	/**
+	 * @param  string $wire  Raw protocol bytes.
+	 * @return RaSvnConnection A connection reading from the given bytes.
+	 */
+	private function connection_for( $wire ) {
+		$stream = fopen( 'php://memory', 'r+b' );
+		fwrite( $stream, $wire );
+		rewind( $stream );
+
+		return new RaSvnConnection( $stream );
+	}
+
+	public function test_reads_words() {
+		$item = $this->connection_for( 'success ' )->read_item();
+		$this->assertSame( RaSvnItem::TYPE_WORD, $item->type );
+		$this->assertSame( 'success', $item->get_word() );
+		$this->assertTrue( $item->is_word( 'success' ) );
+		$this->assertFalse( $item->is_word( 'failure' ) );
+	}
+
+	public function test_reads_numbers() {
+		$this->assertSame( 42, $this->connection_for( '42 ' )->read_item()->get_number() );
+		$this->assertSame( 0, $this->connection_for( '0 ' )->read_item()->get_number() );
+	}
+
+	public function test_reads_strings() {
+		$this->assertSame( 'hello', $this->connection_for( '5:hello ' )->read_item()->get_string() );
+		$this->assertSame( '', $this->connection_for( '0: ' )->read_item()->get_string() );
+	}
+
+	public function test_reads_binary_strings() {
+		$binary = "\x00\x01\xff( ) 7:trap";
+		$item   = $this->connection_for( strlen( $binary ) . ':' . $binary . ' ' )->read_item();
+		$this->assertSame( $binary, $item->get_string() );
+	}
+
+	public function test_reads_nested_lists() {
+		// A real svnserve greeting.
+		$connection = $this->connection_for( '( success ( 2 2 ( ) ( edit-pipeline svndiff1 ) ) ) ' );
+		$tuple      = $connection->read_item()->get_list();
+		$this->assertSame( 'success', $tuple[0]->get_word() );
+		$params = $tuple[1]->get_list();
+		$this->assertSame( 2, $params[0]->get_number() );
+		$this->assertSame( 2, $params[1]->get_number() );
+		$this->assertSame( array(), $params[2]->get_list() );
+		$capabilities = $params[3]->get_list();
+		$this->assertSame( 'edit-pipeline', $capabilities[0]->get_word() );
+		$this->assertSame( 'svndiff1', $capabilities[1]->get_word() );
+	}
+
+	public function test_reads_consecutive_items() {
+		$connection = $this->connection_for( '( success ( ) ) ( failure ( ) ) 12 ' );
+		$this->assertSame( 'success', $connection->read_item()->get_list()[0]->get_word() );
+		$this->assertSame( 'failure', $connection->read_item()->get_list()[0]->get_word() );
+		$this->assertSame( 12, $connection->read_item()->get_number() );
+	}
+
+	public function test_tolerates_extra_whitespace() {
+		$item = $this->connection_for( "  (  success \n (  1  )  )  " )->read_item();
+		$this->assertSame( 'success', $item->get_list()[0]->get_word() );
+		$this->assertSame( 1, $item->get_list()[1]->get_list()[0]->get_number() );
+	}
+
+	public function test_throws_on_connection_end() {
+		$this->expectException( SvnException::class );
+		$this->connection_for( '( success ( ' )->read_item();
+	}
+
+	public function test_optional_value_helpers() {
+		$connection = $this->connection_for( '( ) ( 5 ) ' );
+		$this->assertNull( $connection->read_item()->get_optional() );
+		$this->assertSame( 5, $connection->read_item()->get_optional()->get_number() );
+	}
+
+	public function test_type_mismatch_throws() {
+		$this->expectException( SvnException::class );
+		$this->connection_for( '42 ' )->read_item()->get_string();
+	}
+
+	public function test_boolean_words() {
+		$connection = $this->connection_for( 'true false ' );
+		$this->assertTrue( $connection->read_item()->get_boolean() );
+		$this->assertFalse( $connection->read_item()->get_boolean() );
+	}
+
+	public function test_encode_string() {
+		$this->assertSame( '5:hello', RaSvnConnection::encode_string( 'hello' ) );
+		$this->assertSame( '0:', RaSvnConnection::encode_string( '' ) );
+	}
+
+	public function test_encode_boolean() {
+		$this->assertSame( 'true', RaSvnConnection::encode_boolean( true ) );
+		$this->assertSame( 'false', RaSvnConnection::encode_boolean( false ) );
+	}
+
+	public function test_write_appends_to_stream() {
+		$stream     = fopen( 'php://memory', 'r+b' );
+		$connection = new RaSvnConnection( $stream );
+		$connection->write( '( get-latest-rev ( ) ) ' );
+		rewind( $stream );
+		$this->assertSame( '( get-latest-rev ( ) ) ', stream_get_contents( $stream ) );
+	}
+}

--- a/components/Svn/Tests/RecordingEditor.php
+++ b/components/Svn/Tests/RecordingEditor.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace WordPress\Svn\Tests;
+
+use WordPress\Svn\SvnDiffApplier;
+use WordPress\Svn\SvnEditor;
+
+/**
+ * An SvnEditor that records the drive it receives: the ordered list of
+ * editor events, the decoded file contents, and the property changes.
+ * Used to assert on what the session classes emit.
+ */
+class RecordingEditor implements SvnEditor {
+	/**
+	 * @var string[]
+	 */
+	public $events = array();
+
+	/**
+	 * @var array Path => decoded file contents.
+	 */
+	public $files = array();
+
+	/**
+	 * @var array Path => property name => value.
+	 */
+	public $properties = array();
+
+	/**
+	 * @var int|null
+	 */
+	public $target_revision;
+
+	/**
+	 * @var SvnDiffApplier[]
+	 */
+	private $appliers = array();
+
+	/**
+	 * @var array Pristine contents handed to appliers, path => string.
+	 */
+	private $bases;
+
+	public function __construct( $bases = array() ) {
+		$this->bases = $bases;
+	}
+
+	public function set_target_revision( $revision ) {
+		$this->target_revision = $revision;
+		$this->events[]        = "target-revision: {$revision}";
+	}
+
+	public function open_root() {
+		$this->events[] = 'open-root';
+	}
+
+	public function add_directory( $path ) {
+		$this->events[] = "add-directory: {$path}";
+	}
+
+	public function open_directory( $path ) {
+		$this->events[] = "open-directory: {$path}";
+	}
+
+	public function change_directory_property( $path, $name, $value ) {
+		$this->properties[ $path ][ $name ] = $value;
+		$this->events[] = "change-directory-property: {$path} {$name}";
+	}
+
+	public function close_directory( $path ) {
+		$this->events[] = "close-directory: {$path}";
+	}
+
+	public function add_file( $path ) {
+		$this->events[] = "add-file: {$path}";
+	}
+
+	public function open_file( $path ) {
+		$this->events[] = "open-file: {$path}";
+	}
+
+	public function change_file_property( $path, $name, $value ) {
+		$this->properties[ $path ][ $name ] = $value;
+		$this->events[] = "change-file-property: {$path} {$name}";
+	}
+
+	public function apply_textdelta( $path, $base_checksum ) {
+		$this->appliers[ $path ] = new SvnDiffApplier( isset( $this->bases[ $path ] ) ? $this->bases[ $path ] : '' );
+	}
+
+	public function write_textdelta_chunk( $path, $svndiff_bytes ) {
+		$this->appliers[ $path ]->append_bytes( $svndiff_bytes );
+	}
+
+	public function textdelta_end( $path ) {
+		$this->appliers[ $path ]->finish();
+		$this->files[ $path ] = $this->appliers[ $path ]->get_target();
+		unset( $this->appliers[ $path ] );
+	}
+
+	public function close_file( $path, $text_checksum ) {
+		$checksum_state = null === $text_checksum ? 'no checksum' : (
+			isset( $this->files[ $path ] ) && md5( $this->files[ $path ] ) === $text_checksum ? 'checksum ok' : 'CHECKSUM MISMATCH'
+		);
+		$this->events[] = "close-file: {$path} ({$checksum_state})";
+	}
+
+	public function delete_entry( $path ) {
+		$this->events[] = "delete-entry: {$path}";
+	}
+
+	public function close_edit() {
+		$this->events[] = 'close-edit';
+	}
+
+	public function abort_edit() {
+		$this->events[] = 'abort-edit';
+	}
+}

--- a/components/Svn/Tests/SvnClientBehaviorTrait.php
+++ b/components/Svn/Tests/SvnClientBehaviorTrait.php
@@ -152,7 +152,7 @@ trait SvnClientBehaviorTrait {
 		$this->assertSame( "a change from the test suite\n", file_get_contents( "$verify_path/hello.txt" ) );
 		$this->assertSame( "<?php // new\n", file_get_contents( "$verify_path/lib/nested/util.php" ) );
 		$this->assertSame( "standalone\n", file_get_contents( "$verify_path/standalone.txt" ) );
-		$this->assertFileDoesNotExist( "$verify_path/sub/deep/nested.txt" );
+		$this->assertFalse( file_exists( "$verify_path/sub/deep/nested.txt" ) );
 	}
 
 	public function test_commit_does_not_rewrite_eol_styled_files() {
@@ -193,7 +193,7 @@ trait SvnClientBehaviorTrait {
 		$this->assertContains( 'multi.txt', $result['deleted'] );
 		$this->assertSame( "updated upstream\n", file_get_contents( "$reader/hello.txt" ) );
 		$this->assertSame( "fresh\n", file_get_contents( "$reader/fresh.txt" ) );
-		$this->assertFileDoesNotExist( "$reader/multi.txt" );
+		$this->assertFalse( file_exists( "$reader/multi.txt" ) );
 		$this->assertSame( array(), $client->status( $reader ) );
 	}
 
@@ -244,7 +244,7 @@ trait SvnClientBehaviorTrait {
 		}
 
 		$client->resolved( $reader, 'hello.txt' );
-		$this->assertFileDoesNotExist( $incoming );
+		$this->assertFalse( file_exists( $incoming ) );
 		$resolution = $client->commit( $reader, 'the reader wins' );
 		$this->assertGreaterThan( $committed['revision'], $resolution['revision'] );
 	}
@@ -282,7 +282,7 @@ trait SvnClientBehaviorTrait {
 		$this->assertFileExists( "$path/hello.txt" );
 
 		$client->delete( $path, 'hello.txt', array( 'force' => true ) );
-		$this->assertFileDoesNotExist( "$path/hello.txt" );
+		$this->assertFalse( file_exists( "$path/hello.txt" ) );
 		$this->assertSame( 'deleted', $client->status( $path )['hello.txt'] );
 	}
 
@@ -363,7 +363,7 @@ trait SvnClientBehaviorTrait {
 		// ignore_externals skips the nested checkout entirely.
 		$bare_path = $this->make_temp_path();
 		$client->checkout( $this->repo() . '/trunk', $bare_path, array( 'ignore_externals' => true ) );
-		$this->assertFileDoesNotExist( "$bare_path/vendor/sub-external" );
+		$this->assertFalse( file_exists( "$bare_path/vendor/sub-external" ) );
 	}
 
 	public function test_checkout_with_limited_depth() {
@@ -373,7 +373,7 @@ trait SvnClientBehaviorTrait {
 
 		$this->assertFileExists( "$path/hello.txt" );
 		$this->assertFileExists( "$path/multi.txt" );
-		$this->assertFileDoesNotExist( "$path/sub" );
+		$this->assertFalse( file_exists( "$path/sub" ) );
 	}
 
 	public function test_out_of_date_commit_is_rejected() {

--- a/components/Svn/Tests/SvnClientBehaviorTrait.php
+++ b/components/Svn/Tests/SvnClientBehaviorTrait.php
@@ -1,0 +1,397 @@
+<?php
+declare(strict_types=1);
+
+namespace WordPress\Svn\Tests;
+
+use WordPress\Svn\SvnClient;
+use WordPress\Svn\SvnException;
+
+/**
+ * The client test scenarios, shared between the transports: the
+ * svn:// suite runs them against a local svnserve, the http:// suite
+ * against Apache + mod_dav_svn in Docker. Both servers expose the same
+ * fixture repositories (see SvnTestServer).
+ */
+trait SvnClientBehaviorTrait {
+	/**
+	 * @var string[] Temp directories to remove after each test.
+	 */
+	private $temp_dirs = array();
+
+	/**
+	 * @var string|null URL of this test's private fixture repository.
+	 */
+	private $repo_base;
+
+	/**
+	 * @return SvnTestServer The running server for this suite.
+	 */
+	abstract protected function server();
+
+	/**
+	 * @after
+	 */
+	public function remove_temp_dirs() {
+		foreach ( $this->temp_dirs as $directory ) {
+			SvnTestServer::run( 'rm -rf ' . escapeshellarg( $directory ) );
+		}
+		$this->temp_dirs   = array();
+		$this->repo_base   = null;
+	}
+
+	/**
+	 * @return string URL of a fixture repository private to the running test.
+	 */
+	protected function repo() {
+		if ( null === $this->repo_base ) {
+			$this->repo_base = $this->server()->create_repository();
+		}
+
+		return $this->repo_base;
+	}
+
+	protected function make_temp_path() {
+		$path              = sys_get_temp_dir() . '/svn-client-test-' . bin2hex( random_bytes( 6 ) );
+		$this->temp_dirs[] = $path;
+
+		return $path;
+	}
+
+	protected function client( $with_credentials = false ) {
+		$options = array( 'timeout_ms' => 15000 );
+		if ( $with_credentials ) {
+			$options['username'] = SvnTestServer::USERNAME;
+			$options['password'] = SvnTestServer::PASSWORD;
+		}
+
+		return new SvnClient( $options );
+	}
+
+	public function test_session_primitives() {
+		$session = $this->client()->open_session( $this->repo() . '/trunk' );
+
+		$this->assertGreaterThanOrEqual( 2, $session->get_latest_revision() );
+		$this->assertSame( 'file', $session->check_path( 'hello.txt' ) );
+		$this->assertSame( 'dir', $session->check_path( 'sub' ) );
+		$this->assertSame( 'none', $session->check_path( 'no-such-node' ) );
+
+		$names = array();
+		foreach ( $session->list_directory( '' ) as $entry ) {
+			$names[ $entry['name'] ] = $entry['kind'];
+		}
+		$this->assertSame( 'file', $names['hello.txt'] );
+		$this->assertSame( 'file', $names['multi.txt'] );
+		$this->assertSame( 'dir', $names['sub'] );
+
+		$file = $session->get_file( 'hello.txt' );
+		$this->assertSame( "hello world\n", $file['contents'] );
+		$this->assertSame( md5( $file['contents'] ), $file['checksum'] );
+
+		$properties = $session->get_properties( 'multi.txt' );
+		$this->assertSame( 'CRLF', $properties['svn:eol-style'] );
+
+		$session->close();
+	}
+
+	public function test_checkout_produces_clean_working_copy() {
+		$client = $this->client();
+		$path   = $this->make_temp_path();
+		$result = $client->checkout( $this->repo() . '/trunk', $path );
+
+		$this->assertGreaterThanOrEqual( 2, $result['revision'] );
+		$this->assertSame( "hello world\n", file_get_contents( "$path/hello.txt" ) );
+		$this->assertSame( "nested file\n", file_get_contents( "$path/sub/deep/nested.txt" ) );
+		// Fixed eol-style files arrive with their style's line endings.
+		$this->assertSame( "line1\r\nline2\r\nline3\r\n", file_get_contents( "$path/multi.txt" ) );
+
+		// A fresh checkout must be pristine – especially the CRLF file.
+		$this->assertSame( array(), $client->status( $path ) );
+
+		$info = $client->info( $path );
+		$this->assertSame( $this->repo() . '/trunk', $info['url'] );
+		$this->assertSame( $this->repo(), $info['repository_root'] );
+	}
+
+	public function test_checkout_at_old_revision() {
+		$client = $this->client();
+		$path   = $this->make_temp_path();
+		$result = $client->checkout( $this->repo() . '/trunk', $path, array( 'revision' => 1 ) );
+
+		$this->assertSame( 1, $result['revision'] );
+		$this->assertSame( 1, $client->info( $path )['revision'] );
+		// At r1 the eol-style property did not exist yet.
+		$this->assertSame( "line1\nline2\nline3\n", file_get_contents( "$path/multi.txt" ) );
+	}
+
+	public function test_commit_roundtrip() {
+		$client = $this->client();
+		$path   = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $path );
+
+		file_put_contents( "$path/hello.txt", "a change from the test suite\n" );
+		mkdir( "$path/lib/nested", 0777, true );
+		file_put_contents( "$path/lib/nested/util.php", "<?php // new\n" );
+		file_put_contents( "$path/standalone.txt", "standalone\n" );
+		$client->add( $path, array( 'lib', 'standalone.txt' ) );
+		$client->delete( $path, 'sub/deep/nested.txt' );
+
+		$status = $client->status( $path );
+		$this->assertSame( 'modified', $status['hello.txt'] );
+		$this->assertSame( 'added', $status['lib'] );
+		$this->assertSame( 'added', $status['lib/nested/util.php'] );
+		$this->assertSame( 'deleted', $status['sub/deep/nested.txt'] );
+
+		$commit_info = $client->commit( $path, 'roundtrip commit from the test suite' );
+		$this->assertGreaterThanOrEqual( 3, $commit_info['revision'] );
+		$this->assertSame( array(), $client->status( $path ) );
+		$this->assertNull( $client->commit( $path, 'nothing to do' ) );
+
+		// An independent checkout must see exactly what was committed.
+		$verify_path = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $verify_path );
+		$this->assertSame( "a change from the test suite\n", file_get_contents( "$verify_path/hello.txt" ) );
+		$this->assertSame( "<?php // new\n", file_get_contents( "$verify_path/lib/nested/util.php" ) );
+		$this->assertSame( "standalone\n", file_get_contents( "$verify_path/standalone.txt" ) );
+		$this->assertFileDoesNotExist( "$verify_path/sub/deep/nested.txt" );
+	}
+
+	public function test_commit_does_not_rewrite_eol_styled_files() {
+		// Regression test: committing an unrelated change must not sneak
+		// in an end-of-line normalization of svn:eol-style files.
+		$client = $this->client();
+		$path   = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $path );
+		$revision_before = $client->info( $path )['revision'];
+
+		file_put_contents( "$path/unrelated.txt", "unrelated\n" );
+		$client->add( $path, 'unrelated.txt' );
+		$client->commit( $path, 'unrelated change' );
+
+		$session = $client->open_session( $this->repo() . '/trunk' );
+		$file    = $session->get_file( 'multi.txt' );
+		$session->close();
+		$this->assertSame( "line1\r\nline2\r\nline3\r\n", $file['contents'] );
+	}
+
+	public function test_update_pulls_changes() {
+		$client = $this->client();
+		$writer = $this->make_temp_path();
+		$reader = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $writer );
+		$client->checkout( $this->repo() . '/trunk', $reader );
+
+		file_put_contents( "$writer/hello.txt", "updated upstream\n" );
+		file_put_contents( "$writer/fresh.txt", "fresh\n" );
+		$client->add( $writer, 'fresh.txt' );
+		$client->delete( $writer, 'multi.txt' );
+		$committed = $client->commit( $writer, 'update test changes' );
+
+		$result = $client->update( $reader );
+		$this->assertSame( $committed['revision'], $result['revision'] );
+		$this->assertContains( 'fresh.txt', $result['added'] );
+		$this->assertContains( 'hello.txt', $result['updated'] );
+		$this->assertContains( 'multi.txt', $result['deleted'] );
+		$this->assertSame( "updated upstream\n", file_get_contents( "$reader/hello.txt" ) );
+		$this->assertSame( "fresh\n", file_get_contents( "$reader/fresh.txt" ) );
+		$this->assertFileDoesNotExist( "$reader/multi.txt" );
+		$this->assertSame( array(), $client->status( $reader ) );
+	}
+
+	public function test_update_preserves_unrelated_local_modifications() {
+		$client = $this->client();
+		$writer = $this->make_temp_path();
+		$reader = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $writer );
+		$client->checkout( $this->repo() . '/trunk', $reader );
+
+		file_put_contents( "$writer/hello.txt", "upstream edit\n" );
+		$client->commit( $writer, 'edit hello upstream' );
+
+		file_put_contents( "$reader/multi.txt", "local edit\r\n" );
+		$client->update( $reader );
+
+		$this->assertSame( "upstream edit\n", file_get_contents( "$reader/hello.txt" ) );
+		$this->assertSame( "local edit\r\n", file_get_contents( "$reader/multi.txt" ) );
+		$this->assertSame( array( 'multi.txt' => 'modified' ), $client->status( $reader ) );
+	}
+
+	public function test_conflicting_update_and_resolution() {
+		$client = $this->client();
+		$writer = $this->make_temp_path();
+		$reader = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $writer );
+		$client->checkout( $this->repo() . '/trunk', $reader );
+
+		file_put_contents( "$writer/hello.txt", "the writer's version\n" );
+		$committed = $client->commit( $writer, 'writer changes hello' );
+
+		file_put_contents( "$reader/hello.txt", "the reader's version\n" );
+		$result = $client->update( $reader );
+
+		$this->assertSame( array( 'hello.txt' ), $result['conflicted'] );
+		$this->assertSame( 'conflicted', $client->status( $reader )['hello.txt'] );
+		// The local version stays in place, the incoming version lands
+		// next to it as <name>.r<revision>.
+		$this->assertSame( "the reader's version\n", file_get_contents( "$reader/hello.txt" ) );
+		$incoming = "$reader/hello.txt.r{$committed['revision']}";
+		$this->assertSame( "the writer's version\n", file_get_contents( $incoming ) );
+
+		try {
+			$client->commit( $reader, 'must be blocked' );
+			$this->fail( 'Committing a conflicted working copy must throw.' );
+		} catch ( SvnException $exception ) {
+			$this->assertStringContainsString( 'conflict', $exception->getMessage() );
+		}
+
+		$client->resolved( $reader, 'hello.txt' );
+		$this->assertFileDoesNotExist( $incoming );
+		$resolution = $client->commit( $reader, 'the reader wins' );
+		$this->assertGreaterThan( $committed['revision'], $resolution['revision'] );
+	}
+
+	public function test_revert_restores_pristine_state() {
+		$client = $this->client();
+		$path   = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $path );
+
+		file_put_contents( "$path/hello.txt", "scribbles\n" );
+		file_put_contents( "$path/new-file.txt", "new\n" );
+		$client->add( $path, 'new-file.txt' );
+		$client->delete( $path, 'multi.txt' );
+
+		$client->revert( $path, array( 'hello.txt', 'new-file.txt', 'multi.txt' ) );
+
+		$this->assertSame( "hello world\n", file_get_contents( "$path/hello.txt" ) );
+		$this->assertSame( "line1\r\nline2\r\nline3\r\n", file_get_contents( "$path/multi.txt" ) );
+		// Reverting an addition keeps the file on disk, unversioned.
+		$this->assertSame( array( 'new-file.txt' => 'unversioned' ), $client->status( $path ) );
+	}
+
+	public function test_delete_refuses_modified_files_without_force() {
+		$client = $this->client();
+		$path   = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $path );
+		file_put_contents( "$path/hello.txt", "precious local edit\n" );
+
+		try {
+			$client->delete( $path, 'hello.txt' );
+			$this->fail( 'Deleting a modified file without force must throw.' );
+		} catch ( SvnException $exception ) {
+			$this->assertStringContainsString( 'local modifications', $exception->getMessage() );
+		}
+		$this->assertFileExists( "$path/hello.txt" );
+
+		$client->delete( $path, 'hello.txt', array( 'force' => true ) );
+		$this->assertFileDoesNotExist( "$path/hello.txt" );
+		$this->assertSame( 'deleted', $client->status( $path )['hello.txt'] );
+	}
+
+	public function test_authentication() {
+		$auth_url = $this->server()->create_repository( true ) . '/trunk';
+
+		try {
+			$this->client()->checkout( $auth_url, $this->make_temp_path() );
+			$this->fail( 'Anonymous access to the authenticated repository must throw.' );
+		} catch ( SvnException $exception ) {
+			// Expected: the server demands credentials.
+			$this->assertNotSame( '', $exception->getMessage() );
+		}
+
+		$wrong_password = new \WordPress\Svn\SvnClient(
+			array(
+				'username'   => SvnTestServer::USERNAME,
+				'password'   => 'wrong-password',
+				'timeout_ms' => 15000,
+			)
+		);
+		try {
+			$wrong_password->checkout( $auth_url, $this->make_temp_path() );
+			$this->fail( 'A wrong password must throw.' );
+		} catch ( SvnException $exception ) {
+			$this->assertNotSame( '', $exception->getMessage() );
+		}
+
+		$client = $this->client( true );
+		$path   = $this->make_temp_path();
+		$client->checkout( $auth_url, $path );
+		$this->assertSame( "hello world\n", file_get_contents( "$path/hello.txt" ) );
+
+		file_put_contents( "$path/by-alice.txt", "authenticated write\n" );
+		$client->add( $path, 'by-alice.txt' );
+		$commit_info = $client->commit( $path, 'authenticated commit' );
+		$this->assertSame( SvnTestServer::USERNAME, $commit_info['author'] );
+	}
+
+	public function test_externals_are_checked_out_as_nested_working_copies() {
+		$client = $this->client();
+
+		// Define an external pointing at ^/trunk/sub – exercises both the
+		// property commit and the repository-root-relative URL syntax.
+		$session = $client->open_session( $this->repo() );
+		$session->commit(
+			'define externals',
+			array(
+				array(
+					'op'            => 'modify-properties',
+					'path'          => 'trunk',
+					'kind'          => 'dir',
+					'base_revision' => $session->get_latest_revision(),
+					'properties'    => array( 'svn:externals' => "^/trunk/sub vendor/sub-external\n" ),
+				),
+			)
+		);
+		$session->close();
+
+		$path   = $this->make_temp_path();
+		$result = $client->checkout( $this->repo() . '/trunk', $path );
+		$this->assertArrayHasKey( 'vendor/sub-external', $result['externals'] );
+		$this->assertSame( "nested file\n", file_get_contents( "$path/vendor/sub-external/deep/nested.txt" ) );
+
+		// The external is its own working copy of the referenced URL.
+		$external_info = $client->info( "$path/vendor/sub-external" );
+		$this->assertSame( $this->repo() . '/trunk/sub', $external_info['url'] );
+
+		// Status reports the external but does not descend into it.
+		$status = $client->status( $path );
+		$this->assertSame( 'external', $status['vendor/sub-external'] );
+		$this->assertArrayNotHasKey( 'vendor/sub-external/deep/nested.txt', $status );
+
+		// Updating keeps the external in sync.
+		$update_result = $client->update( $path );
+		$this->assertArrayHasKey( 'vendor/sub-external', $update_result['externals'] );
+
+		// ignore_externals skips the nested checkout entirely.
+		$bare_path = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $bare_path, array( 'ignore_externals' => true ) );
+		$this->assertFileDoesNotExist( "$bare_path/vendor/sub-external" );
+	}
+
+	public function test_checkout_with_limited_depth() {
+		$client = $this->client();
+		$path   = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $path, array( 'depth' => 'files' ) );
+
+		$this->assertFileExists( "$path/hello.txt" );
+		$this->assertFileExists( "$path/multi.txt" );
+		$this->assertFileDoesNotExist( "$path/sub" );
+	}
+
+	public function test_out_of_date_commit_is_rejected() {
+		$client = $this->client();
+		$first  = $this->make_temp_path();
+		$second = $this->make_temp_path();
+		$client->checkout( $this->repo() . '/trunk', $first );
+		$client->checkout( $this->repo() . '/trunk', $second );
+
+		file_put_contents( "$first/hello.txt", "first writer\n" );
+		$client->commit( $first, 'first writer wins' );
+
+		file_put_contents( "$second/hello.txt", "second writer\n" );
+		try {
+			$client->commit( $second, 'should be out of date' );
+			$this->fail( 'Committing against an out-of-date base must throw.' );
+		} catch ( SvnException $exception ) {
+			$this->assertNotSame( '', $exception->getMessage() );
+		}
+	}
+}

--- a/components/Svn/Tests/SvnDiffTest.php
+++ b/components/Svn/Tests/SvnDiffTest.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WordPress\Svn\SvnDiff;
+use WordPress\Svn\SvnDiffApplier;
+use WordPress\Svn\SvnException;
+
+class SvnDiffTest extends TestCase {
+	public function test_encode_varint_single_byte() {
+		$this->assertSame( "\x00", SvnDiff::encode_varint( 0 ) );
+		$this->assertSame( "\x7f", SvnDiff::encode_varint( 127 ) );
+	}
+
+	public function test_encode_varint_multi_byte() {
+		$this->assertSame( "\x81\x00", SvnDiff::encode_varint( 128 ) );
+		$this->assertSame( "\x86\x90\x23", SvnDiff::encode_varint( 100387 ) );
+	}
+
+	public function test_parse_varint_round_trips() {
+		foreach ( array( 0, 1, 63, 64, 127, 128, 300, 102400, 99999999 ) as $number ) {
+			$position = 0;
+			$this->assertSame(
+				$number,
+				SvnDiffApplier::parse_varint_from( SvnDiff::encode_varint( $number ), $position )
+			);
+		}
+	}
+
+	public function test_parse_varint_returns_null_on_truncated_input() {
+		$position = 0;
+		$this->assertNull( SvnDiffApplier::parse_varint_from( "\x81", $position ) );
+		$this->assertSame( 0, $position );
+	}
+
+	public function test_fulltext_round_trip() {
+		$contents = "Hello, svndiff!\nSecond line.\n";
+		$applier  = new SvnDiffApplier( '' );
+		$applier->append_bytes( SvnDiff::encode_fulltext( $contents ) );
+		$applier->finish();
+		$this->assertSame( $contents, $applier->get_target() );
+	}
+
+	public function test_fulltext_round_trip_empty_string() {
+		$applier = new SvnDiffApplier( '' );
+		$applier->append_bytes( SvnDiff::encode_fulltext( '' ) );
+		$applier->finish();
+		$this->assertSame( '', $applier->get_target() );
+	}
+
+	public function test_fulltext_round_trip_larger_than_window_size() {
+		$contents = str_repeat( "0123456789abcdef\n", 20000 ); // 340 KB, several windows.
+		$applier  = new SvnDiffApplier( '' );
+		$applier->append_bytes( SvnDiff::encode_fulltext( $contents ) );
+		$applier->finish();
+		$this->assertSame( $contents, $applier->get_target() );
+	}
+
+	public function test_byte_by_byte_feeding() {
+		$contents = 'incremental decoding works';
+		$svndiff  = SvnDiff::encode_fulltext( $contents );
+		$applier  = new SvnDiffApplier( '' );
+		for ( $i = 0; $i < strlen( $svndiff ); $i++ ) {
+			$applier->append_bytes( $svndiff[ $i ] );
+		}
+		$applier->finish();
+		$this->assertSame( $contents, $applier->get_target() );
+	}
+
+	public function test_copy_from_source_instruction() {
+		// Window: copy bytes 4..9 of the source view, then 3 new bytes.
+		$instructions = "\x06\x04" . "\x83";
+		$window       = "\x00\x0a\x09" . SvnDiff::encode_varint( strlen( $instructions ) ) . "\x03" . $instructions . 'NEW';
+		$applier      = new SvnDiffApplier( 'abcdefghij' );
+		$applier->append_bytes( "SVN\x00" . $window );
+		$applier->finish();
+		$this->assertSame( 'efghijNEW', $applier->get_target() );
+	}
+
+	public function test_overlapping_copy_from_target_repeats_bytes() {
+		// One new byte 'x', then a target copy of length 5 starting at
+		// offset 0 – RLE-style expansion into 'xxxxxx'.
+		$instructions = "\x81" . "\x45\x00";
+		$window       = "\x00\x00\x06" . SvnDiff::encode_varint( strlen( $instructions ) ) . "\x01" . $instructions . 'x';
+		$applier      = new SvnDiffApplier( '' );
+		$applier->append_bytes( "SVN\x00" . $window );
+		$applier->finish();
+		$this->assertSame( 'xxxxxx', $applier->get_target() );
+	}
+
+	public function test_rejects_bad_header() {
+		$this->expectException( SvnException::class );
+		$applier = new SvnDiffApplier( '' );
+		$applier->append_bytes( 'GIT0nope' );
+	}
+
+	public function test_rejects_unsupported_version() {
+		$this->expectException( SvnException::class );
+		$this->expectExceptionMessage( 'svndiff version 2' );
+		$applier = new SvnDiffApplier( '' );
+		$applier->append_bytes( "SVN\x02" );
+	}
+
+	public function test_rejects_window_with_wrong_target_length() {
+		$this->expectException( SvnException::class );
+		// Window claims 5 target bytes but the instruction only emits 3.
+		$applier = new SvnDiffApplier( '' );
+		$applier->append_bytes( "SVN\x00" . "\x00\x00\x05\x01\x03" . "\x83" . 'abc' );
+	}
+
+	public function test_finish_rejects_truncated_window() {
+		$this->expectException( SvnException::class );
+		$applier = new SvnDiffApplier( '' );
+		$applier->append_bytes( substr( SvnDiff::encode_fulltext( 'truncated' ), 0, 8 ) );
+		$applier->finish();
+	}
+
+	public function test_decodes_real_mod_dav_svn_delta() {
+		// Captured from a live mod_dav_svn update-report response.
+		$svndiff = base64_decode( 'U1ZOAAAADAEMjG5lc3RlZCBmaWxlCg==' );
+		$applier = new SvnDiffApplier( '' );
+		$applier->append_bytes( $svndiff );
+		$applier->finish();
+		$this->assertSame( "nested file\n", $applier->get_target() );
+	}
+
+	public function test_flush_target_returns_and_forgets() {
+		$applier = new SvnDiffApplier( '' );
+		$applier->append_bytes( SvnDiff::encode_fulltext( 'abc' ) );
+		$this->assertSame( 'abc', $applier->flush_target() );
+		$this->assertSame( '', $applier->get_target() );
+	}
+}

--- a/components/Svn/Tests/SvnExternalsTest.php
+++ b/components/Svn/Tests/SvnExternalsTest.php
@@ -41,6 +41,11 @@ class SvnExternalsTest extends TestCase {
 		$this->assertSame( 42, $externals[0]['revision'] );
 	}
 
+	public function test_head_operative_revision_is_unpinned() {
+		$externals = svn_parse_externals( '-r HEAD https://other.example.com/lib@99 lib', self::DIR_URL, self::ROOT_URL );
+		$this->assertNull( $externals[0]['revision'] );
+	}
+
 	public function test_historical_format_with_revision() {
 		$externals = svn_parse_externals( 'lib -r 7 https://other.example.com/lib', self::DIR_URL, self::ROOT_URL );
 		$this->assertSame( 7, $externals[0]['revision'] );
@@ -94,6 +99,21 @@ class SvnExternalsTest extends TestCase {
 	public function test_rejects_target_escaping_the_directory() {
 		$this->expectException( SvnException::class );
 		svn_parse_externals( 'https://other.example.com/lib ../../etc', self::DIR_URL, self::ROOT_URL );
+	}
+
+	public function test_rejects_target_with_parent_segment_at_the_end() {
+		$this->expectException( SvnException::class );
+		svn_parse_externals( 'https://other.example.com/lib vendor/..', self::DIR_URL, self::ROOT_URL );
+	}
+
+	public function test_rejects_target_with_windows_separator() {
+		$this->expectException( SvnException::class );
+		svn_parse_externals( 'https://other.example.com/lib vendor\\lib', self::DIR_URL, self::ROOT_URL );
+	}
+
+	public function test_rejects_invalid_operative_revision() {
+		$this->expectException( SvnException::class );
+		svn_parse_externals( '-r 12x https://other.example.com/lib lib', self::DIR_URL, self::ROOT_URL );
 	}
 
 	public function test_rejects_line_without_url() {

--- a/components/Svn/Tests/SvnExternalsTest.php
+++ b/components/Svn/Tests/SvnExternalsTest.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WordPress\Svn\SvnException;
+
+use function WordPress\Svn\svn_parse_externals;
+use function WordPress\Svn\svn_resolve_url;
+
+class SvnExternalsTest extends TestCase {
+	const DIR_URL  = 'https://example.com/repo/trunk/vendor';
+	const ROOT_URL = 'https://example.com/repo';
+
+	public function test_modern_format_url_then_target() {
+		$externals = svn_parse_externals( 'https://other.example.com/lib lib', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame(
+			array(
+				array(
+					'url'      => 'https://other.example.com/lib',
+					'target'   => 'lib',
+					'revision' => null,
+				),
+			),
+			$externals
+		);
+	}
+
+	public function test_historical_format_target_then_url() {
+		$externals = svn_parse_externals( 'lib https://other.example.com/lib', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 'lib', $externals[0]['target'] );
+		$this->assertSame( 'https://other.example.com/lib', $externals[0]['url'] );
+	}
+
+	public function test_operative_revision_with_space() {
+		$externals = svn_parse_externals( '-r 42 https://other.example.com/lib lib', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 42, $externals[0]['revision'] );
+	}
+
+	public function test_operative_revision_without_space() {
+		$externals = svn_parse_externals( '-r42 https://other.example.com/lib lib', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 42, $externals[0]['revision'] );
+	}
+
+	public function test_historical_format_with_revision() {
+		$externals = svn_parse_externals( 'lib -r 7 https://other.example.com/lib', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 7, $externals[0]['revision'] );
+		$this->assertSame( 'lib', $externals[0]['target'] );
+	}
+
+	public function test_peg_revision_pins_the_external() {
+		$externals = svn_parse_externals( 'https://other.example.com/lib@99 lib', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 99, $externals[0]['revision'] );
+		$this->assertSame( 'https://other.example.com/lib', $externals[0]['url'] );
+	}
+
+	public function test_operative_revision_wins_over_peg() {
+		$externals = svn_parse_externals( '-r 7 https://other.example.com/lib@99 lib', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 7, $externals[0]['revision'] );
+	}
+
+	public function test_repository_root_relative_url() {
+		$externals = svn_parse_externals( '^/tags/1.0 stable', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 'https://example.com/repo/tags/1.0', $externals[0]['url'] );
+	}
+
+	public function test_parent_directory_relative_url() {
+		$externals = svn_parse_externals( '../sibling lib', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 'https://example.com/repo/trunk/sibling', $externals[0]['url'] );
+	}
+
+	public function test_scheme_relative_url() {
+		$externals = svn_parse_externals( '//cdn.example.com/assets assets', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 'https://cdn.example.com/assets', $externals[0]['url'] );
+	}
+
+	public function test_server_root_relative_url() {
+		$externals = svn_parse_externals( '/other-repo/trunk other', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 'https://example.com/other-repo/trunk', $externals[0]['url'] );
+	}
+
+	public function test_quoted_target_with_spaces() {
+		$externals = svn_parse_externals( 'https://other.example.com/lib "my lib"', self::DIR_URL, self::ROOT_URL );
+		$this->assertSame( 'my lib', $externals[0]['target'] );
+	}
+
+	public function test_multiple_lines_with_comments_and_blanks() {
+		$value     = "# vendored libraries\n\nhttps://a.example.com/x x\n   \nhttps://b.example.com/y y\n";
+		$externals = svn_parse_externals( $value, self::DIR_URL, self::ROOT_URL );
+		$this->assertCount( 2, $externals );
+		$this->assertSame( 'x', $externals[0]['target'] );
+		$this->assertSame( 'y', $externals[1]['target'] );
+	}
+
+	public function test_rejects_target_escaping_the_directory() {
+		$this->expectException( SvnException::class );
+		svn_parse_externals( 'https://other.example.com/lib ../../etc', self::DIR_URL, self::ROOT_URL );
+	}
+
+	public function test_rejects_line_without_url() {
+		$this->expectException( SvnException::class );
+		svn_parse_externals( 'one two', self::DIR_URL, self::ROOT_URL );
+	}
+
+	public function test_rejects_relative_url_escaping_the_server() {
+		$this->expectException( SvnException::class );
+		svn_parse_externals( '../../../../../up lib', self::DIR_URL, self::ROOT_URL );
+	}
+
+	public function test_resolve_url_keeps_absolute_urls() {
+		$this->assertSame(
+			'svn://example.org/repo',
+			svn_resolve_url( 'svn://example.org/repo/', self::DIR_URL, self::ROOT_URL )
+		);
+	}
+
+	public function test_resolve_url_handles_ports() {
+		$this->assertSame(
+			'http://example.com:8080/repo/tags',
+			svn_resolve_url( '^/tags', 'http://example.com:8080/repo/trunk', 'http://example.com:8080/repo' )
+		);
+	}
+}

--- a/components/Svn/Tests/SvnTestServer.php
+++ b/components/Svn/Tests/SvnTestServer.php
@@ -1,0 +1,308 @@
+<?php
+declare(strict_types=1);
+
+namespace WordPress\Svn\Tests;
+
+/**
+ * Spins up real Subversion servers for the integration tests:
+ *
+ *  - start_svnserve() runs the local `svnserve` binary against
+ *    repositories created with `svnadmin`. Requires the subversion
+ *    tools on the PATH.
+ *  - start_dav() runs Apache + mod_dav_svn in a Docker container,
+ *    built from Tests/http-server/. Requires a running Docker daemon.
+ *
+ * Both servers expose the same fixture layout:
+ *
+ *    repo  (anonymous read/write)        auth-repo / repo2 (alice:secret123)
+ *      trunk/hello.txt                     ... same contents ...
+ *      trunk/multi.txt   (svn:eol-style CRLF as of r2)
+ *      trunk/sub/deep/nested.txt
+ *      branches/
+ */
+class SvnTestServer {
+	const DOCKER_IMAGE = 'php-toolkit-svn-test-server';
+	const USERNAME     = 'alice';
+	const PASSWORD     = 'secret123';
+
+	/**
+	 * @var string 'svnserve' or 'dav'
+	 */
+	private $kind;
+
+	/**
+	 * @var int
+	 */
+	private $port;
+
+	/**
+	 * @var string|null Temp directory holding svnserve repositories.
+	 */
+	private $directory;
+
+	/**
+	 * @var resource|null svnserve process handle.
+	 */
+	private $process;
+
+	/**
+	 * @var string|null Docker container id.
+	 */
+	private $container_id;
+
+	public static function svn_binaries_available() {
+		static $available = null;
+		if ( null === $available ) {
+			exec( 'svnadmin --version 2>/dev/null', $output, $exit_code );
+			$available = 0 === $exit_code;
+			if ( $available ) {
+				exec( 'svnserve --version 2>/dev/null', $output, $exit_code );
+				$available = 0 === $exit_code;
+			}
+			if ( $available ) {
+				exec( 'svn --version 2>/dev/null', $output, $exit_code );
+				$available = 0 === $exit_code;
+			}
+		}
+
+		return $available;
+	}
+
+	public static function docker_available() {
+		static $available = null;
+		if ( null === $available ) {
+			exec( 'docker ps 2>/dev/null', $output, $exit_code );
+			$available = 0 === $exit_code;
+		}
+
+		return $available;
+	}
+
+	/**
+	 * Starts svnserve with two fixture repositories.
+	 *
+	 * @return SvnTestServer
+	 */
+	public static function start_svnserve() {
+		$server            = new SvnTestServer();
+		$server->kind      = 'svnserve';
+		$server->directory = sys_get_temp_dir() . '/php-toolkit-svn-test-' . getmypid() . '-' . bin2hex( random_bytes( 4 ) );
+		mkdir( $server->directory, 0777, true );
+
+		self::create_fixture_repository( $server->directory . '/repo', false );
+		self::create_fixture_repository( $server->directory . '/auth-repo', true );
+
+		$server->port = self::find_free_port();
+		$command      = sprintf(
+			'svnserve -d -T --foreground -r %s --listen-host 127.0.0.1 --listen-port %d',
+			escapeshellarg( $server->directory ),
+			$server->port
+		);
+		$server->process = proc_open( $command, array(), $pipes );
+		if ( ! is_resource( $server->process ) ) {
+			throw new \RuntimeException( 'Could not start svnserve.' );
+		}
+		self::wait_for_port( $server->port );
+
+		return $server;
+	}
+
+	/**
+	 * Starts the Apache + mod_dav_svn Docker container.
+	 *
+	 * @return SvnTestServer
+	 */
+	public static function start_dav() {
+		$server       = new SvnTestServer();
+		$server->kind = 'dav';
+
+		exec( 'docker image inspect ' . self::DOCKER_IMAGE . ' >/dev/null 2>&1', $output, $exit_code );
+		if ( 0 !== $exit_code ) {
+			exec(
+				'docker build -t ' . self::DOCKER_IMAGE . ' ' . escapeshellarg( __DIR__ . '/http-server' ) . ' 2>&1',
+				$build_output,
+				$build_exit_code
+			);
+			if ( 0 !== $build_exit_code ) {
+				throw new \RuntimeException( "Could not build the mod_dav_svn test image:\n" . implode( "\n", $build_output ) );
+			}
+		}
+
+		$server->port = self::find_free_port();
+		exec(
+			sprintf( 'docker run -d --rm -p 127.0.0.1:%d:80 %s 2>&1', $server->port, self::DOCKER_IMAGE ),
+			$run_output,
+			$run_exit_code
+		);
+		if ( 0 !== $run_exit_code ) {
+			throw new \RuntimeException( "Could not start the mod_dav_svn test container:\n" . implode( "\n", $run_output ) );
+		}
+		$server->container_id = trim( implode( "\n", $run_output ) );
+
+		// Apache needs a moment to create the fixture repositories.
+		$deadline = microtime( true ) + 60;
+		while ( microtime( true ) < $deadline ) {
+			$context  = stream_context_create( array( 'http' => array( 'timeout' => 2, 'ignore_errors' => true ) ) );
+			$contents = @file_get_contents( "http://127.0.0.1:{$server->port}/repos/repo1/trunk/hello.txt", false, $context );
+			if ( "hello world\n" === $contents ) {
+				return $server;
+			}
+			usleep( 250000 );
+		}
+		$server->stop();
+		throw new \RuntimeException( 'The mod_dav_svn test container did not become ready in time.' );
+	}
+
+	/**
+	 * @param  string $repository  Repository name: 'repo' or 'auth-repo'.
+	 * @return string The URL of the repository for this server.
+	 */
+	public function url( $repository = 'repo' ) {
+		if ( 'svnserve' === $this->kind ) {
+			return "svn://127.0.0.1:{$this->port}/{$repository}";
+		}
+		// The DAV container mounts the anonymous repository at
+		// /repos/repo1 and the authenticated one at /auth-repos/repo2.
+		return 'auth-repo' === $repository
+			? "http://127.0.0.1:{$this->port}/auth-repos/repo2"
+			: "http://127.0.0.1:{$this->port}/repos/repo1";
+	}
+
+	/**
+	 * Creates a fresh, isolated fixture repository and returns its URL.
+	 * Lets every test mutate its own repository without affecting the
+	 * other tests.
+	 *
+	 * @param  bool $requires_auth  Whether the repository requires alice:secret123.
+	 * @return string The URL of the new repository.
+	 */
+	public function create_repository( $requires_auth = false ) {
+		$name = 'test-repo-' . bin2hex( random_bytes( 6 ) );
+		if ( 'svnserve' === $this->kind ) {
+			// Clone the already-built fixture repository instead of
+			// rebuilding it with svn commands – this is much faster.
+			$template = $this->directory . '/' . ( $requires_auth ? 'auth-repo' : 'repo' );
+			self::run( 'cp -R ' . escapeshellarg( $template ) . ' ' . escapeshellarg( $this->directory . '/' . $name ) );
+
+			return "svn://127.0.0.1:{$this->port}/{$name}";
+		}
+
+		$mode = $requires_auth ? 'auth' : 'anon';
+		self::run(
+			'docker exec ' . escapeshellarg( $this->container_id ) . " /create-repo.sh {$name} {$mode}"
+		);
+
+		return $requires_auth
+			? "http://127.0.0.1:{$this->port}/auth-repos/{$name}"
+			: "http://127.0.0.1:{$this->port}/repos/{$name}";
+	}
+
+	public function stop() {
+		if ( null !== $this->process && is_resource( $this->process ) ) {
+			proc_terminate( $this->process );
+			proc_close( $this->process );
+			$this->process = null;
+		}
+		if ( null !== $this->container_id ) {
+			exec( 'docker stop -t 1 ' . escapeshellarg( $this->container_id ) . ' >/dev/null 2>&1' );
+			$this->container_id = null;
+		}
+		if ( null !== $this->directory ) {
+			self::remove_directory( $this->directory );
+			$this->directory = null;
+		}
+	}
+
+	/**
+	 * Creates a repository with the standard fixture layout.
+	 *
+	 * @param string $path           Where to create the repository.
+	 * @param bool   $requires_auth  Whether to require alice:secret123 for all access.
+	 */
+	private static function create_fixture_repository( $path, $requires_auth ) {
+		self::run( 'svnadmin create ' . escapeshellarg( $path ) );
+
+		if ( $requires_auth ) {
+			file_put_contents(
+				$path . '/conf/svnserve.conf',
+				"[general]\nanon-access = none\nauth-access = write\npassword-db = passwd\nrealm = SvnTestRealm\n"
+			);
+			file_put_contents( $path . '/conf/passwd', "[users]\n" . self::USERNAME . ' = ' . self::PASSWORD . "\n" );
+		} else {
+			file_put_contents(
+				$path . '/conf/svnserve.conf',
+				"[general]\nanon-access = write\nauth-access = write\n"
+			);
+		}
+
+		$work = $path . '-work';
+		self::run( 'svn checkout -q ' . escapeshellarg( 'file://' . $path ) . ' ' . escapeshellarg( $work ) );
+		mkdir( "$work/trunk/sub/deep", 0777, true );
+		mkdir( "$work/branches" );
+		file_put_contents( "$work/trunk/hello.txt", "hello world\n" );
+		file_put_contents( "$work/trunk/multi.txt", "line1\nline2\nline3\n" );
+		file_put_contents( "$work/trunk/sub/deep/nested.txt", "nested file\n" );
+		self::run( 'svn add -q trunk branches', $work );
+		self::run( 'svn commit -q -m "initial content" --username fixture', $work );
+		self::run( 'svn propset -q svn:eol-style CRLF trunk/multi.txt', $work );
+		self::run( 'svn commit -q -m "set eol-style" --username fixture', $work );
+		self::remove_directory( $work );
+	}
+
+	/**
+	 * Runs a shell command, throwing on failure.
+	 *
+	 * @param string      $command            The command to run.
+	 * @param string|null $working_directory  Directory to run it in.
+	 */
+	public static function run( $command, $working_directory = null ) {
+		$prefix = null !== $working_directory ? 'cd ' . escapeshellarg( $working_directory ) . ' && ' : '';
+		exec( $prefix . $command . ' 2>&1', $output, $exit_code );
+		if ( 0 !== $exit_code ) {
+			throw new \RuntimeException( "Command failed ({$command}):\n" . implode( "\n", $output ) );
+		}
+	}
+
+	private static function find_free_port() {
+		$socket = stream_socket_server( 'tcp://127.0.0.1:0', $error_code, $error_message );
+		if ( false === $socket ) {
+			throw new \RuntimeException( "Could not find a free port: {$error_message}" );
+		}
+		$name = stream_socket_get_name( $socket, false );
+		fclose( $socket );
+
+		return (int) substr( $name, strrpos( $name, ':' ) + 1 );
+	}
+
+	private static function wait_for_port( $port ) {
+		$deadline = microtime( true ) + 15;
+		while ( microtime( true ) < $deadline ) {
+			$socket = @stream_socket_client( "tcp://127.0.0.1:{$port}", $error_code, $error_message, 1 );
+			if ( false !== $socket ) {
+				fclose( $socket );
+
+				return;
+			}
+			usleep( 100000 );
+		}
+		throw new \RuntimeException( "svnserve did not start listening on port {$port}." );
+	}
+
+	private static function remove_directory( $path ) {
+		if ( ! is_dir( $path ) ) {
+			return;
+		}
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $path, \FilesystemIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $iterator as $item ) {
+			if ( $item->isDir() && ! $item->isLink() ) {
+				rmdir( $item->getPathname() );
+			} else {
+				unlink( $item->getPathname() );
+			}
+		}
+		rmdir( $path );
+	}
+}

--- a/components/Svn/Tests/SvnWorkingCopyTest.php
+++ b/components/Svn/Tests/SvnWorkingCopyTest.php
@@ -1,0 +1,190 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WordPress\Filesystem\InMemoryFilesystem;
+use WordPress\Svn\SvnException;
+use WordPress\Svn\SvnWorkingCopy;
+
+class SvnWorkingCopyTest extends TestCase {
+	private function make_working_copy() {
+		$filesystem = InMemoryFilesystem::create();
+		$filesystem->mkdir( '/wc', array( 'recursive' => true ) );
+
+		return array(
+			SvnWorkingCopy::initialize(
+				$filesystem,
+				'/wc',
+				array(
+					'url'             => 'svn://example.com/repo/trunk',
+					'repository_root' => 'svn://example.com/repo',
+					'uuid'            => 'fake-uuid',
+					'revision'        => 7,
+				)
+			),
+			$filesystem,
+		);
+	}
+
+	public function test_initialize_and_reopen() {
+		list( $working_copy, $filesystem ) = $this->make_working_copy();
+
+		$this->assertTrue( SvnWorkingCopy::is_working_copy( $filesystem, '/wc' ) );
+
+		$reopened = SvnWorkingCopy::open( $filesystem, '/wc' );
+		$this->assertSame( 'svn://example.com/repo/trunk', $reopened->get_url() );
+		$this->assertSame( 'svn://example.com/repo', $reopened->get_repository_root() );
+		$this->assertSame( 'fake-uuid', $reopened->get_uuid() );
+		$this->assertSame( 7, $reopened->get_revision() );
+	}
+
+	public function test_open_rejects_plain_directories() {
+		$filesystem = InMemoryFilesystem::create();
+		$filesystem->mkdir( '/not-a-wc', array( 'recursive' => true ) );
+
+		$this->expectException( SvnException::class );
+		SvnWorkingCopy::open( $filesystem, '/not-a-wc' );
+	}
+
+	public function test_pristine_store_round_trips() {
+		list( $working_copy ) = $this->make_working_copy();
+
+		$checksum = $working_copy->store_pristine( "some contents\n" );
+		$this->assertSame( md5( "some contents\n" ), $checksum );
+		$this->assertSame( "some contents\n", $working_copy->read_pristine( $checksum ) );
+	}
+
+	public function test_entries_survive_a_save_load_cycle() {
+		list( $working_copy, $filesystem ) = $this->make_working_copy();
+
+		$working_copy->set_entry(
+			'a.txt',
+			array(
+				'kind'     => 'file',
+				'revision' => 7,
+				'checksum' => md5( 'x' ),
+			)
+		);
+		$working_copy->save();
+
+		$reopened = SvnWorkingCopy::open( $filesystem, '/wc' );
+		$this->assertSame( 'file', $reopened->get_entry( 'a.txt' )['kind'] );
+		$this->assertNull( $reopened->get_entry( 'missing.txt' ) );
+	}
+
+	public function test_status_reports_each_state() {
+		list( $working_copy, $filesystem ) = $this->make_working_copy();
+
+		// normal: on disk, matches pristine.
+		$checksum = $working_copy->store_pristine( "fine\n" );
+		$filesystem->put_contents( '/wc/normal.txt', "fine\n" );
+		$working_copy->set_entry(
+			'normal.txt',
+			array(
+				'kind'     => 'file',
+				'revision' => 7,
+				'checksum' => $checksum,
+			)
+		);
+
+		// modified: on disk, differs from pristine.
+		$filesystem->put_contents( '/wc/modified.txt', "changed\n" );
+		$working_copy->set_entry(
+			'modified.txt',
+			array(
+				'kind'     => 'file',
+				'revision' => 7,
+				'checksum' => $checksum,
+			)
+		);
+
+		// missing: entry without a file.
+		$working_copy->set_entry(
+			'missing.txt',
+			array(
+				'kind'     => 'file',
+				'revision' => 7,
+				'checksum' => $checksum,
+			)
+		);
+
+		// added / deleted schedules and a conflict.
+		$filesystem->put_contents( '/wc/added.txt', "new\n" );
+		$working_copy->set_entry(
+			'added.txt',
+			array(
+				'kind'     => 'file',
+				'schedule' => 'add',
+			)
+		);
+		$working_copy->set_entry(
+			'deleted.txt',
+			array(
+				'kind'     => 'file',
+				'revision' => 7,
+				'checksum' => $checksum,
+				'schedule' => 'delete',
+			)
+		);
+		$filesystem->put_contents( '/wc/conflicted.txt', "mine\n" );
+		$filesystem->put_contents( '/wc/conflicted.txt.r9', "theirs\n" );
+		$working_copy->set_entry(
+			'conflicted.txt',
+			array(
+				'kind'          => 'file',
+				'revision'      => 7,
+				'checksum'      => $checksum,
+				'conflict'      => true,
+				'conflict_file' => 'conflicted.txt.r9',
+			)
+		);
+
+		// unversioned: on disk without an entry.
+		$filesystem->put_contents( '/wc/stray.txt', "stray\n" );
+
+		$status = $working_copy->get_status();
+		$this->assertArrayNotHasKey( 'normal.txt', $status );
+		$this->assertSame( 'modified', $status['modified.txt'] );
+		$this->assertSame( 'missing', $status['missing.txt'] );
+		$this->assertSame( 'added', $status['added.txt'] );
+		$this->assertSame( 'deleted', $status['deleted.txt'] );
+		$this->assertSame( 'conflicted', $status['conflicted.txt'] );
+		$this->assertSame( 'unversioned', $status['stray.txt'] );
+		// Conflict artifacts are bookkeeping, not unversioned files.
+		$this->assertArrayNotHasKey( 'conflicted.txt.r9', $status );
+	}
+
+	public function test_eol_translation_to_disk() {
+		$crlf = array( 'svn:eol-style' => 'CRLF' );
+		$this->assertSame( "a\r\nb\r\n", SvnWorkingCopy::translate_to_disk( "a\nb\n", $crlf ) );
+		$this->assertSame( "a\r\nb\r\n", SvnWorkingCopy::translate_to_disk( "a\r\nb\r\n", $crlf ) );
+
+		$native = array( 'svn:eol-style' => 'native' );
+		$this->assertSame( "a\nb\n", SvnWorkingCopy::translate_to_disk( "a\r\nb\r", $native ) );
+
+		$cr = array( 'svn:eol-style' => 'CR' );
+		$this->assertSame( "a\rb\r", SvnWorkingCopy::translate_to_disk( "a\nb\n", $cr ) );
+
+		// No property: bytes pass through untouched.
+		$this->assertSame( "a\r\nb\n", SvnWorkingCopy::translate_to_disk( "a\r\nb\n", array() ) );
+	}
+
+	public function test_eol_aware_modification_check() {
+		list( $working_copy, $filesystem ) = $this->make_working_copy();
+
+		// An eol-styled file whose pristine and working copy only differ
+		// in line endings is NOT modified.
+		$entry = array(
+			'kind'     => 'file',
+			'revision' => 7,
+			'checksum' => $working_copy->store_pristine( "a\r\nb\r\n" ),
+			'props'    => array( 'svn:eol-style' => 'CRLF' ),
+		);
+		$working_copy->set_entry( 'eol.txt', $entry );
+		$filesystem->put_contents( '/wc/eol.txt', "a\nb\n" );
+		$this->assertFalse( $working_copy->is_file_modified( 'eol.txt', $entry ) );
+
+		$filesystem->put_contents( '/wc/eol.txt', "a\nCHANGED\n" );
+		$this->assertTrue( $working_copy->is_file_modified( 'eol.txt', $entry ) );
+	}
+}

--- a/components/Svn/Tests/SvnWorkingCopyTest.php
+++ b/components/Svn/Tests/SvnWorkingCopyTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 use WordPress\Filesystem\InMemoryFilesystem;
 use WordPress\Svn\SvnException;
 use WordPress\Svn\SvnWorkingCopy;
+use WordPress\Svn\WorkingCopyEditor;
 
 class SvnWorkingCopyTest extends TestCase {
 	private function make_working_copy() {
@@ -70,6 +71,42 @@ class SvnWorkingCopyTest extends TestCase {
 		$reopened = SvnWorkingCopy::open( $filesystem, '/wc' );
 		$this->assertSame( 'file', $reopened->get_entry( 'a.txt' )['kind'] );
 		$this->assertNull( $reopened->get_entry( 'missing.txt' ) );
+	}
+
+	/**
+	 * @dataProvider unsafe_path_provider
+	 *
+	 * @param string $path  Path that must not be accepted as a working-copy path.
+	 */
+	public function test_disk_paths_must_stay_inside_the_working_copy( $path ) {
+		list( $working_copy ) = $this->make_working_copy();
+
+		$this->expectException( SvnException::class );
+		$working_copy->get_disk_path( $path );
+	}
+
+	public function unsafe_path_provider() {
+		return array(
+			array( '../escape' ),
+			array( 'nested/../escape' ),
+			array( 'nested/./file.txt' ),
+			array( 'nested//file.txt' ),
+			array( '/absolute' ),
+			array( 'nested\\file.txt' ),
+		);
+	}
+
+	public function test_editor_rejects_server_paths_that_escape_the_working_copy() {
+		list( $working_copy, $filesystem ) = $this->make_working_copy();
+		$editor                           = new WorkingCopyEditor( $working_copy );
+		$editor->set_target_revision( 8 );
+
+		try {
+			$editor->add_directory( '../escape' );
+			$this->fail( 'Server-driven editor paths must not escape the working copy.' );
+		} catch ( SvnException $exception ) {
+			$this->assertFalse( $filesystem->is_dir( '/escape' ) );
+		}
 	}
 
 	public function test_status_reports_each_state() {

--- a/components/Svn/Tests/SvnserveClientTest.php
+++ b/components/Svn/Tests/SvnserveClientTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WordPress\Svn\Tests\SvnClientBehaviorTrait;
+use WordPress\Svn\Tests\SvnTestServer;
+
+require_once __DIR__ . '/SvnTestServer.php';
+require_once __DIR__ . '/SvnClientBehaviorTrait.php';
+
+/**
+ * Runs the client scenarios over the svn:// protocol against a real,
+ * locally spawned svnserve. Skipped when the subversion tools are not
+ * installed.
+ */
+class SvnserveClientTest extends TestCase {
+	use SvnClientBehaviorTrait;
+
+	/**
+	 * @var SvnTestServer|null
+	 */
+	private static $svnserve;
+
+	/**
+	 * @beforeClass
+	 */
+	public static function start_server() {
+		if ( ! SvnTestServer::svn_binaries_available() ) {
+			self::markTestSkipped( 'The svnadmin/svnserve/svn binaries are not available.' );
+		}
+		self::$svnserve = SvnTestServer::start_svnserve();
+	}
+
+	/**
+	 * @afterClass
+	 */
+	public static function stop_server() {
+		if ( null !== self::$svnserve ) {
+			self::$svnserve->stop();
+			self::$svnserve = null;
+		}
+	}
+
+	protected function server() {
+		return self::$svnserve;
+	}
+
+	public function test_interoperates_with_the_official_client() {
+		$repo_url = $this->repo();
+		$client   = $this->client();
+		$path     = $this->make_temp_path();
+		$client->checkout( $repo_url . '/trunk', $path );
+
+		file_put_contents( "$path/hello.txt", "written by php-toolkit\n" );
+		file_put_contents( "$path/from-php.txt", "a new file\n" );
+		$client->add( $path, 'from-php.txt' );
+		$commit_info = $client->commit( $path, 'commit for CLI interop check' );
+
+		// The official client must see our commit…
+		$official = $this->make_temp_path();
+		SvnTestServer::run(
+			'svn checkout -q ' . escapeshellarg( $repo_url . '/trunk' ) . ' ' . escapeshellarg( $official )
+		);
+		$this->assertSame( "written by php-toolkit\n", file_get_contents( "$official/hello.txt" ) );
+		$this->assertSame( "a new file\n", file_get_contents( "$official/from-php.txt" ) );
+
+		// …and apart from the administrative areas the two working
+		// copies must be byte-identical.
+		SvnTestServer::run(
+			'diff -r --exclude=.svn ' . escapeshellarg( $official ) . ' ' . escapeshellarg( $path )
+		);
+
+		// The other direction: a CLI commit must reach us via update.
+		file_put_contents( "$official/from-cli.txt", "committed by the official client\n" );
+		SvnTestServer::run( 'svn add -q from-cli.txt && svn commit -q -m "from the CLI" --username fixture', $official );
+		$client->update( $path );
+		$this->assertSame( "committed by the official client\n", file_get_contents( "$path/from-cli.txt" ) );
+
+		// And the repository itself must stay healthy.
+		$this->assertGreaterThan( 0, $commit_info['revision'] );
+	}
+}

--- a/components/Svn/Tests/WordPressDevelopCheckoutTest.php
+++ b/components/Svn/Tests/WordPressDevelopCheckoutTest.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WordPress\Svn\SvnClient;
+
+/**
+ * The full proof: checks out the entire wordpress-develop trunk –
+ * thousands of files, hundreds of megabytes – over HTTPS, with every
+ * file checksum-verified during the editor drive, then updates it
+ * across 80 revisions of real history.
+ *
+ * This downloads a lot of data, so it requires a double opt-in:
+ *
+ *     SVN_TESTS_ONLINE=1 SVN_TESTS_HUGE=1 \
+ *         vendor/bin/phpunit components/Svn/Tests/WordPressDevelopCheckoutTest.php
+ */
+class WordPressDevelopCheckoutTest extends TestCase {
+	/**
+	 * @var string|null
+	 */
+	private $checkout_path;
+
+	/**
+	 * @before
+	 */
+	public function require_opt_in() {
+		if ( ! getenv( 'SVN_TESTS_ONLINE' ) || ! getenv( 'SVN_TESTS_HUGE' ) ) {
+			$this->markTestSkipped( 'Set SVN_TESTS_ONLINE=1 and SVN_TESTS_HUGE=1 to run the full wordpress-develop checkout.' );
+		}
+		$this->checkout_path = sys_get_temp_dir() . '/svn-wpdevelop-test-' . bin2hex( random_bytes( 6 ) );
+	}
+
+	/**
+	 * @after
+	 */
+	public function remove_checkout() {
+		if ( null !== $this->checkout_path ) {
+			exec( 'rm -rf ' . escapeshellarg( $this->checkout_path ) );
+			$this->checkout_path = null;
+		}
+	}
+
+	public function test_full_wordpress_develop_checkout_and_update() {
+		$client = new SvnClient( array( 'timeout_ms' => 600000 ) );
+
+		// Pin two known revisions so the assertions stay meaningful.
+		$old_revision = 62400;
+		$new_revision = 62480;
+
+		$result = $client->checkout(
+			'https://develop.svn.wordpress.org/trunk',
+			$this->checkout_path,
+			array( 'revision' => $old_revision )
+		);
+		$this->assertSame( $old_revision, $result['revision'] );
+		$this->assertGreaterThan( 6000, count( $result['added'] ) );
+
+		// The tree must contain the well-known landmarks…
+		$this->assertFileExists( "{$this->checkout_path}/src/wp-includes/version.php" );
+		$this->assertFileExists( "{$this->checkout_path}/src/wp-settings.php" );
+		$this->assertFileExists( "{$this->checkout_path}/tests/phpunit/includes/bootstrap.php" );
+		$this->assertStringContainsString(
+			'$wp_version',
+			file_get_contents( "{$this->checkout_path}/src/wp-includes/version.php" )
+		);
+
+		// …including wordpress-develop's real svn:externals definition,
+		// which points at a different WordPress.org server entirely.
+		$importer = "{$this->checkout_path}/tests/phpunit/data/plugins/wordpress-importer";
+		$this->assertFileExists( "$importer/class-wp-import.php" );
+		$this->assertSame(
+			'https://plugins.svn.wordpress.org/wordpress-importer/trunk',
+			$client->info( $importer )['url']
+		);
+
+		// Every file was checksum-verified during the drive; the status
+		// walk re-verifies all of them against the pristine store. Only
+		// the external may be flagged.
+		$status = $client->status( $this->checkout_path );
+		unset( $status['tests/phpunit/data/plugins/wordpress-importer'] );
+		$this->assertSame( array(), $status );
+
+		// Now replay 80 revisions of real WordPress history.
+		$update = $client->update( $this->checkout_path, array( 'revision' => $new_revision ) );
+		$this->assertSame( $new_revision, $update['revision'] );
+		$this->assertGreaterThan( 100, count( $update['updated'] ) );
+		$this->assertSame( array(), $update['conflicted'] );
+		$this->assertSame( $new_revision, $client->info( $this->checkout_path )['revision'] );
+	}
+}

--- a/components/Svn/Tests/WordPressOrgTest.php
+++ b/components/Svn/Tests/WordPressOrgTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WordPress\Svn\SvnClient;
+
+/**
+ * Tests against the real WordPress.org Subversion servers:
+ * develop.svn.wordpress.org (WordPress core development) and
+ * plugins.svn.wordpress.org (the plugin directory).
+ *
+ * These need the network, so they only run when opted in:
+ *
+ *     SVN_TESTS_ONLINE=1 vendor/bin/phpunit components/Svn/Tests/WordPressOrgTest.php
+ */
+class WordPressOrgTest extends TestCase {
+	const WORDPRESS_DEVELOP = 'https://develop.svn.wordpress.org';
+	const PLUGINS           = 'https://plugins.svn.wordpress.org';
+
+	/**
+	 * @var string[]
+	 */
+	private $temp_dirs = array();
+
+	/**
+	 * @before
+	 */
+	public function require_opt_in() {
+		if ( ! getenv( 'SVN_TESTS_ONLINE' ) ) {
+			$this->markTestSkipped( 'Set SVN_TESTS_ONLINE=1 to run the WordPress.org network tests.' );
+		}
+	}
+
+	/**
+	 * @after
+	 */
+	public function remove_temp_dirs() {
+		foreach ( $this->temp_dirs as $directory ) {
+			exec( 'rm -rf ' . escapeshellarg( $directory ) );
+		}
+		$this->temp_dirs = array();
+	}
+
+	private function make_temp_path() {
+		$path              = sys_get_temp_dir() . '/svn-wporg-test-' . bin2hex( random_bytes( 6 ) );
+		$this->temp_dirs[] = $path;
+
+		return $path;
+	}
+
+	private function client() {
+		return new SvnClient( array( 'timeout_ms' => 120000 ) );
+	}
+
+	public function test_wordpress_develop_basics() {
+		$client = $this->client();
+
+		$latest = $client->latest_revision( self::WORDPRESS_DEVELOP );
+		// WordPress development passed r62000 in 2025.
+		$this->assertGreaterThan( 62000, $latest );
+
+		$session = $client->open_session( self::WORDPRESS_DEVELOP . '/trunk' );
+		$this->assertSame( 'https://develop.svn.wordpress.org', $session->get_repository_root() );
+		$this->assertSame( '602fd350-edb4-49c9-b593-d223f7449a82', $session->get_uuid() );
+
+		$names = array();
+		foreach ( $session->list_directory( '' ) as $entry ) {
+			$names[ $entry['name'] ] = $entry['kind'];
+		}
+		$this->assertSame( 'dir', $names['src'] );
+		$this->assertSame( 'dir', $names['tests'] );
+		$this->assertSame( 'file', $names['package.json'] );
+
+		$file = $session->get_file( 'wp-config-sample.php' );
+		$this->assertSame( md5( $file['contents'] ), $file['checksum'] );
+		$this->assertStringContainsString( 'DB_NAME', $file['contents'] );
+		$this->assertSame( 'CRLF', $file['properties']['svn:eol-style'] );
+
+		$session->close();
+	}
+
+	public function test_checkout_a_wordpress_develop_subtree() {
+		$client = $this->client();
+		$path   = $this->make_temp_path();
+
+		$result = $client->checkout( self::WORDPRESS_DEVELOP . '/trunk/src/wp-admin/css/colors', $path );
+
+		$this->assertGreaterThan( 62000, $result['revision'] );
+		$this->assertFileExists( "$path/blue/colors.scss" );
+		$this->assertFileExists( "$path/midnight/colors.scss" );
+		$this->assertStringContainsString( '$scheme-name', file_get_contents( "$path/blue/colors.scss" ) );
+
+		// A fresh checkout must be clean.
+		$this->assertSame( array(), $client->status( $path ) );
+	}
+
+	public function test_checkout_wordpress_develop_root_with_limited_depth() {
+		$client = $this->client();
+		$path   = $this->make_temp_path();
+
+		$result = $client->checkout( self::WORDPRESS_DEVELOP . '/trunk', $path, array( 'depth' => 'files' ) );
+
+		$this->assertGreaterThan( 62000, $result['revision'] );
+		$this->assertFileExists( "$path/wp-config-sample.php" );
+		$this->assertFileExists( "$path/package.json" );
+		$this->assertFileDoesNotExist( "$path/src" );
+
+		// wp-config-sample.php carries svn:eol-style CRLF.
+		$this->assertStringContainsString( "\r\n", file_get_contents( "$path/wp-config-sample.php" ) );
+		$this->assertSame( array(), $client->status( $path ) );
+	}
+
+	public function test_plugins_repository_read() {
+		$client  = $this->client();
+		$session = $client->open_session( self::PLUGINS . '/hello-dolly/trunk' );
+
+		$file = $session->get_file( 'hello.php' );
+		$this->assertSame( md5( $file['contents'] ), $file['checksum'] );
+		$this->assertStringContainsString( 'Hello Dolly', $file['contents'] );
+
+		$session->close();
+
+		$path = $this->make_temp_path();
+		$client->checkout( self::PLUGINS . '/hello-dolly/trunk', $path );
+		$this->assertFileExists( "$path/hello.php" );
+		$this->assertSame( array(), $client->status( $path ) );
+	}
+}

--- a/components/Svn/Tests/WordPressOrgTest.php
+++ b/components/Svn/Tests/WordPressOrgTest.php
@@ -103,7 +103,7 @@ class WordPressOrgTest extends TestCase {
 		$this->assertGreaterThan( 62000, $result['revision'] );
 		$this->assertFileExists( "$path/wp-config-sample.php" );
 		$this->assertFileExists( "$path/package.json" );
-		$this->assertFileDoesNotExist( "$path/src" );
+		$this->assertFalse( file_exists( "$path/src" ) );
 
 		// wp-config-sample.php carries svn:eol-style CRLF.
 		$this->assertStringContainsString( "\r\n", file_get_contents( "$path/wp-config-sample.php" ) );

--- a/components/Svn/Tests/fixtures/update-report-checkout.xml
+++ b/components/Svn/Tests/fixtures/update-report-checkout.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<S:update-report xmlns:S="svn:" xmlns:V="http://subversion.tigris.org/xmlns/dav/" xmlns:D="DAV:" send-all="true" inline-props="true">
+<S:target-revision rev="2"/>
+<S:open-directory rev="2">
+<D:checked-in><D:href>/repos/repo1/!svn/rvr/2/trunk</D:href></D:checked-in>
+<S:set-prop name="svn:entry:committed-rev">2</S:set-prop>
+<S:set-prop name="svn:entry:committed-date">2026-06-10T10:44:26.052108Z</S:set-prop>
+<S:set-prop name="svn:entry:last-author">fixture</S:set-prop>
+<S:set-prop name="svn:entry:uuid">99c65cdb-4f48-4f56-a481-b20bcf5ce199</S:set-prop>
+<S:add-file name="hello.txt" sha1-checksum="22596363b3de40b06f981fb85d82312e8c0ed511">
+<D:checked-in><D:href>/repos/repo1/!svn/rvr/1/trunk/hello.txt</D:href></D:checked-in>
+<S:set-prop name="svn:entry:committed-rev">1</S:set-prop>
+<S:set-prop name="svn:entry:committed-date">2026-06-10T10:44:26.015930Z</S:set-prop>
+<S:set-prop name="svn:entry:last-author">fixture</S:set-prop>
+<S:set-prop name="svn:entry:uuid">99c65cdb-4f48-4f56-a481-b20bcf5ce199</S:set-prop>
+<S:txdelta>U1ZOAAAADAEMjGhlbGxvIHdvcmxkCg==</S:txdelta><S:prop><V:md5-checksum>6f5902ac237024bdd0c176cb93063dc4</V:md5-checksum></S:prop></S:add-file>
+<S:add-file name="multi.txt" sha1-checksum="08874e7ad960b0733c54db76451542b0b571f24d">
+<D:checked-in><D:href>/repos/repo1/!svn/rvr/2/trunk/multi.txt</D:href></D:checked-in>
+<S:set-prop name="svn:entry:committed-rev">2</S:set-prop>
+<S:set-prop name="svn:entry:committed-date">2026-06-10T10:44:26.052108Z</S:set-prop>
+<S:set-prop name="svn:entry:last-author">fixture</S:set-prop>
+<S:set-prop name="svn:entry:uuid">99c65cdb-4f48-4f56-a481-b20bcf5ce199</S:set-prop>
+<S:set-prop name="svn:eol-style">CRLF</S:set-prop>
+<S:txdelta>U1ZOAAAAFQEVlWxpbmUxDQpsaW5lMg0KbGluZTMNCg==</S:txdelta><S:prop><V:md5-checksum>4eddda61f5e53754d0b028ab69a17be9</V:md5-checksum></S:prop></S:add-file>
+<S:add-directory name="sub" bc-url="/repos/repo1/!svn/bc/1/trunk/sub">
+<D:checked-in><D:href>/repos/repo1/!svn/rvr/1/trunk/sub</D:href></D:checked-in>
+<S:set-prop name="svn:entry:committed-rev">1</S:set-prop>
+<S:set-prop name="svn:entry:committed-date">2026-06-10T10:44:26.015930Z</S:set-prop>
+<S:set-prop name="svn:entry:last-author">fixture</S:set-prop>
+<S:set-prop name="svn:entry:uuid">99c65cdb-4f48-4f56-a481-b20bcf5ce199</S:set-prop>
+<S:add-directory name="deep" bc-url="/repos/repo1/!svn/bc/1/trunk/sub/deep">
+<D:checked-in><D:href>/repos/repo1/!svn/rvr/1/trunk/sub/deep</D:href></D:checked-in>
+<S:set-prop name="svn:entry:committed-rev">1</S:set-prop>
+<S:set-prop name="svn:entry:committed-date">2026-06-10T10:44:26.015930Z</S:set-prop>
+<S:set-prop name="svn:entry:last-author">fixture</S:set-prop>
+<S:set-prop name="svn:entry:uuid">99c65cdb-4f48-4f56-a481-b20bcf5ce199</S:set-prop>
+<S:add-file name="nested.txt" sha1-checksum="6897bc5b50ceac27200cda28f6d09319a1633114">
+<D:checked-in><D:href>/repos/repo1/!svn/rvr/1/trunk/sub/deep/nested.txt</D:href></D:checked-in>
+<S:set-prop name="svn:entry:committed-rev">1</S:set-prop>
+<S:set-prop name="svn:entry:committed-date">2026-06-10T10:44:26.015930Z</S:set-prop>
+<S:set-prop name="svn:entry:last-author">fixture</S:set-prop>
+<S:set-prop name="svn:entry:uuid">99c65cdb-4f48-4f56-a481-b20bcf5ce199</S:set-prop>
+<S:txdelta>U1ZOAAAADAEMjG5lc3RlZCBmaWxlCg==</S:txdelta><S:prop><V:md5-checksum>a47170636e9c528995092e14a81000ab</V:md5-checksum></S:prop></S:add-file>
+</S:add-directory>
+</S:add-directory>
+</S:open-directory>
+</S:update-report>

--- a/components/Svn/Tests/http-server/Dockerfile
+++ b/components/Svn/Tests/http-server/Dockerfile
@@ -1,0 +1,18 @@
+# Apache + mod_dav_svn server used by the Svn component's HTTP
+# integration tests. See WithSvnHttpServerTrait.php for how it is built
+# and started.
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends apache2 libapache2-mod-svn subversion \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN a2enmod dav dav_svn authn_core authn_file auth_basic authz_user
+
+COPY httpd-svn.conf /etc/apache2/conf-enabled/svn.conf
+COPY entrypoint.sh /entrypoint.sh
+COPY create-repo.sh /create-repo.sh
+RUN chmod +x /entrypoint.sh /create-repo.sh
+
+EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]

--- a/components/Svn/Tests/http-server/create-repo.sh
+++ b/components/Svn/Tests/http-server/create-repo.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Creates one fixture repository: create-repo.sh <name> <anon|auth>
+# Used both by the entrypoint and by the test suite (via docker exec)
+# to give every test an isolated repository.
+set -e
+
+name="$1"
+mode="${2:-anon}"
+
+if [ "$mode" = "auth" ]; then
+	parent=/var/svn-auth
+else
+	parent=/var/svn
+fi
+
+# Clone the template fixture when it exists – much faster than
+# rebuilding the fixture content with svn commands.
+if [ -d "$parent/.template" ]; then
+	cp -a "$parent/.template" "$parent/$name"
+	exit 0
+fi
+
+svnadmin create "$parent/$name"
+work="$(mktemp -d)"
+svn checkout -q "file://$parent/$name" "$work"
+cd "$work"
+mkdir -p trunk/sub/deep branches
+printf 'hello world\n' > trunk/hello.txt
+printf 'line1\nline2\nline3\n' > trunk/multi.txt
+printf 'nested file\n' > trunk/sub/deep/nested.txt
+svn add -q trunk branches
+svn commit -q -m 'initial content' --username fixture
+svn propset -q svn:eol-style CRLF trunk/multi.txt
+svn commit -q -m 'set eol-style' --username fixture
+cd /
+rm -rf "$work"
+chown -R www-data:www-data "$parent/$name"

--- a/components/Svn/Tests/http-server/entrypoint.sh
+++ b/components/Svn/Tests/http-server/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Creates the initial test repositories and starts Apache in the
+# foreground. The test suite creates more repositories on the fly with
+# create-repo.sh via docker exec.
+set -e
+
+htpasswd -bc /etc/apache2/dav_svn.passwd alice secret123
+
+mkdir -p /var/svn /var/svn-auth
+
+/create-repo.sh .template anon
+/create-repo.sh .template auth
+/create-repo.sh repo1 anon
+/create-repo.sh repo2 auth
+
+. /etc/apache2/envvars
+exec apache2 -DFOREGROUND

--- a/components/Svn/Tests/http-server/httpd-svn.conf
+++ b/components/Svn/Tests/http-server/httpd-svn.conf
@@ -1,0 +1,18 @@
+# Two repository mounts:
+#  - /repos/*      anonymous read and write
+#  - /auth-repos/* read and write require basic auth (alice / secret123)
+<Location /repos>
+	DAV svn
+	SVNParentPath /var/svn
+	SVNListParentPath on
+</Location>
+
+<Location /auth-repos>
+	DAV svn
+	SVNParentPath /var/svn-auth
+	SVNListParentPath on
+	AuthType Basic
+	AuthName "Svn Test Realm"
+	AuthUserFile /etc/apache2/dav_svn.passwd
+	Require valid-user
+</Location>

--- a/components/Svn/class-svnclient.php
+++ b/components/Svn/class-svnclient.php
@@ -1,0 +1,679 @@
+<?php
+
+namespace WordPress\Svn;
+
+use WordPress\Filesystem\LocalFilesystem;
+use WordPress\Svn\Protocol\DavSession;
+use WordPress\Svn\Protocol\RaSvnSession;
+
+/**
+ * A Subversion client in pure PHP.
+ *
+ * Supports checking out, updating, and committing to Subversion
+ * repositories over both svn:// (the ra_svn protocol) and http:// /
+ * https:// (the DAV-based protocol, requires a Subversion 1.7+ server).
+ * svn:externals are checked out as nested working copies.
+ *
+ *     $client = new SvnClient( array( 'username' => 'alice', 'password' => 's3cret' ) );
+ *     $client->checkout( 'https://develop.svn.wordpress.org/trunk', '/tmp/wordpress-develop' );
+ *     // ...edit files...
+ *     $client->add( '/tmp/wordpress-develop', 'src/new-file.php' );
+ *     $client->commit( '/tmp/wordpress-develop', 'Add a new file.' );
+ *     $client->update( '/tmp/wordpress-develop' );
+ *
+ * Working copies use this component's own `.svn` administrative format –
+ * they are not interchangeable with working copies created by the
+ * official `svn` client. The repositories themselves are fully
+ * interoperable, of course.
+ *
+ * All working copy paths handed to this class are paths within the
+ * configured Filesystem (the local disk by default) and use forward
+ * slashes on every platform.
+ */
+class SvnClient {
+	/**
+	 * @var array
+	 */
+	private $options;
+
+	/**
+	 * @var \WordPress\Filesystem\Filesystem
+	 */
+	private $filesystem;
+
+	/**
+	 * @param array $options {
+	 *     @type string     $username    Username for authenticated operations.
+	 *     @type string     $password    Password for authenticated operations.
+	 *     @type Filesystem $filesystem  Filesystem to place working copies on.
+	 *                                   Defaults to the local disk.
+	 *     @type int        $timeout_ms  Network read timeout. Default 60000.
+	 *     @type Client     $http_client Custom HttpClient\Client for http(s) sessions.
+	 * }
+	 */
+	public function __construct( $options = array() ) {
+		$this->options    = $options;
+		$this->filesystem = isset( $options['filesystem'] ) ? $options['filesystem'] : LocalFilesystem::create();
+	}
+
+	/**
+	 * Opens a repository session for a URL. Useful for repository-level
+	 * operations that need no working copy, such as listing directories.
+	 *
+	 * @param  string $url  An svn://, http://, or https:// repository URL.
+	 * @return SvnSession
+	 * @throws SvnException When the URL scheme is not supported.
+	 */
+	public function open_session( $url ) {
+		$scheme = parse_url( $url, PHP_URL_SCHEME );
+		if ( 'svn' === $scheme ) {
+			return RaSvnSession::connect( $url, $this->options );
+		}
+		if ( 'http' === $scheme || 'https' === $scheme ) {
+			return DavSession::connect( $url, $this->options );
+		}
+
+		throw new SvnException( "Unsupported repository URL scheme '{$scheme}'. Use svn://, http://, or https://." );
+	}
+
+	/**
+	 * @param  string $url  A repository URL.
+	 * @return int The youngest revision of the repository.
+	 */
+	public function latest_revision( $url ) {
+		$session = $this->open_session( $url );
+		try {
+			return $session->get_latest_revision();
+		} finally {
+			$session->close();
+		}
+	}
+
+	/**
+	 * Checks out a repository URL into a new working copy.
+	 *
+	 * @param  string $url      The URL to check out.
+	 * @param  string $path     Where to create the working copy. Must not
+	 *                          exist yet, or be an empty directory.
+	 * @param  array  $options  {
+	 *     @type int    $revision          Revision to check out. Default: the latest.
+	 *     @type string $depth             'empty', 'files', 'immediates', or
+	 *                                     'infinity' (default).
+	 *     @type bool   $ignore_externals  Skip svn:externals. Default false.
+	 * }
+	 * @return array The checkout result: revision plus lists of affected paths.
+	 * @throws SvnException When the target is in the way or the server errors.
+	 */
+	public function checkout( $url, $path, $options = array() ) {
+		return $this->checkout_internal( $url, $path, $options, 0 );
+	}
+
+	/**
+	 * Brings a working copy up to date with the repository.
+	 *
+	 * Locally modified files that also changed in the repository are
+	 * kept; the incoming version is stored next to them as
+	 * `<name>.r<revision>` and the file is marked conflicted until
+	 * resolved() is called.
+	 *
+	 * @param  string $path     The working copy root.
+	 * @param  array  $options  {
+	 *     @type int  $revision          Revision to update to. Default: the latest.
+	 *     @type bool $ignore_externals  Skip svn:externals. Default false.
+	 * }
+	 * @return array The update result: revision plus lists of affected paths.
+	 */
+	public function update( $path, $options = array() ) {
+		return $this->update_internal( $path, $options, 0 );
+	}
+
+	/**
+	 * Reports the local changes in a working copy.
+	 *
+	 * @param  string $path  The working copy root.
+	 * @return array Map of relative path => 'modified', 'added', 'deleted',
+	 *               'missing', 'conflicted', 'unversioned', 'external', or
+	 *               'obstructed'. Unmodified files are not reported.
+	 */
+	public function status( $path ) {
+		return $this->open_working_copy( $path )->get_status();
+	}
+
+	/**
+	 * Returns what the working copy knows about itself.
+	 *
+	 * @param  string $path  The working copy root.
+	 * @return array { url, repository_root, uuid, revision, depth }
+	 */
+	public function info( $path ) {
+		$working_copy = $this->open_working_copy( $path );
+
+		return array(
+			'url'             => $working_copy->get_url(),
+			'repository_root' => $working_copy->get_repository_root(),
+			'uuid'            => $working_copy->get_uuid(),
+			'revision'        => $working_copy->get_revision(),
+			'depth'           => $working_copy->get_depth(),
+		);
+	}
+
+	/**
+	 * Schedules unversioned files or directories for addition. Directories
+	 * are added recursively. Unversioned parent directories are scheduled
+	 * automatically.
+	 *
+	 * @param string          $path            The working copy root.
+	 * @param string|string[] $relative_paths  Path(s) to add, relative to the root.
+	 */
+	public function add( $path, $relative_paths ) {
+		$working_copy = $this->open_working_copy( $path );
+		foreach ( (array) $relative_paths as $relative_path ) {
+			$this->add_path( $working_copy, trim( $relative_path, '/' ) );
+		}
+		$working_copy->save();
+	}
+
+	/**
+	 * Schedules versioned files or directories for deletion and removes
+	 * them from disk. The deletion happens in the repository on the next
+	 * commit.
+	 *
+	 * @param  string          $path            The working copy root.
+	 * @param  string|string[] $relative_paths  Path(s) to delete, relative to the root.
+	 * @param  array           $options         { @type bool $force  Delete even when locally modified. }
+	 * @throws SvnException When a path is unversioned or locally modified.
+	 */
+	public function delete( $path, $relative_paths, $options = array() ) {
+		$working_copy = $this->open_working_copy( $path );
+		foreach ( (array) $relative_paths as $relative_path ) {
+			$this->delete_path( $working_copy, trim( $relative_path, '/' ), ! empty( $options['force'] ) );
+		}
+		$working_copy->save();
+	}
+
+	/**
+	 * Discards local changes, restoring files to their pristine state.
+	 *
+	 * @param string          $path            The working copy root.
+	 * @param string|string[] $relative_paths  Path(s) to revert, relative to the root.
+	 */
+	public function revert( $path, $relative_paths ) {
+		$working_copy = $this->open_working_copy( $path );
+		foreach ( (array) $relative_paths as $relative_path ) {
+			$this->revert_path( $working_copy, trim( $relative_path, '/' ) );
+		}
+		$working_copy->save();
+	}
+
+	/**
+	 * Marks conflicted files as resolved, keeping their current working
+	 * contents, and removes the `<name>.r<revision>` conflict files.
+	 *
+	 * @param string          $path            The working copy root.
+	 * @param string|string[] $relative_paths  Path(s) to resolve, relative to the root.
+	 */
+	public function resolved( $path, $relative_paths ) {
+		$working_copy = $this->open_working_copy( $path );
+		$filesystem   = $working_copy->get_filesystem();
+		foreach ( (array) $relative_paths as $relative_path ) {
+			$relative_path = trim( $relative_path, '/' );
+			$entry         = $working_copy->get_entry( $relative_path );
+			if ( null === $entry || empty( $entry['conflict'] ) ) {
+				continue;
+			}
+			if ( isset( $entry['conflict_file'] ) && $filesystem->is_file( $working_copy->get_disk_path( $entry['conflict_file'] ) ) ) {
+				$filesystem->rm( $working_copy->get_disk_path( $entry['conflict_file'] ) );
+			}
+			unset( $entry['conflict'], $entry['conflict_file'] );
+			$working_copy->set_entry( $relative_path, $entry );
+		}
+		$working_copy->save();
+	}
+
+	/**
+	 * Commits the local changes of a working copy as a new revision.
+	 *
+	 * Changes inside svn:externals are not committed – commit each
+	 * external's working copy separately, like the official client.
+	 *
+	 * @param  string $path     The working copy root.
+	 * @param  string $message  The log message.
+	 * @return array|null Commit info { revision, author, date }, or null
+	 *                    when there was nothing to commit.
+	 * @throws SvnException When conflicts exist or the server rejects the commit.
+	 */
+	public function commit( $path, $message ) {
+		$working_copy = $this->open_working_copy( $path );
+		$status       = $working_copy->get_status();
+
+		$conflicted = array_keys( $status, 'conflicted', true );
+		if ( count( $conflicted ) > 0 ) {
+			throw new SvnException( 'Cannot commit: conflicts remain in ' . implode( ', ', $conflicted ) . '. Resolve them first.' );
+		}
+
+		$operations = $this->status_to_operations( $working_copy, $status );
+		if ( 0 === count( $operations ) ) {
+			return null;
+		}
+
+		$session = $this->open_session( $working_copy->get_url() );
+		try {
+			$commit_info = $session->commit( $message, $operations );
+		} finally {
+			$session->close();
+		}
+
+		$this->record_committed_changes( $working_copy, $operations, $commit_info['revision'] );
+
+		return $commit_info;
+	}
+
+	/**
+	 * Opens the working copy at a path.
+	 *
+	 * @param  string $path  The working copy root.
+	 * @return SvnWorkingCopy
+	 */
+	private function open_working_copy( $path ) {
+		return SvnWorkingCopy::open( $this->filesystem, $path );
+	}
+
+	private function checkout_internal( $url, $path, $options, $externals_depth ) {
+		$url = rtrim( $url, '/' );
+		if ( SvnWorkingCopy::is_working_copy( $this->filesystem, $path ) ) {
+			throw new SvnException( "'{$path}' is already a working copy. Use update() instead." );
+		}
+		if ( $this->filesystem->is_file( $path ) ) {
+			throw new SvnException( "Cannot check out into '{$path}': a file is in the way." );
+		}
+		if ( $this->filesystem->is_dir( $path ) && count( $this->filesystem->ls( $path ) ) > 0 ) {
+			throw new SvnException( "Cannot check out into '{$path}': the directory is not empty." );
+		}
+
+		$depth   = isset( $options['depth'] ) ? $options['depth'] : 'infinity';
+		$session = $this->open_session( $url );
+		try {
+			$revision = isset( $options['revision'] ) ? $options['revision'] : $session->get_latest_revision();
+
+			$working_copy = SvnWorkingCopy::initialize(
+				$this->filesystem,
+				$path,
+				array(
+					'url'             => $session->get_session_url(),
+					'repository_root' => $session->get_repository_root(),
+					'uuid'            => $session->get_uuid(),
+					'revision'        => $revision,
+					'depth'           => $depth,
+				)
+			);
+
+			$editor = new WorkingCopyEditor( $working_copy );
+			$session->drive_update(
+				$revision,
+				array(
+					array(
+						'path'        => '',
+						'revision'    => $revision,
+						'start_empty' => true,
+					),
+				),
+				$editor,
+				array( 'depth' => $depth )
+			);
+		} finally {
+			$session->close();
+		}
+
+		$result = $editor->get_result();
+		if ( empty( $options['ignore_externals'] ) ) {
+			$result['externals'] = $this->sync_externals( $working_copy, $externals_depth );
+		}
+		$result['revision'] = $revision;
+
+		return $result;
+	}
+
+	private function update_internal( $path, $options, $externals_depth ) {
+		$working_copy = $this->open_working_copy( $path );
+		$session      = $this->open_session( $working_copy->get_url() );
+		try {
+			$revision = isset( $options['revision'] ) ? $options['revision'] : $session->get_latest_revision();
+
+			// Describe the working copy state to the server. Commits leave
+			// the committed entries at a newer revision than the rest of
+			// the working copy, and reporting those entries individually
+			// makes the server send deltas against the right bases.
+			$report = array(
+				array(
+					'path'        => '',
+					'revision'    => $working_copy->get_revision(),
+					'start_empty' => false,
+				),
+			);
+			foreach ( $working_copy->get_entries() as $entry_path => $entry ) {
+				if ( '' === $entry_path || isset( $entry['schedule'] ) ) {
+					continue;
+				}
+				if ( $entry['revision'] !== $working_copy->get_revision() ) {
+					$report[] = array(
+						'path'        => $entry_path,
+						'revision'    => $entry['revision'],
+						'start_empty' => false,
+					);
+				}
+			}
+
+			$editor = new WorkingCopyEditor( $working_copy );
+			$session->drive_update(
+				$revision,
+				$report,
+				$editor,
+				array( 'depth' => $working_copy->get_depth() )
+			);
+		} finally {
+			$session->close();
+		}
+
+		$result = $editor->get_result();
+		if ( empty( $options['ignore_externals'] ) ) {
+			$result['externals'] = $this->sync_externals( $working_copy, $externals_depth );
+		}
+		$result['revision'] = $revision;
+
+		return $result;
+	}
+
+	/**
+	 * Checks out or updates every svn:externals definition found in the
+	 * working copy as a nested working copy.
+	 *
+	 * @param  SvnWorkingCopy $working_copy     The parent working copy.
+	 * @param  int            $externals_depth  Current nesting depth, to break cycles.
+	 * @return array Map of external target path => { url, revision }.
+	 */
+	private function sync_externals( SvnWorkingCopy $working_copy, $externals_depth ) {
+		if ( $externals_depth >= SvnWorkingCopy::MAX_EXTERNALS_DEPTH ) {
+			return array();
+		}
+
+		$definitions = array();
+		foreach ( $working_copy->get_entries() as $entry_path => $entry ) {
+			if ( 'dir' !== $entry['kind'] || ! isset( $entry['props']['svn:externals'] ) ) {
+				continue;
+			}
+			$directory_url = $working_copy->get_url() . ( '' === $entry_path ? '' : '/' . $entry_path );
+			$externals     = svn_parse_externals(
+				$entry['props']['svn:externals'],
+				$directory_url,
+				$working_copy->get_repository_root()
+			);
+			foreach ( $externals as $external ) {
+				$target_path                 = ( '' === $entry_path ? '' : $entry_path . '/' ) . $external['target'];
+				$definitions[ $target_path ] = $external;
+			}
+		}
+
+		$recorded = array();
+		foreach ( $definitions as $target_path => $external ) {
+			$disk_path = $working_copy->get_disk_path( $target_path );
+			if ( SvnWorkingCopy::is_working_copy( $this->filesystem, $disk_path ) ) {
+				$nested = SvnWorkingCopy::open( $this->filesystem, $disk_path );
+				if ( $nested->get_url() !== $external['url'] ) {
+					// The external now points elsewhere. Re-checkouts of
+					// switched externals are not supported yet; leave the
+					// existing checkout alone.
+					continue;
+				}
+				$this->update_internal(
+					$disk_path,
+					null === $external['revision'] ? array() : array( 'revision' => $external['revision'] ),
+					$externals_depth + 1
+				);
+			} else {
+				$this->checkout_internal(
+					$external['url'],
+					$disk_path,
+					null === $external['revision'] ? array() : array( 'revision' => $external['revision'] ),
+					$externals_depth + 1
+				);
+			}
+			$recorded[ $target_path ] = array(
+				'url'      => $external['url'],
+				'revision' => $external['revision'],
+			);
+		}
+
+		$working_copy->set_externals( $recorded );
+		$working_copy->save();
+
+		return $recorded;
+	}
+
+	private function add_path( SvnWorkingCopy $working_copy, $relative_path ) {
+		if ( '' === $relative_path ) {
+			throw new SvnException( 'Cannot add the working copy root.' );
+		}
+		$entry = $working_copy->get_entry( $relative_path );
+		if ( null !== $entry ) {
+			return;
+		}
+		$filesystem = $working_copy->get_filesystem();
+		$disk_path  = $working_copy->get_disk_path( $relative_path );
+		if ( ! $filesystem->exists( $disk_path ) ) {
+			throw new SvnException( "Cannot add '{$relative_path}': no such file or directory." );
+		}
+
+		// Schedule unversioned ancestors too.
+		$slash_position = strrpos( $relative_path, '/' );
+		if ( false !== $slash_position ) {
+			$this->add_path( $working_copy, substr( $relative_path, 0, $slash_position ) );
+		}
+
+		if ( $filesystem->is_dir( $disk_path ) ) {
+			$working_copy->set_entry(
+				$relative_path,
+				array(
+					'kind'     => 'dir',
+					'schedule' => 'add',
+				)
+			);
+			foreach ( $filesystem->ls( $disk_path ) as $child_name ) {
+				if ( SvnWorkingCopy::ADMIN_DIR === $child_name ) {
+					continue;
+				}
+				$this->add_path( $working_copy, $relative_path . '/' . $child_name );
+			}
+		} else {
+			$working_copy->set_entry(
+				$relative_path,
+				array(
+					'kind'     => 'file',
+					'schedule' => 'add',
+				)
+			);
+		}
+	}
+
+	private function delete_path( SvnWorkingCopy $working_copy, $relative_path, $force ) {
+		$entry = $working_copy->get_entry( $relative_path );
+		if ( null === $entry ) {
+			throw new SvnException( "Cannot delete '{$relative_path}': not under version control." );
+		}
+		$filesystem = $working_copy->get_filesystem();
+
+		$paths = array_merge( array( $relative_path ), $working_copy->get_entry_paths_under( $relative_path ) );
+		if ( ! $force ) {
+			foreach ( $paths as $target_path ) {
+				$target_entry = $working_copy->get_entry( $target_path );
+				if ( 'file' === $target_entry['kind']
+					&& ! isset( $target_entry['schedule'] )
+					&& $filesystem->is_file( $working_copy->get_disk_path( $target_path ) )
+					&& $working_copy->is_file_modified( $target_path, $target_entry ) ) {
+					throw new SvnException( "Cannot delete '{$target_path}': it has local modifications. Pass the 'force' option to delete it anyway." );
+				}
+			}
+		}
+
+		rsort( $paths );
+		foreach ( $paths as $target_path ) {
+			$target_entry = $working_copy->get_entry( $target_path );
+			$disk_path    = $working_copy->get_disk_path( $target_path );
+			if ( isset( $target_entry['schedule'] ) && 'add' === $target_entry['schedule'] ) {
+				// Deleting a scheduled addition just unschedules it.
+				$working_copy->remove_entry( $target_path );
+			} else {
+				$target_entry['schedule'] = 'delete';
+				$working_copy->set_entry( $target_path, $target_entry );
+			}
+			if ( 'file' === $target_entry['kind'] && $filesystem->is_file( $disk_path ) ) {
+				$filesystem->rm( $disk_path );
+			} elseif ( 'dir' === $target_entry['kind'] && $filesystem->is_dir( $disk_path ) && 0 === count( $filesystem->ls( $disk_path ) ) ) {
+				$filesystem->rmdir( $disk_path, array() );
+			}
+		}
+	}
+
+	private function revert_path( SvnWorkingCopy $working_copy, $relative_path ) {
+		$entry = $working_copy->get_entry( $relative_path );
+		if ( null === $entry ) {
+			return;
+		}
+		$filesystem = $working_copy->get_filesystem();
+
+		if ( isset( $entry['schedule'] ) && 'add' === $entry['schedule'] ) {
+			// Reverting an addition leaves the file on disk, unversioned.
+			$working_copy->remove_entry( $relative_path );
+			foreach ( $working_copy->get_entry_paths_under( $relative_path ) as $child_path ) {
+				$working_copy->remove_entry( $child_path );
+			}
+
+			return;
+		}
+
+		if ( 'dir' === $entry['kind'] ) {
+			unset( $entry['schedule'] );
+			$working_copy->set_entry( $relative_path, $entry );
+			if ( ! $filesystem->is_dir( $working_copy->get_disk_path( $relative_path ) ) ) {
+				$filesystem->mkdir( $working_copy->get_disk_path( $relative_path ), array( 'recursive' => true ) );
+			}
+			foreach ( $working_copy->get_entry_paths_under( $relative_path ) as $child_path ) {
+				$this->revert_path( $working_copy, $child_path );
+			}
+
+			return;
+		}
+
+		unset( $entry['schedule'], $entry['conflict'] );
+		if ( isset( $entry['conflict_file'] ) ) {
+			if ( $filesystem->is_file( $working_copy->get_disk_path( $entry['conflict_file'] ) ) ) {
+				$filesystem->rm( $working_copy->get_disk_path( $entry['conflict_file'] ) );
+			}
+			unset( $entry['conflict_file'] );
+		}
+		if ( isset( $entry['checksum'] ) ) {
+			$working_copy->write_working_file(
+				$relative_path,
+				$working_copy->read_pristine( $entry['checksum'] ),
+				isset( $entry['props'] ) ? $entry['props'] : array()
+			);
+		}
+		$working_copy->set_entry( $relative_path, $entry );
+	}
+
+	/**
+	 * Converts a status report into the commit operations the session
+	 * layer understands.
+	 *
+	 * @param  SvnWorkingCopy $working_copy  The working copy being committed.
+	 * @param  array          $status        Output of SvnWorkingCopy::get_status().
+	 * @return array[] Commit operations, see SvnSession::commit().
+	 */
+	private function status_to_operations( SvnWorkingCopy $working_copy, $status ) {
+		$operations = array();
+		foreach ( $status as $relative_path => $state ) {
+			$entry = $working_copy->get_entry( $relative_path );
+			switch ( $state ) {
+				case 'added':
+					if ( 'dir' === $entry['kind'] ) {
+						$operations[] = array(
+							'op'   => 'add-directory',
+							'path' => $relative_path,
+						);
+					} else {
+						$operations[] = array(
+							'op'       => 'add-file',
+							'path'     => $relative_path,
+							'contents' => $working_copy->read_working_file( $relative_path, $entry ),
+						);
+					}
+					break;
+
+				case 'modified':
+					$operations[] = array(
+						'op'            => 'modify-file',
+						'path'          => $relative_path,
+						'contents'      => $working_copy->read_working_file( $relative_path, $entry ),
+						'base_revision' => $entry['revision'],
+					);
+					break;
+
+				case 'deleted':
+					// One delete of the topmost scheduled path covers all
+					// the scheduled deletions below it.
+					$slash_position = strrpos( $relative_path, '/' );
+					$parent_path    = false === $slash_position ? '' : substr( $relative_path, 0, $slash_position );
+					$parent_status  = isset( $status[ $parent_path ] ) ? $status[ $parent_path ] : null;
+					if ( 'deleted' !== $parent_status ) {
+						$operations[] = array(
+							'op'            => 'delete',
+							'path'          => $relative_path,
+							'base_revision' => isset( $entry['revision'] ) ? $entry['revision'] : $working_copy->get_revision(),
+						);
+					}
+					break;
+			}
+		}
+
+		return $operations;
+	}
+
+	/**
+	 * Updates the working copy metadata after a successful commit: the
+	 * committed entries move to the new revision and their pristines
+	 * match what was sent to the server.
+	 *
+	 * @param SvnWorkingCopy $working_copy  The committed working copy.
+	 * @param array[]        $operations    The committed operations.
+	 * @param int            $new_revision  The revision the commit created.
+	 */
+	private function record_committed_changes( SvnWorkingCopy $working_copy, $operations, $new_revision ) {
+		foreach ( $operations as $operation ) {
+			$relative_path = $operation['path'];
+			switch ( $operation['op'] ) {
+				case 'add-directory':
+					$entry = $working_copy->get_entry( $relative_path );
+					unset( $entry['schedule'] );
+					$entry['revision'] = $new_revision;
+					$working_copy->set_entry( $relative_path, $entry );
+					break;
+
+				case 'add-file':
+				case 'modify-file':
+					$entry = $working_copy->get_entry( $relative_path );
+					unset( $entry['schedule'] );
+					$entry['revision'] = $new_revision;
+					$entry['checksum'] = $working_copy->store_pristine( $operation['contents'] );
+					$working_copy->set_entry( $relative_path, $entry );
+					break;
+
+				case 'delete':
+					$working_copy->remove_entry( $relative_path );
+					foreach ( $working_copy->get_entry_paths_under( $relative_path ) as $child_path ) {
+						$working_copy->remove_entry( $child_path );
+					}
+					break;
+			}
+		}
+		$working_copy->save();
+	}
+}

--- a/components/Svn/class-svndiff.php
+++ b/components/Svn/class-svndiff.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace WordPress\Svn;
+
+/**
+ * Encodes full-text data as svndiff0 deltas.
+ *
+ * Subversion exchanges file contents as binary deltas in the "svndiff"
+ * format. When the entire file is sent (as opposed to a delta against
+ * an earlier version), the delta consists of windows that only use
+ * "copy from new data" instructions.
+ *
+ * See the streaming decoder in SvnDiffApplier for the format details.
+ */
+class SvnDiff {
+	const HEADER_V0 = "SVN\x00";
+
+	/**
+	 * Maximum number of target bytes encoded in a single svndiff window.
+	 *
+	 * 100 KB mirrors SVN_DELTA_WINDOW_SIZE in Subversion itself.
+	 */
+	const WINDOW_SIZE = 102400;
+
+	/**
+	 * Encodes a string as a self-contained svndiff0 document that ignores
+	 * the source text entirely – every window emits raw "new data".
+	 *
+	 * @param  string $contents  The full text to encode.
+	 * @return string The svndiff0 representation of $contents.
+	 */
+	public static function encode_fulltext( $contents ) {
+		$svndiff = self::HEADER_V0;
+		$offset  = 0;
+		$length  = strlen( $contents );
+		do {
+			$chunk    = substr( $contents, $offset, self::WINDOW_SIZE );
+			$svndiff .= self::encode_fulltext_window( $chunk );
+			$offset  += strlen( $chunk );
+		} while ( $offset < $length );
+
+		return $svndiff;
+	}
+
+	/**
+	 * Encodes a single svndiff0 window holding raw new data.
+	 *
+	 * @param  string $chunk  Up to WINDOW_SIZE bytes of target data.
+	 * @return string The encoded window.
+	 */
+	private static function encode_fulltext_window( $chunk ) {
+		$chunk_length = strlen( $chunk );
+		$instruction  = self::encode_copy_from_new_data_instruction( $chunk_length );
+
+		return self::encode_varint( 0 ) . // Source view offset.
+			self::encode_varint( 0 ) . // Source view length.
+			self::encode_varint( $chunk_length ) . // Target view length.
+			self::encode_varint( strlen( $instruction ) ) . // Instructions length.
+			self::encode_varint( $chunk_length ) . // New data length.
+			$instruction .
+			$chunk;
+	}
+
+	/**
+	 * Encodes a "copy from new data" instruction.
+	 *
+	 * The first byte holds the opcode in its two high bits (0b10 for
+	 * new data) and the length in the low six bits. A length of zero
+	 * means the real length follows as a varint.
+	 *
+	 * @param  int $length  Number of new data bytes the instruction covers.
+	 * @return string The encoded instruction.
+	 */
+	private static function encode_copy_from_new_data_instruction( $length ) {
+		if ( $length > 0 && $length < 64 ) {
+			return chr( 0x80 | $length );
+		}
+
+		return chr( 0x80 ) . self::encode_varint( $length );
+	}
+
+	/**
+	 * Encodes a non-negative integer in the variable-length format used
+	 * throughout svndiff: base-128, most significant group first, with
+	 * the high bit set on every byte except the last one.
+	 *
+	 * @param  int $number  The non-negative integer to encode.
+	 * @return string The encoded varint.
+	 */
+	public static function encode_varint( $number ) {
+		$bytes    = chr( $number & 0x7f );
+		$number >>= 7;
+		while ( $number > 0 ) {
+			$bytes    = chr( 0x80 | ( $number & 0x7f ) ) . $bytes;
+			$number >>= 7;
+		}
+
+		return $bytes;
+	}
+}

--- a/components/Svn/class-svndiffapplier.php
+++ b/components/Svn/class-svndiffapplier.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace WordPress\Svn;
+
+/**
+ * Streaming svndiff decoder.
+ *
+ * Applies an svndiff document to a source text and produces the target
+ * text. svndiff bytes can be appended in arbitrarily small chunks – the
+ * applier buffers data until a complete window is available, applies it,
+ * and discards it. This is how both the svn:// protocol and mod_dav_svn
+ * deliver file contents during checkouts and updates.
+ *
+ * The svndiff format, in short:
+ *
+ *     "SVN" <version byte> <window>*
+ *
+ * Each window is five varints – source view offset, source view length,
+ * target view length, instructions length, new data length – followed by
+ * the instructions section and the new data section. Instructions are:
+ *
+ *     0b00 – copy <length> bytes from the source view (offset varint follows)
+ *     0b01 – copy <length> bytes from the target view (offset varint follows,
+ *            may overlap the bytes being produced, like memmove cannot)
+ *     0b10 – copy <length> bytes from the new data section
+ *
+ * The opcode lives in the two high bits of the first instruction byte and
+ * the length in the low six bits; a zero length means a varint with the
+ * real length follows.
+ *
+ * In svndiff1 (version byte 0x01) the instructions and new data sections
+ * each start with a varint holding the uncompressed length. If that length
+ * differs from the remaining section length, the section is zlib-compressed.
+ */
+class SvnDiffApplier {
+	/**
+	 * The source text new windows may copy from. Empty for plain
+	 * full-text transmissions such as a fresh checkout.
+	 *
+	 * @var string
+	 */
+	private $source;
+
+	/**
+	 * Undecoded svndiff bytes received so far.
+	 *
+	 * @var string
+	 */
+	private $buffer = '';
+
+	/**
+	 * Format version parsed from the header, or null before the
+	 * header was seen. Versions 0 and 1 are supported.
+	 *
+	 * @var int|null
+	 */
+	private $version;
+
+	/**
+	 * Target bytes produced so far across all windows.
+	 *
+	 * @var string
+	 */
+	private $target = '';
+
+	/**
+	 * @param string $source  The source text the delta applies to. Use an
+	 *                        empty string when the server sends full texts.
+	 */
+	public function __construct( $source = '' ) {
+		$this->source = $source;
+	}
+
+	/**
+	 * Feeds more svndiff bytes into the applier and applies every window
+	 * that became complete.
+	 *
+	 * @param  string $bytes  The next chunk of the svndiff document.
+	 * @throws SvnException When the document is malformed or uses an unsupported version.
+	 */
+	public function append_bytes( $bytes ) {
+		$this->buffer .= $bytes;
+
+		if ( null === $this->version ) {
+			if ( strlen( $this->buffer ) < 4 ) {
+				return;
+			}
+			if ( 'SVN' !== substr( $this->buffer, 0, 3 ) ) {
+				throw new SvnException( 'Malformed svndiff data: bad header.' );
+			}
+			$this->version = ord( $this->buffer[3] );
+			if ( 0 !== $this->version && 1 !== $this->version ) {
+				throw new SvnException( "Unsupported svndiff version {$this->version}. Only svndiff0 and svndiff1 are supported." );
+			}
+			$this->buffer = substr( $this->buffer, 4 );
+		}
+
+		while ( $this->apply_next_window() ) {
+			continue;
+		}
+	}
+
+	/**
+	 * Returns the target text produced so far.
+	 *
+	 * @return string
+	 */
+	public function get_target() {
+		return $this->target;
+	}
+
+	/**
+	 * Returns the produced target text and forgets it so that long
+	 * streams can be consumed with bounded memory.
+	 *
+	 * @return string
+	 */
+	public function flush_target() {
+		$flushed      = $this->target;
+		$this->target = '';
+
+		return $flushed;
+	}
+
+	/**
+	 * Signals the end of the svndiff document.
+	 *
+	 * @throws SvnException When unconsumed bytes remain – this indicates truncated input.
+	 */
+	public function finish() {
+		if ( '' !== $this->buffer ) {
+			throw new SvnException( 'Malformed svndiff data: trailing or truncated window data.' );
+		}
+	}
+
+	/**
+	 * Tries to decode and apply the next window from the buffer.
+	 *
+	 * @return bool Whether a complete window was applied.
+	 * @throws SvnException When the window data is malformed.
+	 */
+	private function apply_next_window() {
+		if ( '' === $this->buffer ) {
+			return false;
+		}
+
+		$pos                = 0;
+		$source_view_offset = $this->parse_varint( $pos );
+		$source_view_length = $this->parse_varint( $pos );
+		$target_view_length = $this->parse_varint( $pos );
+		$instructions_size  = $this->parse_varint( $pos );
+		$new_data_size      = $this->parse_varint( $pos );
+		if ( null === $source_view_offset || null === $source_view_length || null === $target_view_length || null === $instructions_size || null === $new_data_size ) {
+			// The window header is not complete yet.
+			return false;
+		}
+
+		if ( strlen( $this->buffer ) - $pos < $instructions_size + $new_data_size ) {
+			// The window body is not complete yet.
+			return false;
+		}
+
+		$instructions = substr( $this->buffer, $pos, $instructions_size );
+		$new_data     = substr( $this->buffer, $pos + $instructions_size, $new_data_size );
+		$this->buffer = substr( $this->buffer, $pos + $instructions_size + $new_data_size );
+
+		if ( 1 === $this->version ) {
+			$instructions = $this->inflate_section( $instructions );
+			$new_data     = $this->inflate_section( $new_data );
+		}
+
+		$source_view   = substr( $this->source, $source_view_offset, $source_view_length );
+		$this->target .= $this->apply_window( $instructions, $new_data, $source_view, $target_view_length );
+
+		return true;
+	}
+
+	/**
+	 * Decompresses an svndiff1 section.
+	 *
+	 * Sections start with a varint holding the uncompressed length.
+	 * When it equals the remaining length the data is stored as-is,
+	 * otherwise it is zlib-compressed.
+	 *
+	 * @param  string $section  The raw section bytes.
+	 * @return string The decompressed section data.
+	 * @throws SvnException When the compressed data is malformed.
+	 */
+	private function inflate_section( $section ) {
+		$pos    = 0;
+		$length = self::parse_varint_from( $section, $pos );
+		if ( null === $length ) {
+			throw new SvnException( 'Malformed svndiff1 section header.' );
+		}
+		$data = substr( $section, $pos );
+		if ( strlen( $data ) === $length ) {
+			return $data;
+		}
+		if ( ! function_exists( 'zlib_decode' ) ) {
+			throw new SvnException( 'The server sent zlib-compressed svndiff1 data but the zlib extension is not available.' );
+		}
+		$inflated = zlib_decode( $data );
+		if ( false === $inflated || strlen( $inflated ) !== $length ) {
+			throw new SvnException( 'Malformed svndiff1 section: zlib decompression failed.' );
+		}
+
+		return $inflated;
+	}
+
+	/**
+	 * Executes the instructions of a single window.
+	 *
+	 * @param  string $instructions        The decoded instructions section.
+	 * @param  string $new_data            The decoded new data section.
+	 * @param  string $source_view         The slice of the source text this window may copy from.
+	 * @param  int    $target_view_length  The expected size of the produced data.
+	 * @return string The produced target view.
+	 * @throws SvnException When the instructions are malformed.
+	 */
+	private function apply_window( $instructions, $new_data, $source_view, $target_view_length ) {
+		$target_view  = '';
+		$new_data_pos = 0;
+		$pos          = 0;
+		$length       = strlen( $instructions );
+		while ( $pos < $length ) {
+			$first_byte  = ord( $instructions[ $pos ] );
+			$opcode      = ( $first_byte >> 6 ) & 0x3;
+			$copy_length = $first_byte & 0x3f;
+			++$pos;
+			if ( 0 === $copy_length ) {
+				$copy_length = self::parse_varint_from( $instructions, $pos );
+			}
+			if ( null === $copy_length ) {
+				throw new SvnException( 'Malformed svndiff window: truncated instruction length.' );
+			}
+
+			switch ( $opcode ) {
+				case 0:
+					// Copy from the source view.
+					$offset = self::parse_varint_from( $instructions, $pos );
+					if ( null === $offset || $offset + $copy_length > strlen( $source_view ) ) {
+						throw new SvnException( 'Malformed svndiff window: source copy out of bounds.' );
+					}
+					$target_view .= substr( $source_view, $offset, $copy_length );
+					break;
+
+				case 1:
+					// Copy from the target view. The copied range is allowed to
+					// overlap the bytes being produced – a run like "offset 0,
+					// length 100" over a 1-byte target repeats that byte 100
+					// times – so copy in progressively doubling chunks instead
+					// of a single substr().
+					$offset = self::parse_varint_from( $instructions, $pos );
+					if ( null === $offset || $offset >= strlen( $target_view ) ) {
+						throw new SvnException( 'Malformed svndiff window: target copy out of bounds.' );
+					}
+					$available = strlen( $target_view ) - $offset;
+					while ( $copy_length > 0 ) {
+						$step         = min( $copy_length, $available );
+						$target_view .= substr( $target_view, $offset, $step );
+						$copy_length -= $step;
+						$available   += $step;
+					}
+					break;
+
+				case 2:
+					// Copy from the new data section.
+					if ( $new_data_pos + $copy_length > strlen( $new_data ) ) {
+						throw new SvnException( 'Malformed svndiff window: new data copy out of bounds.' );
+					}
+					$target_view  .= substr( $new_data, $new_data_pos, $copy_length );
+					$new_data_pos += $copy_length;
+					break;
+
+				default:
+					throw new SvnException( 'Malformed svndiff window: invalid instruction opcode.' );
+			}
+		}
+
+		if ( strlen( $target_view ) !== $target_view_length ) {
+			throw new SvnException(
+				sprintf(
+					'Malformed svndiff window: produced %d bytes, expected %d.',
+					strlen( $target_view ),
+					$target_view_length
+				)
+			);
+		}
+
+		return $target_view;
+	}
+
+	/**
+	 * Parses a varint from the internal buffer.
+	 *
+	 * @param  int $pos  Byte offset to parse at; advanced past the varint on success.
+	 * @return int|null The parsed integer, or null when the buffer ends mid-varint.
+	 */
+	private function parse_varint( &$pos ) {
+		return self::parse_varint_from( $this->buffer, $pos );
+	}
+
+	/**
+	 * Parses a base-128 varint with continuation bits.
+	 *
+	 * @param  string $bytes  The string to parse from.
+	 * @param  int    $pos    Byte offset to parse at; advanced past the varint on success.
+	 * @return int|null The parsed integer, or null when the string ends mid-varint.
+	 */
+	public static function parse_varint_from( $bytes, &$pos ) {
+		$value  = 0;
+		$length = strlen( $bytes );
+		for ( $i = $pos; $i < $length; $i++ ) {
+			$byte  = ord( $bytes[ $i ] );
+			$value = ( $value << 7 ) | ( $byte & 0x7f );
+			if ( 0 === ( $byte & 0x80 ) ) {
+				$pos = $i + 1;
+
+				return $value;
+			}
+		}
+
+		return null;
+	}
+}

--- a/components/Svn/class-svnexception.php
+++ b/components/Svn/class-svnexception.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace WordPress\Svn;
+
+use Exception;
+
+class SvnException extends Exception {
+
+}

--- a/components/Svn/class-svnworkingcopy.php
+++ b/components/Svn/class-svnworkingcopy.php
@@ -1,0 +1,491 @@
+<?php
+
+namespace WordPress\Svn;
+
+use WordPress\Filesystem\Filesystem;
+
+/**
+ * A Subversion working copy: a directory tree on a filesystem plus the
+ * `.svn` administrative area that tracks where it came from.
+ *
+ * The administrative format is specific to this component – it is NOT
+ * compatible with the SQLite-based `.svn` format the official client
+ * uses, in either direction. Metadata lives in `.svn/wc.json` and
+ * pristine (as-checked-out) file contents live in `.svn/pristine/`,
+ * keyed by their MD5 checksum.
+ *
+ * Pristine copies are what make offline `status` and conflict detection
+ * possible: a file is locally modified when its content differs from
+ * its pristine copy.
+ *
+ * Entries are keyed by forward-slash paths relative to the working copy
+ * root; the root directory itself is the entry with the key ''.
+ */
+class SvnWorkingCopy {
+	const ADMIN_DIR = '.svn';
+	const FORMAT    = 1;
+
+	/**
+	 * Working copies of svn:externals are nested inside their parent
+	 * working copy. Limit how deep externals may nest to break cycles
+	 * where repositories reference each other.
+	 */
+	const MAX_EXTERNALS_DEPTH = 5;
+
+	/**
+	 * @var Filesystem
+	 */
+	private $filesystem;
+
+	/**
+	 * Absolute path of the working copy root within $filesystem.
+	 *
+	 * @var string
+	 */
+	private $root;
+
+	/**
+	 * Decoded wc.json contents.
+	 *
+	 * @var array
+	 */
+	private $data;
+
+	private function __construct( Filesystem $filesystem, $root, $data ) {
+		$this->filesystem = $filesystem;
+		$this->root       = rtrim( $root, '/' );
+		$this->data       = $data;
+	}
+
+	/**
+	 * Creates a fresh administrative area for a new checkout.
+	 *
+	 * @param  Filesystem $filesystem  The filesystem to check out onto.
+	 * @param  string     $root        Absolute path of the working copy root.
+	 * @param  array      $info        {
+	 *     @type string $url              The checked-out URL.
+	 *     @type string $repository_root  The repository root URL.
+	 *     @type string $uuid             The repository UUID.
+	 *     @type int    $revision         The checked-out revision.
+	 *     @type string $depth            The checkout depth.
+	 * }
+	 * @return SvnWorkingCopy
+	 */
+	public static function initialize( Filesystem $filesystem, $root, $info ) {
+		$data = array(
+			'format'          => self::FORMAT,
+			'url'             => rtrim( $info['url'], '/' ),
+			'repository_root' => rtrim( $info['repository_root'], '/' ),
+			'uuid'            => $info['uuid'],
+			'revision'        => $info['revision'],
+			'depth'           => isset( $info['depth'] ) ? $info['depth'] : 'infinity',
+			'entries'         => array(
+				'' => array(
+					'kind'     => 'dir',
+					'revision' => $info['revision'],
+				),
+			),
+			'externals'       => array(),
+		);
+
+		$working_copy = new SvnWorkingCopy( $filesystem, $root, $data );
+		$filesystem->mkdir( $working_copy->get_admin_path( 'pristine' ), array( 'recursive' => true ) );
+		$working_copy->save();
+
+		return $working_copy;
+	}
+
+	/**
+	 * Opens an existing working copy.
+	 *
+	 * @param  Filesystem $filesystem  The filesystem holding the working copy.
+	 * @param  string     $root        Absolute path of the working copy root.
+	 * @return SvnWorkingCopy
+	 * @throws SvnException When $root is not a working copy created by this component.
+	 */
+	public static function open( Filesystem $filesystem, $root ) {
+		$root      = rtrim( $root, '/' );
+		$json_path = $root . '/' . self::ADMIN_DIR . '/wc.json';
+		if ( ! $filesystem->is_file( $json_path ) ) {
+			throw new SvnException( "'{$root}' is not a php-toolkit Subversion working copy (no .svn/wc.json found)." );
+		}
+		$data = json_decode( $filesystem->get_contents( $json_path ), true );
+		if ( ! is_array( $data ) || ! isset( $data['format'] ) ) {
+			throw new SvnException( "The working copy metadata at '{$json_path}' is corrupted." );
+		}
+		if ( self::FORMAT !== $data['format'] ) {
+			throw new SvnException( "Unsupported working copy format {$data['format']}." );
+		}
+
+		return new SvnWorkingCopy( $filesystem, $root, $data );
+	}
+
+	/**
+	 * @param  Filesystem $filesystem  The filesystem to inspect.
+	 * @param  string     $root        The path to inspect.
+	 * @return bool Whether the path is a working copy created by this component.
+	 */
+	public static function is_working_copy( Filesystem $filesystem, $root ) {
+		return $filesystem->is_file( rtrim( $root, '/' ) . '/' . self::ADMIN_DIR . '/wc.json' );
+	}
+
+	/**
+	 * Persists the metadata to .svn/wc.json.
+	 */
+	public function save() {
+		$this->filesystem->put_contents(
+			$this->get_admin_path( 'wc.json' ),
+			json_encode( $this->data )
+		);
+	}
+
+	public function get_filesystem() {
+		return $this->filesystem;
+	}
+
+	public function get_root() {
+		return $this->root;
+	}
+
+	public function get_url() {
+		return $this->data['url'];
+	}
+
+	public function get_repository_root() {
+		return $this->data['repository_root'];
+	}
+
+	public function get_uuid() {
+		return $this->data['uuid'];
+	}
+
+	public function get_revision() {
+		return $this->data['revision'];
+	}
+
+	public function set_revision( $revision ) {
+		$this->data['revision'] = $revision;
+	}
+
+	public function get_depth() {
+		return isset( $this->data['depth'] ) ? $this->data['depth'] : 'infinity';
+	}
+
+	/**
+	 * @return array Map of external target path (relative to the working
+	 *               copy root) => array{url, revision}.
+	 */
+	public function get_externals() {
+		return isset( $this->data['externals'] ) ? $this->data['externals'] : array();
+	}
+
+	public function set_externals( $externals ) {
+		$this->data['externals'] = $externals;
+	}
+
+	/**
+	 * @param  string $path  Entry path relative to the root, '' for the root itself.
+	 * @return array|null The entry, or null when the path is not versioned.
+	 */
+	public function get_entry( $path ) {
+		return isset( $this->data['entries'][ $path ] ) ? $this->data['entries'][ $path ] : null;
+	}
+
+	public function set_entry( $path, $entry ) {
+		$this->data['entries'][ $path ] = $entry;
+	}
+
+	public function remove_entry( $path ) {
+		unset( $this->data['entries'][ $path ] );
+	}
+
+	/**
+	 * @return array All entries, keyed by relative path.
+	 */
+	public function get_entries() {
+		return $this->data['entries'];
+	}
+
+	/**
+	 * @param  string $path  Directory entry path, '' for the root.
+	 * @return string[] Paths of all entries strictly below $path.
+	 */
+	public function get_entry_paths_under( $path ) {
+		$prefix = '' === $path ? '' : $path . '/';
+		$found  = array();
+		foreach ( $this->data['entries'] as $entry_path => $entry ) {
+			if ( '' !== $entry_path && ( '' === $prefix || 0 === strpos( $entry_path, $prefix ) ) ) {
+				$found[] = $entry_path;
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * @param  string $relative_path  Path relative to the working copy root.
+	 * @return string The absolute path within the filesystem.
+	 */
+	public function get_disk_path( $relative_path ) {
+		return '' === $relative_path ? $this->root : $this->root . '/' . $relative_path;
+	}
+
+	/**
+	 * @param  string $name  A file name inside the administrative area.
+	 * @return string The absolute path within the filesystem.
+	 */
+	public function get_admin_path( $name ) {
+		return $this->root . '/' . self::ADMIN_DIR . '/' . $name;
+	}
+
+	/**
+	 * Stores pristine file contents, keyed by checksum.
+	 *
+	 * @param  string $contents  Repository-normal-form contents.
+	 * @return string The MD5 checksum the contents are stored under.
+	 */
+	public function store_pristine( $contents ) {
+		$checksum = md5( $contents );
+		$path     = $this->get_admin_path( 'pristine/' . $checksum );
+		if ( ! $this->filesystem->is_file( $path ) ) {
+			$this->filesystem->put_contents( $path, $contents );
+		}
+
+		return $checksum;
+	}
+
+	/**
+	 * @param  string $checksum  The MD5 checksum returned by store_pristine().
+	 * @return string The pristine contents.
+	 * @throws SvnException When no pristine with this checksum exists.
+	 */
+	public function read_pristine( $checksum ) {
+		$path = $this->get_admin_path( 'pristine/' . $checksum );
+		if ( ! $this->filesystem->is_file( $path ) ) {
+			throw new SvnException( "The working copy is corrupted: missing pristine {$checksum}." );
+		}
+
+		return $this->filesystem->get_contents( $path );
+	}
+
+	/**
+	 * Reads a working file and converts it back to repository normal
+	 * form so it can be compared against pristines and committed.
+	 *
+	 * @param  string $path   Entry path relative to the root.
+	 * @param  array  $entry  The entry, used for its properties.
+	 * @return string The file contents in repository normal form.
+	 */
+	public function read_working_file( $path, $entry ) {
+		$contents = $this->filesystem->get_contents( $this->get_disk_path( $path ) );
+
+		return self::translate_from_disk( $contents, isset( $entry['props'] ) ? $entry['props'] : array() );
+	}
+
+	/**
+	 * Writes repository-normal-form contents to a working file, applying
+	 * the svn:eol-style translation the properties ask for.
+	 *
+	 * @param string $path        Entry path relative to the root.
+	 * @param string $contents    Repository-normal-form contents.
+	 * @param array  $properties  The file's versioned properties.
+	 */
+	public function write_working_file( $path, $contents, $properties ) {
+		$this->filesystem->put_contents(
+			$this->get_disk_path( $path ),
+			self::translate_to_disk( $contents, $properties )
+		);
+	}
+
+	/**
+	 * Checks whether a working file differs from its pristine copy.
+	 *
+	 * @param  string $path   Entry path relative to the root.
+	 * @param  array  $entry  The file's entry.
+	 * @return bool Whether the file is locally modified.
+	 */
+	public function is_file_modified( $path, $entry ) {
+		if ( ! isset( $entry['checksum'] ) ) {
+			return true;
+		}
+		if ( ! $this->filesystem->is_file( $this->get_disk_path( $path ) ) ) {
+			return false;
+		}
+
+		$working = $this->read_working_file( $path, $entry );
+		if ( md5( $working ) === $entry['checksum'] ) {
+			return false;
+		}
+		if ( ! isset( $entry['props']['svn:eol-style'] ) ) {
+			return true;
+		}
+
+		// The pristine of an eol-styled file may use line endings that
+		// differ from the style's canonical ones (e.g. a 'native' file
+		// committed with CRLF by a non-translating client). Compare the
+		// normalized forms before declaring the file modified – a plain
+		// checkout must never look locally modified.
+		$properties = isset( $entry['props'] ) ? $entry['props'] : array();
+
+		return self::translate_from_disk( $this->read_pristine( $entry['checksum'] ), $properties ) !== $working;
+	}
+
+	/**
+	 * Computes the status of every entry and unversioned path.
+	 *
+	 * Externals are reported with the status 'external' and their
+	 * contents are not descended into – they are independent working
+	 * copies. Unmodified entries are not reported at all.
+	 *
+	 * @return array Map of relative path => one of 'modified', 'added',
+	 *               'deleted', 'missing', 'conflicted', 'unversioned',
+	 *               'external', 'obstructed'.
+	 */
+	public function get_status() {
+		$status    = array();
+		$externals = $this->get_externals();
+
+		foreach ( $this->data['entries'] as $path => $entry ) {
+			if ( '' === $path ) {
+				continue;
+			}
+			$schedule = isset( $entry['schedule'] ) ? $entry['schedule'] : null;
+			if ( 'add' === $schedule ) {
+				$status[ $path ] = 'added';
+				continue;
+			}
+			if ( 'delete' === $schedule ) {
+				$status[ $path ] = 'deleted';
+				continue;
+			}
+			if ( ! empty( $entry['conflict'] ) ) {
+				$status[ $path ] = 'conflicted';
+				continue;
+			}
+			$disk_path = $this->get_disk_path( $path );
+			if ( 'dir' === $entry['kind'] ) {
+				if ( ! $this->filesystem->is_dir( $disk_path ) ) {
+					$status[ $path ] = $this->filesystem->is_file( $disk_path ) ? 'obstructed' : 'missing';
+				}
+				continue;
+			}
+			if ( ! $this->filesystem->is_file( $disk_path ) ) {
+				$status[ $path ] = $this->filesystem->is_dir( $disk_path ) ? 'obstructed' : 'missing';
+				continue;
+			}
+			if ( $this->is_file_modified( $path, $entry ) ) {
+				$status[ $path ] = 'modified';
+			}
+		}
+
+		foreach ( $externals as $external_path => $external ) {
+			$status[ $external_path ] = 'external';
+		}
+
+		// Conflict artifacts (the `<name>.r<revision>` files) are part of
+		// the conflict bookkeeping, not unversioned files.
+		$conflict_files = array();
+		foreach ( $this->data['entries'] as $entry ) {
+			if ( isset( $entry['conflict_file'] ) ) {
+				$conflict_files[ $entry['conflict_file'] ] = true;
+			}
+		}
+
+		$this->collect_unversioned( '', $status, $externals, $conflict_files );
+		ksort( $status );
+
+		return $status;
+	}
+
+	/**
+	 * Recursively finds paths on disk that have no entry.
+	 *
+	 * @param string $directory_path  Directory to walk, relative to the root.
+	 * @param array  $status          Status map to add findings to.
+	 * @param array  $externals       External definitions to skip over.
+	 * @param array  $conflict_files  Conflict artifact paths to skip over.
+	 */
+	private function collect_unversioned( $directory_path, &$status, $externals, $conflict_files ) {
+		$disk_path = $this->get_disk_path( $directory_path );
+		if ( ! $this->filesystem->is_dir( $disk_path ) ) {
+			return;
+		}
+		foreach ( $this->filesystem->ls( $disk_path ) as $name ) {
+			if ( self::ADMIN_DIR === $name ) {
+				continue;
+			}
+			$child_path = '' === $directory_path ? $name : $directory_path . '/' . $name;
+			if ( isset( $externals[ $child_path ] ) || isset( $conflict_files[ $child_path ] ) ) {
+				continue;
+			}
+			$entry = $this->get_entry( $child_path );
+			if ( null === $entry ) {
+				if ( ! isset( $status[ $child_path ] ) ) {
+					$status[ $child_path ] = 'unversioned';
+				}
+				continue;
+			}
+			if ( 'dir' === $entry['kind'] ) {
+				$this->collect_unversioned( $child_path, $status, $externals, $conflict_files );
+			}
+		}
+	}
+
+	/**
+	 * Applies svn:eol-style translation for writing a file to disk.
+	 *
+	 * For the fixed styles (CRLF, CR, LF) Subversion stores the file in
+	 * the repository with exactly that line ending, so checked-out files
+	 * normally pass through unchanged – the translation only repairs
+	 * files whose endings drifted. 'native' files are stored with LF and
+	 * this component uses LF as the native line ending on every
+	 * platform, mirroring its forward-slashes-everywhere policy.
+	 *
+	 * @param  string $contents    Repository contents.
+	 * @param  array  $properties  The file's versioned properties.
+	 * @return string The translated contents.
+	 */
+	public static function translate_to_disk( $contents, $properties ) {
+		return self::normalize_eol( $contents, $properties );
+	}
+
+	/**
+	 * Normalizes a working file for comparing against pristines and for
+	 * committing. The mapping is the same as translate_to_disk(): both
+	 * the working file and the repository use the style's line ending,
+	 * so editing a CRLF file with an LF-only editor does not produce a
+	 * whole-file diff.
+	 *
+	 * @param  string $contents    On-disk contents.
+	 * @param  array  $properties  The file's versioned properties.
+	 * @return string The contents in their canonical form.
+	 */
+	public static function translate_from_disk( $contents, $properties ) {
+		return self::normalize_eol( $contents, $properties );
+	}
+
+	/**
+	 * Converts all line endings to the canonical ending of the file's
+	 * svn:eol-style. Files without the property are returned untouched.
+	 *
+	 * @param  string $contents    The file contents.
+	 * @param  array  $properties  The file's versioned properties.
+	 * @return string The normalized contents.
+	 */
+	private static function normalize_eol( $contents, $properties ) {
+		if ( ! isset( $properties['svn:eol-style'] ) ) {
+			return $contents;
+		}
+		switch ( trim( $properties['svn:eol-style'] ) ) {
+			case 'CRLF':
+				return preg_replace( "/\r\n|\r|\n/", "\r\n", $contents );
+			case 'CR':
+				return preg_replace( "/\r\n|\r|\n/", "\r", $contents );
+			case 'LF':
+			case 'native':
+				return preg_replace( "/\r\n|\r|\n/", "\n", $contents );
+			default:
+				return $contents;
+		}
+	}
+}

--- a/components/Svn/class-svnworkingcopy.php
+++ b/components/Svn/class-svnworkingcopy.php
@@ -176,11 +176,20 @@ class SvnWorkingCopy {
 	 *               copy root) => array{url, revision}.
 	 */
 	public function get_externals() {
-		return isset( $this->data['externals'] ) ? $this->data['externals'] : array();
+		$externals = array();
+		foreach ( isset( $this->data['externals'] ) ? $this->data['externals'] : array() as $path => $external ) {
+			$externals[ svn_normalize_relative_path( $path, false ) ] = $external;
+		}
+
+		return $externals;
 	}
 
 	public function set_externals( $externals ) {
-		$this->data['externals'] = $externals;
+		$normalized = array();
+		foreach ( $externals as $path => $external ) {
+			$normalized[ svn_normalize_relative_path( $path, false ) ] = $external;
+		}
+		$this->data['externals'] = $normalized;
 	}
 
 	/**
@@ -188,14 +197,19 @@ class SvnWorkingCopy {
 	 * @return array|null The entry, or null when the path is not versioned.
 	 */
 	public function get_entry( $path ) {
+		$path = svn_normalize_relative_path( $path );
+
 		return isset( $this->data['entries'][ $path ] ) ? $this->data['entries'][ $path ] : null;
 	}
 
 	public function set_entry( $path, $entry ) {
+		$path = svn_normalize_relative_path( $path );
+
 		$this->data['entries'][ $path ] = $entry;
 	}
 
 	public function remove_entry( $path ) {
+		$path = svn_normalize_relative_path( $path );
 		unset( $this->data['entries'][ $path ] );
 	}
 
@@ -203,7 +217,12 @@ class SvnWorkingCopy {
 	 * @return array All entries, keyed by relative path.
 	 */
 	public function get_entries() {
-		return $this->data['entries'];
+		$entries = array();
+		foreach ( $this->data['entries'] as $path => $entry ) {
+			$entries[ svn_normalize_relative_path( $path ) ] = $entry;
+		}
+
+		return $entries;
 	}
 
 	/**
@@ -211,9 +230,10 @@ class SvnWorkingCopy {
 	 * @return string[] Paths of all entries strictly below $path.
 	 */
 	public function get_entry_paths_under( $path ) {
+		$path   = svn_normalize_relative_path( $path );
 		$prefix = '' === $path ? '' : $path . '/';
 		$found  = array();
-		foreach ( $this->data['entries'] as $entry_path => $entry ) {
+		foreach ( $this->get_entries() as $entry_path => $entry ) {
 			if ( '' !== $entry_path && ( '' === $prefix || 0 === strpos( $entry_path, $prefix ) ) ) {
 				$found[] = $entry_path;
 			}
@@ -227,6 +247,8 @@ class SvnWorkingCopy {
 	 * @return string The absolute path within the filesystem.
 	 */
 	public function get_disk_path( $relative_path ) {
+		$relative_path = svn_normalize_relative_path( $relative_path );
+
 		return '' === $relative_path ? $this->root : $this->root . '/' . $relative_path;
 	}
 
@@ -385,7 +407,7 @@ class SvnWorkingCopy {
 		// Conflict artifacts (the `<name>.r<revision>` files) are part of
 		// the conflict bookkeeping, not unversioned files.
 		$conflict_files = array();
-		foreach ( $this->data['entries'] as $entry ) {
+		foreach ( $this->get_entries() as $entry ) {
 			if ( isset( $entry['conflict_file'] ) ) {
 				$conflict_files[ $entry['conflict_file'] ] = true;
 			}

--- a/components/Svn/class-workingcopyeditor.php
+++ b/components/Svn/class-workingcopyeditor.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace WordPress\Svn;
+
+/**
+ * Applies a server-driven tree delta to a working copy.
+ *
+ * This editor backs both checkouts (the server sends the whole tree)
+ * and updates (the server sends only what changed since the reported
+ * revision). Incoming file contents are svndiff deltas against the
+ * pristine copy, applied with SvnDiffApplier.
+ *
+ * Local modifications are preserved:
+ *
+ *  - When the incoming content equals the locally modified content,
+ *    the file is left alone and simply stops being "modified".
+ *  - Otherwise the local file is kept as-is, the incoming content is
+ *    written next to it as `<name>.r<revision>`, and the entry is
+ *    marked conflicted. Conflicted files refuse to commit until
+ *    SvnClient::resolved() is called.
+ *  - Locally modified files deleted on the server are kept on disk as
+ *    unversioned files.
+ */
+class WorkingCopyEditor implements SvnEditor {
+	/**
+	 * @var SvnWorkingCopy
+	 */
+	private $working_copy;
+
+	/**
+	 * @var int|null
+	 */
+	private $target_revision;
+
+	/**
+	 * In-flight file transmissions, path => state array.
+	 *
+	 * @var array
+	 */
+	private $file_states = array();
+
+	/**
+	 * Outcome of the drive: lists of relative paths keyed by what
+	 * happened to them.
+	 *
+	 * @var array
+	 */
+	private $result = array(
+		'added'      => array(),
+		'updated'    => array(),
+		'deleted'    => array(),
+		'conflicted' => array(),
+		'skipped'    => array(),
+	);
+
+	public function __construct( SvnWorkingCopy $working_copy ) {
+		$this->working_copy = $working_copy;
+	}
+
+	/**
+	 * @return array See $result.
+	 */
+	public function get_result() {
+		return $this->result;
+	}
+
+	public function set_target_revision( $revision ) {
+		$this->target_revision = $revision;
+	}
+
+	public function open_root() {
+		$filesystem = $this->working_copy->get_filesystem();
+		if ( ! $filesystem->is_dir( $this->working_copy->get_root() ) ) {
+			$filesystem->mkdir( $this->working_copy->get_root(), array( 'recursive' => true ) );
+		}
+	}
+
+	public function add_directory( $path ) {
+		$filesystem = $this->working_copy->get_filesystem();
+		$disk_path  = $this->working_copy->get_disk_path( $path );
+		if ( $filesystem->is_file( $disk_path ) ) {
+			throw new SvnException( "Cannot create directory '{$path}': an unversioned file is in the way." );
+		}
+		if ( ! $filesystem->is_dir( $disk_path ) ) {
+			$filesystem->mkdir( $disk_path, array( 'recursive' => true ) );
+		}
+		$this->working_copy->set_entry(
+			$path,
+			array(
+				'kind'     => 'dir',
+				'revision' => $this->target_revision,
+			)
+		);
+		$this->result['added'][] = $path;
+	}
+
+	public function open_directory( $path ) {
+		// Nothing to do – changes arrive through dedicated calls.
+	}
+
+	public function change_directory_property( $path, $name, $value ) {
+		$entry = $this->working_copy->get_entry( $path );
+		if ( null === $entry ) {
+			return;
+		}
+		$properties = isset( $entry['props'] ) ? $entry['props'] : array();
+		if ( null === $value ) {
+			unset( $properties[ $name ] );
+		} else {
+			$properties[ $name ] = $value;
+		}
+		if ( count( $properties ) > 0 ) {
+			$entry['props'] = $properties;
+		} else {
+			unset( $entry['props'] );
+		}
+		$this->working_copy->set_entry( $path, $entry );
+	}
+
+	public function close_directory( $path ) {
+		// Nothing to do.
+	}
+
+	public function add_file( $path ) {
+		$this->file_states[ $path ] = array(
+			'is_add'       => true,
+			'had_delta'    => false,
+			'applier'      => null,
+			'prop_changes' => array(),
+		);
+	}
+
+	public function open_file( $path ) {
+		if ( null === $this->working_copy->get_entry( $path ) ) {
+			throw new SvnException( "The server changed '{$path}' which is not part of this working copy." );
+		}
+		$this->file_states[ $path ] = array(
+			'is_add'       => false,
+			'had_delta'    => false,
+			'applier'      => null,
+			'prop_changes' => array(),
+		);
+	}
+
+	public function change_file_property( $path, $name, $value ) {
+		$this->file_states[ $path ]['prop_changes'][ $name ] = $value;
+	}
+
+	public function apply_textdelta( $path, $base_checksum ) {
+		$state = &$this->file_states[ $path ];
+		$base  = '';
+		if ( ! $state['is_add'] ) {
+			$entry = $this->working_copy->get_entry( $path );
+			if ( isset( $entry['checksum'] ) ) {
+				$base = $this->working_copy->read_pristine( $entry['checksum'] );
+			}
+		}
+		if ( null !== $base_checksum && md5( $base ) !== $base_checksum ) {
+			throw new SvnException( "Checksum mismatch on the delta base of '{$path}': the working copy is corrupted." );
+		}
+		$state['had_delta'] = true;
+		$state['applier']   = new SvnDiffApplier( $base );
+	}
+
+	public function write_textdelta_chunk( $path, $svndiff_bytes ) {
+		$this->file_states[ $path ]['applier']->append_bytes( $svndiff_bytes );
+	}
+
+	public function textdelta_end( $path ) {
+		$this->file_states[ $path ]['applier']->finish();
+	}
+
+	public function close_file( $path, $text_checksum ) {
+		$state = $this->file_states[ $path ];
+		unset( $this->file_states[ $path ] );
+
+		$working_copy = $this->working_copy;
+		$entry        = $working_copy->get_entry( $path );
+		$properties   = ( null !== $entry && isset( $entry['props'] ) ) ? $entry['props'] : array();
+
+		// Resolve the new repository-normal-form contents.
+		if ( $state['had_delta'] ) {
+			$new_contents = $state['applier']->get_target();
+		} elseif ( null !== $entry && isset( $entry['checksum'] ) ) {
+			$new_contents = $working_copy->read_pristine( $entry['checksum'] );
+		} else {
+			$new_contents = '';
+		}
+		if ( null !== $text_checksum && md5( $new_contents ) !== $text_checksum ) {
+			throw new SvnException( "Checksum mismatch on '{$path}': expected {$text_checksum}, got " . md5( $new_contents ) . '.' );
+		}
+
+		// Resolve the new properties.
+		$new_properties = $properties;
+		foreach ( $state['prop_changes'] as $name => $value ) {
+			if ( null === $value ) {
+				unset( $new_properties[ $name ] );
+			} else {
+				$new_properties[ $name ] = $value;
+			}
+		}
+
+		$new_entry = array(
+			'kind'     => 'file',
+			'revision' => $this->target_revision,
+			'checksum' => $working_copy->store_pristine( $new_contents ),
+		);
+		if ( count( $new_properties ) > 0 ) {
+			$new_entry['props'] = $new_properties;
+		}
+
+		$filesystem  = $working_copy->get_filesystem();
+		$disk_path   = $working_copy->get_disk_path( $path );
+		$disk_exists = $filesystem->is_file( $disk_path );
+
+		// Compare normalized forms so that eol-style translation never
+		// reads as a content difference.
+		$local_contents      = null;
+		$normalized_incoming = SvnWorkingCopy::translate_from_disk( $new_contents, $new_properties );
+		if ( $disk_exists ) {
+			$local_contents = SvnWorkingCopy::translate_from_disk(
+				$filesystem->get_contents( $disk_path ),
+				$new_properties
+			);
+		}
+
+		if ( $state['is_add'] ) {
+			if ( $disk_exists && $local_contents !== $normalized_incoming ) {
+				// An unversioned file with different content is in the way.
+				// Keep it and store the incoming version next to it.
+				$working_copy->write_working_file( $path . '.r' . $this->target_revision, $new_contents, $new_properties );
+				$new_entry['conflict']        = true;
+				$new_entry['conflict_file']   = $path . '.r' . $this->target_revision;
+				$this->result['conflicted'][] = $path;
+			} else {
+				if ( ! $disk_exists ) {
+					$working_copy->write_working_file( $path, $new_contents, $new_properties );
+				}
+				$this->result['added'][] = $path;
+			}
+			$working_copy->set_entry( $path, $new_entry );
+
+			return;
+		}
+
+		$locally_modified = $disk_exists && $working_copy->is_file_modified( $path, $entry );
+
+		if ( ! $locally_modified ) {
+			$working_copy->write_working_file( $path, $new_contents, $new_properties );
+			$this->result['updated'][] = $path;
+		} elseif ( $local_contents === $normalized_incoming ) {
+			// The local edit and the incoming change are identical.
+			$this->result['updated'][] = $path;
+		} elseif ( ! $state['had_delta'] ) {
+			// Only properties changed; local content edits can stay.
+			$this->result['updated'][] = $path;
+		} else {
+			// Both sides changed the file. Keep the local version, store
+			// the incoming one as <name>.r<revision>, and flag the conflict.
+			$working_copy->write_working_file( $path . '.r' . $this->target_revision, $new_contents, $new_properties );
+			$new_entry['conflict']        = true;
+			$new_entry['conflict_file']   = $path . '.r' . $this->target_revision;
+			$this->result['conflicted'][] = $path;
+		}
+
+		$working_copy->set_entry( $path, $new_entry );
+	}
+
+	public function delete_entry( $path ) {
+		$working_copy = $this->working_copy;
+		$filesystem   = $working_copy->get_filesystem();
+		$entry        = $working_copy->get_entry( $path );
+		if ( null === $entry ) {
+			return;
+		}
+
+		if ( 'file' === $entry['kind'] ) {
+			$this->delete_file_entry( $path, $entry );
+
+			return;
+		}
+
+		// Delete a directory: remove every versioned child, then the
+		// directory itself when nothing unversioned remains.
+		$child_paths = $working_copy->get_entry_paths_under( $path );
+		rsort( $child_paths );
+		foreach ( $child_paths as $child_path ) {
+			$child_entry = $working_copy->get_entry( $child_path );
+			if ( 'file' === $child_entry['kind'] ) {
+				$this->delete_file_entry( $child_path, $child_entry );
+			} else {
+				$this->delete_directory_if_empty( $child_path );
+				$working_copy->remove_entry( $child_path );
+			}
+		}
+		$this->delete_directory_if_empty( $path );
+		$working_copy->remove_entry( $path );
+		$this->result['deleted'][] = $path;
+	}
+
+	public function close_edit() {
+		if ( count( $this->file_states ) > 0 ) {
+			throw new SvnException( 'The server ended the update while file transmissions were still open.' );
+		}
+
+		// All surviving entries are now at the target revision; scheduled
+		// local changes keep their pending state.
+		foreach ( $this->working_copy->get_entries() as $path => $entry ) {
+			if ( isset( $entry['schedule'] ) ) {
+				continue;
+			}
+			$entry['revision'] = $this->target_revision;
+			$this->working_copy->set_entry( $path, $entry );
+		}
+		$this->working_copy->set_revision( $this->target_revision );
+		$this->working_copy->save();
+	}
+
+	public function abort_edit() {
+		// Persist what was applied so far: every recorded entry matches
+		// what is actually on disk, which keeps the working copy usable
+		// even though it now holds a mix of revisions.
+		$this->working_copy->save();
+	}
+
+	private function delete_file_entry( $path, $entry ) {
+		$working_copy = $this->working_copy;
+		$filesystem   = $working_copy->get_filesystem();
+		$disk_path    = $working_copy->get_disk_path( $path );
+
+		if ( $filesystem->is_file( $disk_path ) && $working_copy->is_file_modified( $path, $entry ) ) {
+			// Keep locally modified files on disk as unversioned files.
+			$this->result['skipped'][] = $path;
+		} elseif ( $filesystem->is_file( $disk_path ) ) {
+			$filesystem->rm( $disk_path );
+			$this->result['deleted'][] = $path;
+		}
+		$working_copy->remove_entry( $path );
+	}
+
+	private function delete_directory_if_empty( $path ) {
+		$filesystem = $this->working_copy->get_filesystem();
+		$disk_path  = $this->working_copy->get_disk_path( $path );
+		if ( $filesystem->is_dir( $disk_path ) && 0 === count( $filesystem->ls( $disk_path ) ) ) {
+			$filesystem->rmdir( $disk_path, array() );
+		}
+	}
+}

--- a/components/Svn/class-workingcopyeditor.php
+++ b/components/Svn/class-workingcopyeditor.php
@@ -76,6 +76,7 @@ class WorkingCopyEditor implements SvnEditor {
 	}
 
 	public function add_directory( $path ) {
+		$path       = svn_normalize_relative_path( $path, false );
 		$filesystem = $this->working_copy->get_filesystem();
 		$disk_path  = $this->working_copy->get_disk_path( $path );
 		if ( $filesystem->is_file( $disk_path ) ) {
@@ -95,10 +96,12 @@ class WorkingCopyEditor implements SvnEditor {
 	}
 
 	public function open_directory( $path ) {
+		svn_normalize_relative_path( $path, false );
 		// Nothing to do – changes arrive through dedicated calls.
 	}
 
 	public function change_directory_property( $path, $name, $value ) {
+		$path  = svn_normalize_relative_path( $path );
 		$entry = $this->working_copy->get_entry( $path );
 		if ( null === $entry ) {
 			return;
@@ -118,10 +121,13 @@ class WorkingCopyEditor implements SvnEditor {
 	}
 
 	public function close_directory( $path ) {
+		svn_normalize_relative_path( $path );
 		// Nothing to do.
 	}
 
 	public function add_file( $path ) {
+		$path = svn_normalize_relative_path( $path, false );
+
 		$this->file_states[ $path ] = array(
 			'is_add'       => true,
 			'had_delta'    => false,
@@ -131,6 +137,7 @@ class WorkingCopyEditor implements SvnEditor {
 	}
 
 	public function open_file( $path ) {
+		$path = svn_normalize_relative_path( $path, false );
 		if ( null === $this->working_copy->get_entry( $path ) ) {
 			throw new SvnException( "The server changed '{$path}' which is not part of this working copy." );
 		}
@@ -143,10 +150,12 @@ class WorkingCopyEditor implements SvnEditor {
 	}
 
 	public function change_file_property( $path, $name, $value ) {
+		$path = svn_normalize_relative_path( $path, false );
 		$this->file_states[ $path ]['prop_changes'][ $name ] = $value;
 	}
 
 	public function apply_textdelta( $path, $base_checksum ) {
+		$path  = svn_normalize_relative_path( $path, false );
 		$state = &$this->file_states[ $path ];
 		$base  = '';
 		if ( ! $state['is_add'] ) {
@@ -163,14 +172,17 @@ class WorkingCopyEditor implements SvnEditor {
 	}
 
 	public function write_textdelta_chunk( $path, $svndiff_bytes ) {
+		$path = svn_normalize_relative_path( $path, false );
 		$this->file_states[ $path ]['applier']->append_bytes( $svndiff_bytes );
 	}
 
 	public function textdelta_end( $path ) {
+		$path = svn_normalize_relative_path( $path, false );
 		$this->file_states[ $path ]['applier']->finish();
 	}
 
 	public function close_file( $path, $text_checksum ) {
+		$path  = svn_normalize_relative_path( $path, false );
 		$state = $this->file_states[ $path ];
 		unset( $this->file_states[ $path ] );
 
@@ -267,6 +279,7 @@ class WorkingCopyEditor implements SvnEditor {
 	}
 
 	public function delete_entry( $path ) {
+		$path         = svn_normalize_relative_path( $path, false );
 		$working_copy = $this->working_copy;
 		$filesystem   = $working_copy->get_filesystem();
 		$entry        = $working_copy->get_entry( $path );

--- a/components/Svn/composer.json
+++ b/components/Svn/composer.json
@@ -1,0 +1,47 @@
+{
+    "name": "wp-php-toolkit/svn",
+    "description": "Subversion client component for WordPress.",
+    "type": "library",
+    "license": "GPL-2.0-or-later",
+    "keywords": [
+        "wordpress",
+        "php-toolkit"
+    ],
+    "homepage": "https://wordpress.github.io/php-toolkit/reference/svn.html",
+    "authors": [
+        {
+            "name": "Adam Zielinski",
+            "email": "adam@adamziel.com"
+        },
+        {
+            "name": "WordPress Team",
+            "email": "wordpress@wordpress.org"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/WordPress/php-toolkit/issues",
+        "source": "https://github.com/WordPress/php-toolkit",
+        "docs": "https://wordpress.github.io/php-toolkit/reference/svn.html"
+    },
+    "require": {
+        "php": ">=7.2",
+        "wp-php-toolkit/bytestream": "^0.9",
+        "wp-php-toolkit/filesystem": "^0.9",
+        "wp-php-toolkit/http-client": "^0.9",
+        "wp-php-toolkit/xml": "^0.9"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
+    "autoload": {
+        "classmap": [
+            "./"
+        ],
+        "files": [
+            "functions.php"
+        ],
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    }
+}

--- a/components/Svn/functions.php
+++ b/components/Svn/functions.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace WordPress\Svn;
+
+/**
+ * Parses an svn:externals property value.
+ *
+ * Externals nest other repositories (or other parts of the same
+ * repository) inside a working copy. Each non-empty, non-comment line
+ * defines one external in either the modern format:
+ *
+ *     [-r REV] URL[@PEG] TARGET
+ *
+ * or the historical pre-1.5 format:
+ *
+ *     TARGET [-r REV] URL
+ *
+ * URLs may be absolute or relative:
+ *
+ *     ../   relative to the URL of the directory the property is on
+ *     ^/    relative to the repository root
+ *     //    relative to the URL scheme
+ *     /     relative to the server root
+ *
+ * @param  string $property_value   The raw svn:externals value.
+ * @param  string $directory_url    Absolute URL of the directory carrying the property.
+ * @param  string $repository_root  Absolute URL of the repository root.
+ * @return array[] One entry per external: {
+ *     @type string   $url       Absolute URL of the external.
+ *     @type string   $target    Directory the external lives at, relative
+ *                               to the directory carrying the property.
+ *     @type int|null $revision  Pinned revision, or null for HEAD.
+ * }
+ * @throws SvnException When a line cannot be parsed.
+ */
+function svn_parse_externals( $property_value, $directory_url, $repository_root ) {
+	$externals = array();
+	foreach ( explode( "\n", $property_value ) as $line ) {
+		$line = trim( $line );
+		if ( '' === $line || '#' === $line[0] ) {
+			continue;
+		}
+
+		// Tokenize, honoring double-quoted tokens with spaces.
+		preg_match_all( '/"([^"]*)"|(\S+)/', $line, $matches, PREG_SET_ORDER );
+		$tokens = array();
+		foreach ( $matches as $match ) {
+			$tokens[] = isset( $match[2] ) && '' !== $match[2] ? $match[2] : $match[1];
+		}
+
+		// Extract the optional -r REV / -rREV operative revision.
+		$revision    = null;
+		$token_count = count( $tokens );
+		for ( $i = 0; $i < $token_count; $i++ ) {
+			if ( '-r' === $tokens[ $i ] && isset( $tokens[ $i + 1 ] ) ) {
+				$revision = (int) $tokens[ $i + 1 ];
+				array_splice( $tokens, $i, 2 );
+				break;
+			}
+			if ( 0 === strpos( $tokens[ $i ], '-r' ) && strlen( $tokens[ $i ] ) > 2 ) {
+				$revision = (int) substr( $tokens[ $i ], 2 );
+				array_splice( $tokens, $i, 1 );
+				break;
+			}
+		}
+
+		if ( 2 !== count( $tokens ) ) {
+			throw new SvnException( "Cannot parse svn:externals line: '{$line}'." );
+		}
+
+		if ( svn_is_url( $tokens[0] ) ) {
+			$url    = $tokens[0];
+			$target = $tokens[1];
+		} elseif ( svn_is_url( $tokens[1] ) ) {
+			$url    = $tokens[1];
+			$target = $tokens[0];
+		} else {
+			throw new SvnException( "Cannot parse svn:externals line, no URL found: '{$line}'." );
+		}
+
+		// A peg revision (URL@N) pins the external too. Only numeric and
+		// HEAD pegs are meaningful for a checkout.
+		$at_position = strrpos( $url, '@' );
+		if ( false !== $at_position && false === strpos( substr( $url, $at_position ), '/' ) ) {
+			$peg = substr( $url, $at_position + 1 );
+			$url = substr( $url, 0, $at_position );
+			if ( preg_match( '/^\d+$/', $peg ) ) {
+				if ( null === $revision ) {
+					$revision = (int) $peg;
+				}
+			} elseif ( 'HEAD' !== $peg && '' !== $peg ) {
+				throw new SvnException( "Unsupported peg revision '{$peg}' in svn:externals line: '{$line}'." );
+			}
+		}
+
+		$target = trim( $target, '/' );
+		if ( '' === $target || '..' === $target || 0 === strpos( $target, '../' ) || false !== strpos( $target, '/../' ) ) {
+			throw new SvnException( "svn:externals target must be a relative path below the directory: '{$line}'." );
+		}
+
+		$externals[] = array(
+			'url'      => svn_resolve_url( $url, $directory_url, $repository_root ),
+			'target'   => $target,
+			'revision' => $revision,
+		);
+	}
+
+	return $externals;
+}
+
+/**
+ * @param  string $candidate  A token from an svn:externals line.
+ * @return bool Whether the token is an absolute or relative URL rather than a target path.
+ */
+function svn_is_url( $candidate ) {
+	return false !== strpos( $candidate, '://' )
+		|| 0 === strpos( $candidate, '^/' )
+		|| 0 === strpos( $candidate, '//' )
+		|| 0 === strpos( $candidate, '/' )
+		|| 0 === strpos( $candidate, '../' );
+}
+
+/**
+ * Resolves a possibly-relative svn:externals URL to an absolute URL.
+ *
+ * @param  string $url              The URL token from the externals definition.
+ * @param  string $directory_url    Absolute URL of the directory carrying the property.
+ * @param  string $repository_root  Absolute URL of the repository root.
+ * @return string The absolute URL.
+ * @throws SvnException When the URL escapes the server root.
+ */
+function svn_resolve_url( $url, $directory_url, $repository_root ) {
+	if ( false !== strpos( $url, '://' ) ) {
+		return rtrim( $url, '/' );
+	}
+	if ( 0 === strpos( $url, '^/' ) ) {
+		return svn_join_url( $repository_root, substr( $url, 2 ) );
+	}
+	if ( 0 === strpos( $url, '//' ) ) {
+		$scheme = (string) parse_url( $directory_url, PHP_URL_SCHEME );
+
+		return rtrim( $scheme . ':' . $url, '/' );
+	}
+	if ( 0 === strpos( $url, '/' ) ) {
+		$parts     = parse_url( $directory_url );
+		$authority = $parts['scheme'] . '://' . $parts['host'] . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' );
+
+		return rtrim( $authority . $url, '/' );
+	}
+
+	return svn_join_url( $directory_url, $url );
+}
+
+/**
+ * Joins a base URL with a relative path, resolving "." and ".." segments.
+ *
+ * @param  string $base_url  An absolute URL.
+ * @param  string $relative  A relative path, possibly with ".." segments.
+ * @return string The joined absolute URL.
+ * @throws SvnException When ".." segments escape the server root.
+ */
+function svn_join_url( $base_url, $relative ) {
+	$parts     = parse_url( $base_url );
+	$authority = $parts['scheme'] . '://' . $parts['host'] . ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' );
+	$segments  = array();
+	$base_path = isset( $parts['path'] ) ? trim( $parts['path'], '/' ) : '';
+	if ( '' !== $base_path ) {
+		$segments = explode( '/', $base_path );
+	}
+	foreach ( explode( '/', trim( $relative, '/' ) ) as $segment ) {
+		if ( '' === $segment || '.' === $segment ) {
+			continue;
+		}
+		if ( '..' === $segment ) {
+			if ( 0 === count( $segments ) ) {
+				throw new SvnException( "The relative URL '{$relative}' escapes the server root of '{$base_url}'." );
+			}
+			array_pop( $segments );
+			continue;
+		}
+		$segments[] = $segment;
+	}
+
+	return $authority . ( count( $segments ) > 0 ? '/' . implode( '/', $segments ) : '' );
+}

--- a/components/Svn/functions.php
+++ b/components/Svn/functions.php
@@ -49,16 +49,19 @@ function svn_parse_externals( $property_value, $directory_url, $repository_root 
 		}
 
 		// Extract the optional -r REV / -rREV operative revision.
-		$revision    = null;
-		$token_count = count( $tokens );
+		$revision     = null;
+		$has_revision = false;
+		$token_count  = count( $tokens );
 		for ( $i = 0; $i < $token_count; $i++ ) {
 			if ( '-r' === $tokens[ $i ] && isset( $tokens[ $i + 1 ] ) ) {
-				$revision = (int) $tokens[ $i + 1 ];
+				$revision     = svn_parse_externals_revision( $tokens[ $i + 1 ], $line );
+				$has_revision = true;
 				array_splice( $tokens, $i, 2 );
 				break;
 			}
 			if ( 0 === strpos( $tokens[ $i ], '-r' ) && strlen( $tokens[ $i ] ) > 2 ) {
-				$revision = (int) substr( $tokens[ $i ], 2 );
+				$revision     = svn_parse_externals_revision( substr( $tokens[ $i ], 2 ), $line );
+				$has_revision = true;
 				array_splice( $tokens, $i, 1 );
 				break;
 			}
@@ -84,17 +87,17 @@ function svn_parse_externals( $property_value, $directory_url, $repository_root 
 		if ( false !== $at_position && false === strpos( substr( $url, $at_position ), '/' ) ) {
 			$peg = substr( $url, $at_position + 1 );
 			$url = substr( $url, 0, $at_position );
-			if ( preg_match( '/^\d+$/', $peg ) ) {
-				if ( null === $revision ) {
-					$revision = (int) $peg;
+			if ( '' !== $peg ) {
+				$peg_revision = svn_parse_externals_revision( $peg, $line );
+				if ( ! $has_revision ) {
+					$revision = $peg_revision;
 				}
-			} elseif ( 'HEAD' !== $peg && '' !== $peg ) {
-				throw new SvnException( "Unsupported peg revision '{$peg}' in svn:externals line: '{$line}'." );
 			}
 		}
 
-		$target = trim( $target, '/' );
-		if ( '' === $target || '..' === $target || 0 === strpos( $target, '../' ) || false !== strpos( $target, '/../' ) ) {
+		try {
+			$target = svn_normalize_relative_path( trim( $target, '/' ), false );
+		} catch ( SvnException $exception ) {
 			throw new SvnException( "svn:externals target must be a relative path below the directory: '{$line}'." );
 		}
 
@@ -106,6 +109,44 @@ function svn_parse_externals( $property_value, $directory_url, $repository_root 
 	}
 
 	return $externals;
+}
+
+/**
+ * Normalizes an SVN path that must stay below a containing root.
+ *
+ * @param  string $path        Forward-slash path relative to a root.
+ * @param  bool   $allow_root  Whether the empty root path is allowed.
+ * @return string The normalized path.
+ * @throws SvnException When the path is absolute, empty, or contains unsafe segments.
+ */
+function svn_normalize_relative_path( $path, $allow_root = true ) {
+	if ( ! is_string( $path ) ) {
+		throw new SvnException( 'SVN paths must be strings.' );
+	}
+	if ( '' === $path ) {
+		if ( $allow_root ) {
+			return '';
+		}
+		throw new SvnException( 'SVN path must not be empty.' );
+	}
+	if ( 0 === strpos( $path, '/' ) ) {
+		throw new SvnException( "SVN path '{$path}' must be relative." );
+	}
+	if ( false !== strpos( $path, '\\' ) ) {
+		throw new SvnException( "SVN path '{$path}' must use forward slashes." );
+	}
+	if ( false !== strpos( $path, "\0" ) || preg_match( '/[\x01-\x1f\x7f]/', $path ) ) {
+		throw new SvnException( "SVN path '{$path}' contains control characters." );
+	}
+
+	$segments = explode( '/', $path );
+	foreach ( $segments as $segment ) {
+		if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+			throw new SvnException( "SVN path '{$path}' must not contain empty, '.', or '..' segments." );
+		}
+	}
+
+	return implode( '/', $segments );
 }
 
 /**
@@ -182,4 +223,21 @@ function svn_join_url( $base_url, $relative ) {
 	}
 
 	return $authority . ( count( $segments ) > 0 ? '/' . implode( '/', $segments ) : '' );
+}
+
+/**
+ * @param  string $revision  Revision token from an svn:externals definition.
+ * @param  string $line      The full externals line, for error messages.
+ * @return int|null Numeric revision, or null for HEAD.
+ * @throws SvnException When the revision token is unsupported.
+ */
+function svn_parse_externals_revision( $revision, $line ) {
+	if ( preg_match( '/^\d+$/', $revision ) ) {
+		return (int) $revision;
+	}
+	if ( 'HEAD' === strtoupper( $revision ) ) {
+		return null;
+	}
+
+	throw new SvnException( "Unsupported revision '{$revision}' in svn:externals line: '{$line}'." );
 }

--- a/components/Svn/interface-svneditor.php
+++ b/components/Svn/interface-svneditor.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace WordPress\Svn;
+
+/**
+ * Receiver of a Subversion tree delta.
+ *
+ * The "editor" is Subversion's core abstraction: a checkout or an update
+ * is the server walking the client through a series of tree operations –
+ * add this directory, change that file, delete this entry. Both the
+ * svn:// protocol and the HTTP update-report express their responses as
+ * editor drives; the session classes translate the wire format into
+ * calls on this interface.
+ *
+ * All paths are relative to the session URL and use forward slashes.
+ * File contents arrive as svndiff deltas (see SvnDiffApplier) between
+ * apply_textdelta() and textdelta_end() calls.
+ */
+interface SvnEditor {
+	/**
+	 * Announces the revision the drive will take the client to.
+	 *
+	 * @param int $revision  The target revision number.
+	 */
+	public function set_target_revision( $revision );
+
+	/**
+	 * Opens the root of the edited tree. Always the first tree call.
+	 */
+	public function open_root();
+
+	/**
+	 * Adds a new directory.
+	 *
+	 * @param string $path  Directory path relative to the session URL.
+	 */
+	public function add_directory( $path );
+
+	/**
+	 * Opens an existing directory because something below it changes.
+	 *
+	 * @param string $path  Directory path relative to the session URL.
+	 */
+	public function open_directory( $path );
+
+	/**
+	 * Sets or deletes a property on a directory.
+	 *
+	 * @param string      $path   Directory path relative to the session URL ('' for the root).
+	 * @param string      $name   Property name, e.g. "svn:externals".
+	 * @param string|null $value  New property value, or null to delete the property.
+	 */
+	public function change_directory_property( $path, $name, $value );
+
+	/**
+	 * Closes a directory opened with add_directory() or open_directory().
+	 *
+	 * @param string $path  Directory path relative to the session URL.
+	 */
+	public function close_directory( $path );
+
+	/**
+	 * Adds a new file. Content arrives via the textdelta calls.
+	 *
+	 * @param string $path  File path relative to the session URL.
+	 */
+	public function add_file( $path );
+
+	/**
+	 * Opens an existing file whose contents and/or properties change.
+	 *
+	 * @param string $path  File path relative to the session URL.
+	 */
+	public function open_file( $path );
+
+	/**
+	 * Sets or deletes a property on the currently open file.
+	 *
+	 * @param string      $path   File path relative to the session URL.
+	 * @param string      $name   Property name, e.g. "svn:eol-style".
+	 * @param string|null $value  New property value, or null to delete the property.
+	 */
+	public function change_file_property( $path, $name, $value );
+
+	/**
+	 * Starts the content transmission for a file.
+	 *
+	 * @param string      $path           File path relative to the session URL.
+	 * @param string|null $base_checksum  Expected MD5 of the delta base, or null
+	 *                                    when the delta applies to an empty file.
+	 */
+	public function apply_textdelta( $path, $base_checksum );
+
+	/**
+	 * Delivers a chunk of the svndiff document for a file.
+	 *
+	 * @param string $path           File path relative to the session URL.
+	 * @param string $svndiff_bytes  Raw svndiff bytes – chunk boundaries are arbitrary.
+	 */
+	public function write_textdelta_chunk( $path, $svndiff_bytes );
+
+	/**
+	 * Ends the content transmission for a file.
+	 *
+	 * @param string $path  File path relative to the session URL.
+	 */
+	public function textdelta_end( $path );
+
+	/**
+	 * Closes a file opened with add_file() or open_file().
+	 *
+	 * @param string      $path           File path relative to the session URL.
+	 * @param string|null $text_checksum  MD5 of the full resulting text, when the server provides it.
+	 */
+	public function close_file( $path, $text_checksum );
+
+	/**
+	 * Deletes a file or directory.
+	 *
+	 * @param string $path  Path relative to the session URL.
+	 */
+	public function delete_entry( $path );
+
+	/**
+	 * Ends a successful drive.
+	 */
+	public function close_edit();
+
+	/**
+	 * Ends a failed drive. The working copy may be in a partial state.
+	 */
+	public function abort_edit();
+}

--- a/components/Svn/interface-svnsession.php
+++ b/components/Svn/interface-svnsession.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace WordPress\Svn;
+
+/**
+ * A connection to a Subversion repository.
+ *
+ * Implementations exist for the svn:// protocol (RaSvnSession) and for
+ * http:// and https:// (DavSession). Both expose the same repository
+ * primitives so the working copy layer never needs to know which
+ * transport is in use.
+ *
+ * All paths are relative to the session URL and use forward slashes.
+ * An empty string denotes the session URL itself. Revisions are
+ * integers; passing null means "the latest revision".
+ */
+interface SvnSession {
+	/**
+	 * @return string The URL this session was opened at, without credentials.
+	 */
+	public function get_session_url();
+
+	/**
+	 * @return string The repository root URL. Always a prefix of the session URL.
+	 */
+	public function get_repository_root();
+
+	/**
+	 * @return string The repository UUID.
+	 */
+	public function get_uuid();
+
+	/**
+	 * @return int The youngest revision in the repository.
+	 */
+	public function get_latest_revision();
+
+	/**
+	 * Checks what exists at a path.
+	 *
+	 * @param  string   $path      Path relative to the session URL.
+	 * @param  int|null $revision  Revision to inspect, or null for the latest.
+	 * @return string One of 'file', 'dir', or 'none'.
+	 */
+	public function check_path( $path, $revision = null );
+
+	/**
+	 * Lists a directory.
+	 *
+	 * @param  string   $path      Directory path relative to the session URL.
+	 * @param  int|null $revision  Revision to inspect, or null for the latest.
+	 * @return array[] One entry per child: {
+	 *     @type string $name         Child basename.
+	 *     @type string $kind         'file' or 'dir'.
+	 *     @type int    $size         File size in bytes, 0 for directories.
+	 *     @type int    $created_rev  Revision of the last change.
+	 * }
+	 */
+	public function list_directory( $path, $revision = null );
+
+	/**
+	 * Fetches a file.
+	 *
+	 * @param  string   $path      File path relative to the session URL.
+	 * @param  int|null $revision  Revision to fetch, or null for the latest.
+	 * @return array {
+	 *     @type string      $contents    The file contents.
+	 *     @type string|null $checksum    MD5 checksum of the contents, when the server provides it.
+	 *     @type array       $properties  Versioned properties, name => value.
+	 * }
+	 */
+	public function get_file( $path, $revision = null );
+
+	/**
+	 * Fetches the versioned properties of a file or directory.
+	 *
+	 * @param  string   $path      Path relative to the session URL.
+	 * @param  int|null $revision  Revision to inspect, or null for the latest.
+	 * @return array Property name => value.
+	 */
+	public function get_properties( $path, $revision = null );
+
+	/**
+	 * Asks the server to drive the editor with the changes needed to
+	 * bring the reported working copy state to $target_revision.
+	 *
+	 * A fresh checkout is an update too: report the root path with
+	 * 'start_empty' set to true and the server sends the whole tree.
+	 *
+	 * @param int       $target_revision  The revision to update to.
+	 * @param array[]   $report           One entry per reported path: {
+	 *     @type string $path         Path relative to the session URL, '' for the root.
+	 *     @type int    $revision     The revision the working copy has.
+	 *     @type bool   $start_empty  Whether the path should be treated as empty.
+	 * }
+	 * @param SvnEditor $editor           Receives the tree delta.
+	 * @param array     $options          {
+	 *     @type string $depth  'empty', 'files', 'immediates', or 'infinity'. Default 'infinity'.
+	 * }
+	 */
+	public function drive_update( $target_revision, $report, SvnEditor $editor, $options = array() );
+
+	/**
+	 * Commits a set of changes as a new revision.
+	 *
+	 * @param  string  $message     The log message.
+	 * @param  array[] $operations  One entry per change, in any order: {
+	 *     @type string $op  One of:
+	 *         'add-directory'    – { path, properties? }
+	 *         'add-file'         – { path, contents, properties? }
+	 *         'modify-file'      – { path, contents, base_revision, properties? }
+	 *         'modify-properties'– { path, kind ('file'|'dir'), base_revision, properties }
+	 *         'delete'           – { path, base_revision? }
+	 *     'properties' is a map of property name => value, with null
+	 *     meaning "delete this property".
+	 * }
+	 * @return array {
+	 *     @type int    $revision  The new revision number.
+	 *     @type string $author    The commit author, when the server reports it.
+	 *     @type string $date      The commit timestamp, when the server reports it.
+	 * }
+	 */
+	public function commit( $message, $operations );
+
+	/**
+	 * Closes the session and frees the underlying connection.
+	 */
+	public function close();
+}

--- a/composer-ci-matrix-tests.json
+++ b/composer-ci-matrix-tests.json
@@ -45,6 +45,7 @@
 			"components/Merge/vendor-patched",
 			"components/ByteStream/",
 			"components/Polyfill/",
+			"components/Svn/",
 			"components/XML/",
 			"components/Zip/"
 		],
@@ -59,7 +60,8 @@
 			"components/Polyfill/wordpress.php",
 			"components/Polyfill/mbstring.php",
 			"components/Polyfill/php-functions.php",
-			"components/Git/functions.php"
+			"components/Git/functions.php",
+			"components/Svn/functions.php"
 		],
 		"psr-4": {
 			"Rowbot\\": "components/DataLiberation/vendor-patched/",

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
 			"components/Merge/vendor-patched",
 			"components/ByteStream/",
 			"components/Polyfill/",
+			"components/Svn/",
 			"components/ToolkitCodingStandards/",
 			"components/XML/",
 			"components/Zip/"
@@ -77,7 +78,8 @@
 			"components/Polyfill/wordpress.php",
 			"components/Polyfill/mbstring.php",
 			"components/Polyfill/php-functions.php",
-			"components/Git/functions.php"
+			"components/Git/functions.php",
+			"components/Svn/functions.php"
 		],
 		"psr-4": {
 			"Rowbot\\": "components/DataLiberation/vendor-patched/",


### PR DESCRIPTION
## What

A new `components/Svn/` component: a Subversion client in pure PHP. It checks out, updates, and commits to SVN repositories — including WordPress.org's — over both `svn://` (the ra_svn wire protocol) and `http(s)://` (mod_dav_svn), with no `svn` binary and no PHP extensions beyond the toolkit baseline.

```php
$client = new SvnClient( array( 'username' => '…', 'password' => '…' ) );
$client->checkout( 'https://develop.svn.wordpress.org/trunk', '/tmp/wordpress-develop' );
// …edit files…
$client->add( '/tmp/wordpress-develop', 'src/new-file.php' );
$client->commit( '/tmp/wordpress-develop', 'Add a new file.' );
$client->update( '/tmp/wordpress-develop' );
```

## Why

WordPress lives in Subversion — core development, plugins, and themes all ship through it. Automating anything around that ecosystem from PHP currently means shelling out to a binary most hosted environments don't have. This brings SVN into the same pure-PHP fold as the existing Git component.

## How it works

Both transports are implemented around Subversion's core abstraction, the **editor drive** (a stream of tree-change operations). A checkout or update is one request; the server walks the client through the tree, and file contents arrive as svndiff deltas applied against a local pristine store, MD5-verified per file:

- **`RaSvnSession`** speaks the ra_svn wire protocol: handshake, ANONYMOUS/CRAM-MD5 auth, command tuples, server-driven update editor, client-driven commit editor with svndiff0 windows.
- **`DavSession`** speaks HTTP protocol v2 (Subversion 1.7+): OPTIONS stub discovery, PROPFIND/GET reads, streaming `update-report` REPORT parsing (via the XML component), and commits as `POST create-txn` → `PUT`/`MKCOL`/`DELETE`/`PROPPATCH` → `MERGE`.
- **`SvnWorkingCopy` + `WorkingCopyEditor`** manage the working copy: JSON metadata plus a checksum-keyed pristine store under `.svn/`, status detection, `svn:eol-style` translation, and conflict handling (local file kept, incoming saved as `<name>.r<rev>`, commit blocked until `resolved()`).
- **Nested repositories**: `svn:externals` (modern + pre-1.5 syntax, `^/` `../` `//` `/` relative URLs, pinned revisions) are checked out as nested working copies, updated with their parent, and skipped by status/commit — matching the official client.
- Every wire detail was pinned down empirically against live servers before implementation (svnserve 1.14, mod_dav_svn on Apache, and WordPress.org itself).

## Proof: wordpress-develop

Full checkout of `https://develop.svn.wordpress.org/trunk` @ r62480 with `memory_limit=512M`:

| | |
|---|---|
| Nodes checked out | **7,078** — exactly matches `svn ls -R` |
| Wall time | **~12 s** (single streamed response) |
| Peak memory | **38–46 MB** |
| Content | Spot files byte-identical to `svn cat`; every file MD5-verified during the drive; full `status` walk clean |
| Externals | `tests/phpunit/data/plugins/wordpress-importer` (a cross-server external to plugins.svn.wordpress.org) checked out automatically |
| Update | r62400 → r62480 replay: 161 updated / 12 added / 1 deleted, 0 conflicts, 1.8 s |

Reproducible via `SVN_TESTS_ONLINE=1 SVN_TESTS_HUGE=1 vendor/bin/phpunit components/Svn/Tests/WordPressDevelopCheckoutTest.php`.

## Tests

All scenarios run against **real SVN servers**, never mocks:

- **Local svn://** — `SvnserveClientTest` spawns `svnadmin`-created repositories behind a real `svnserve` (auto-skips without the binaries). Includes an interop test: working copies byte-identical with the official client's, commits visible in both directions.
- **Local http://** — `DavClientTest` runs Apache + mod_dav_svn in Docker (`Tests/http-server/`, auto-skips without Docker), anonymous and Basic-auth repositories.
- Both share `SvnClientBehaviorTrait`: checkout (incl. depth + old revisions), status, commit roundtrips, updates, conflict/resolve flows, revert, forced deletes, out-of-date rejection, auth failure/success, externals.
- **Remote** — `WordPressOrgTest` (gated by `SVN_TESTS_ONLINE=1`) exercises develop.svn.wordpress.org and plugins.svn.wordpress.org.
- **Unit** — svndiff codec (incl. hand-crafted windows, overlapping target copies, truncation), ra_svn item codec, externals parser, working copy/eol logic, DAV report parser against a captured mod_dav_svn fixture (incl. 7-byte chunked feeding).

`composer lint` clean for the component; PHPCompatibility clean for 7.2; full project suite passes (5600 tests).

## Design notes & limitations

- **Working copy format is our own** (`.svn/wc.json` + pristine store), not the official client's SQLite `wc.db`. Repositories interoperate fully; working copies don't transfer between clients.
- **HTTP requires Subversion 1.7+ servers** (HTTP protocol v2). The pre-2011 DeltaV dance is not implemented; connect fails with a clear message.
- Subtle bug found & fixed during development: for fixed `svn:eol-style` values (CRLF/CR/LF) the *repository itself* stores that line ending — normalizing to LF made fresh checkouts look locally modified and could silently commit eol rewrites. There's a regression test (`test_commit_does_not_rewrite_eol_styled_files`).
- Two `@TODO`s for the XML component surfaced here: it can't pause mid-XML-declaration in streaming mode (worked around with a tiny prelude buffer) and its 1 GiB memory budget isn't publicly configurable (worked around with a guarded reflection tweak; that's what keeps 600 MB checkouts at ~40 MB RAM).
- Not supported yet: `file://`, `svn+ssh://`, locks, `svn:keywords`, `svn:special` symlinks, merge tracking, mixed-depth sparse checkouts. Documented in the README.
- Root `composer.json` was edited by hand (classmap + files) — `bin/regenerate_composer.json.php` mentioned in AGENTS.md doesn't exist in the repo.
