### PR TITLE
CSS: Add hash token type flag

### DIFF
--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -131,6 +131,14 @@ class CSSProcessor {
 	public const TOKEN_FUNCTION      = 'function-token';
 
 	/**
+	 * Hash-token type flags.
+	 *
+	 * @see https://www.w3.org/TR/css-syntax-3/#typedef-hash-token
+	 */
+	public const HASH_TOKEN_ID           = 'id';
+	public const HASH_TOKEN_UNRESTRICTED = 'unrestricted';
+
+	/**
 	 * URL tokens represent unquoted URLs in url() notation.
 	 *
 	 * Valid: url(image.jpg), url(https://example.com)
@@ -214,6 +222,13 @@ class CSSProcessor {
 	 * @var string|null
 	 */
 	private $token_type = null;
+
+	/**
+	 * The type flag of the current token, if the token carries one.
+	 *
+	 * @var string|null
+	 */
+	private $token_type_flag = null;
 
 	/**
 	 * The byte offset at which the current token starts.
@@ -414,9 +429,9 @@ class CSSProcessor {
 					// Create a <hash-token>.
 					++$this->at;
 
-					// We skip this check as we don't track the type flag:
-					// > If the next 3 input code points would start an ident sequence,
-					// > set the <hash-token>'s type flag to "id".
+					$this->token_type_flag = $this->check_if_3_code_points_start_an_ident_sequence( $this->at )
+						? self::HASH_TOKEN_ID
+						: self::HASH_TOKEN_UNRESTRICTED;
 
 					// Consume an ident sequence, and set the <hash-token>'s value to the returned string.
 					$this->consume_ident_sequence();
@@ -612,6 +627,17 @@ class CSSProcessor {
 	 */
 	public function get_token_type(): ?string {
 		return $this->token_type;
+	}
+
+	/**
+	 * Gets the current token type flag.
+	 *
+	 * Only hash tokens carry a type flag. Other token types return null.
+	 *
+	 * @return string|null
+	 */
+	public function get_token_type_flag(): ?string {
+		return $this->token_type_flag;
 	}
 
 	/**
@@ -986,6 +1012,7 @@ class CSSProcessor {
 	 */
 	private function after_token(): void {
 		$this->token_type            = null;
+		$this->token_type_flag       = null;
 		$this->token_starts_at       = null;
 		$this->token_length          = null;
 		$this->token_value           = null;

--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -131,14 +131,6 @@ class CSSProcessor {
 	public const TOKEN_FUNCTION      = 'function-token';
 
 	/**
-	 * Hash-token type flags.
-	 *
-	 * @see https://www.w3.org/TR/css-syntax-3/#typedef-hash-token
-	 */
-	public const HASH_TOKEN_ID           = 'id';
-	public const HASH_TOKEN_UNRESTRICTED = 'unrestricted';
-
-	/**
 	 * URL tokens represent unquoted URLs in url() notation.
 	 *
 	 * Valid: url(image.jpg), url(https://example.com)
@@ -430,8 +422,8 @@ class CSSProcessor {
 					++$this->at;
 
 					$this->token_type_flag = $this->check_if_3_code_points_start_an_ident_sequence( $this->at )
-						? self::HASH_TOKEN_ID
-						: self::HASH_TOKEN_UNRESTRICTED;
+						? 'id'
+						: 'unrestricted';
 
 					// Consume an ident sequence, and set the <hash-token>'s value to the returned string.
 					$this->consume_ident_sequence();
@@ -632,9 +624,8 @@ class CSSProcessor {
 	/**
 	 * Gets the current token type flag.
 	 *
-	 * Only hash tokens carry a type flag. Other token types return null.
-	 *
 	 * @return string|null
+	 * @phpstan-return 'id'|'unrestricted'|null
 	 */
 	public function get_token_type_flag(): ?string {
 		return $this->token_type_flag;

--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -624,6 +624,14 @@ class CSSProcessor {
 	/**
 	 * Gets the current token type flag.
 	 *
+	 * Some token types have an additional flag:
+	 * - Hash tokens have a flag that is either be "id" or "unrestricted". The
+	 *   following example uses an "id" hash token as the `#ident` ID selector and
+	 *   an "unrestricted" hash token as the `#0f0` hex color:
+	 *       #ident {
+	 *         color: #0f0;
+	 *       }
+	 *
 	 * @return string|null
 	 * @phpstan-return 'id'|'unrestricted'|null
 	 */

--- a/components/DataLiberation/Tests/CSSProcessorTest.php
+++ b/components/DataLiberation/Tests/CSSProcessorTest.php
@@ -68,36 +68,108 @@ class CSSProcessorTest extends TestCase {
 		return $tokens;
 	}
 
-	public function test_hash_tokens_expose_type_flags(): void {
-		$processor = CSSProcessor::create( '#id #1id .' );
+	/**
+	 * Tests that hash tokens expose the proper type flag.
+	 *
+	 * @dataProvider data_hash_tokens_expose_type_flags
+	 */
+	public function test_hash_tokens_expose_type_flags( string $css, array $expected_tokens ): void {
+		$processor = CSSProcessor::create( $css );
 
-		$this->assertTrue( $processor->next_token() );
-		$this->assertSame( CSSProcessor::TOKEN_HASH, $processor->get_token_type() );
-		$this->assertSame( '#id', $processor->get_unnormalized_token() );
-		$this->assertSame( CSSProcessor::HASH_TOKEN_ID, $processor->get_token_type_flag() );
-
-		$this->assertTrue( $processor->next_token() );
-		$this->assertSame( CSSProcessor::TOKEN_WHITESPACE, $processor->get_token_type() );
-		$this->assertSame( ' ', $processor->get_unnormalized_token() );
-		$this->assertNull( $processor->get_token_type_flag() );
-
-		$this->assertTrue( $processor->next_token() );
-		$this->assertSame( CSSProcessor::TOKEN_HASH, $processor->get_token_type() );
-		$this->assertSame( '#1id', $processor->get_unnormalized_token() );
-		$this->assertSame( CSSProcessor::HASH_TOKEN_UNRESTRICTED, $processor->get_token_type_flag() );
-
-		$this->assertTrue( $processor->next_token() );
-		$this->assertSame( CSSProcessor::TOKEN_WHITESPACE, $processor->get_token_type() );
-		$this->assertSame( ' ', $processor->get_unnormalized_token() );
-		$this->assertNull( $processor->get_token_type_flag() );
-
-		$this->assertTrue( $processor->next_token() );
-		$this->assertSame( CSSProcessor::TOKEN_DELIM, $processor->get_token_type() );
-		$this->assertSame( '.', $processor->get_unnormalized_token() );
-		$this->assertNull( $processor->get_token_type_flag() );
+		foreach ( $expected_tokens as $expected_token ) {
+			$this->assertTrue( $processor->next_token() );
+			$this->assertSame( $expected_token['type'], $processor->get_token_type() );
+			$this->assertSame( $expected_token['raw'], $processor->get_unnormalized_token() );
+			$this->assertSame( $expected_token['type_flag'], $processor->get_token_type_flag() );
+		}
 
 		$this->assertFalse( $processor->next_token() );
 		$this->assertNull( $processor->get_token_type_flag() );
+	}
+
+	public static function data_hash_tokens_expose_type_flags(): array {
+		return array(
+			'id hash'                            => array(
+				'#id',
+				array(
+					array(
+						'type'      => CSSProcessor::TOKEN_HASH,
+						'raw'       => '#id',
+						'type_flag' => CSSProcessor::HASH_TOKEN_ID,
+					),
+				),
+			),
+			'unrestricted hash starting digit'   => array(
+				'#1id',
+				array(
+					array(
+						'type'      => CSSProcessor::TOKEN_HASH,
+						'raw'       => '#1id',
+						'type_flag' => CSSProcessor::HASH_TOKEN_UNRESTRICTED,
+					),
+				),
+			),
+			'id hash starting hyphen ident'      => array(
+				'#-id',
+				array(
+					array(
+						'type'      => CSSProcessor::TOKEN_HASH,
+						'raw'       => '#-id',
+						'type_flag' => CSSProcessor::HASH_TOKEN_ID,
+					),
+				),
+			),
+			'unrestricted hash starting hyphen'  => array(
+				'#-1id',
+				array(
+					array(
+						'type'      => CSSProcessor::TOKEN_HASH,
+						'raw'       => '#-1id',
+						'type_flag' => CSSProcessor::HASH_TOKEN_UNRESTRICTED,
+					),
+				),
+			),
+			'id hash starting escape'            => array(
+				'#\\@special',
+				array(
+					array(
+						'type'      => CSSProcessor::TOKEN_HASH,
+						'raw'       => '#\\@special',
+						'type_flag' => CSSProcessor::HASH_TOKEN_ID,
+					),
+				),
+			),
+			'hash delimiter has no type flag'    => array(
+				'#',
+				array(
+					array(
+						'type'      => CSSProcessor::TOKEN_DELIM,
+						'raw'       => '#',
+						'type_flag' => null,
+					),
+				),
+			),
+			'following token clears type flag'   => array(
+				'#id .',
+				array(
+					array(
+						'type'      => CSSProcessor::TOKEN_HASH,
+						'raw'       => '#id',
+						'type_flag' => CSSProcessor::HASH_TOKEN_ID,
+					),
+					array(
+						'type'      => CSSProcessor::TOKEN_WHITESPACE,
+						'raw'       => ' ',
+						'type_flag' => null,
+					),
+					array(
+						'type'      => CSSProcessor::TOKEN_DELIM,
+						'raw'       => '.',
+						'type_flag' => null,
+					),
+				),
+			),
+		);
 	}
 
 	/**

--- a/components/DataLiberation/Tests/CSSProcessorTest.php
+++ b/components/DataLiberation/Tests/CSSProcessorTest.php
@@ -95,7 +95,7 @@ class CSSProcessorTest extends TestCase {
 					array(
 						'type'      => CSSProcessor::TOKEN_HASH,
 						'raw'       => '#id',
-						'type_flag' => CSSProcessor::HASH_TOKEN_ID,
+						'type_flag' => 'id',
 					),
 				),
 			),
@@ -105,7 +105,7 @@ class CSSProcessorTest extends TestCase {
 					array(
 						'type'      => CSSProcessor::TOKEN_HASH,
 						'raw'       => '#1id',
-						'type_flag' => CSSProcessor::HASH_TOKEN_UNRESTRICTED,
+						'type_flag' => 'unrestricted',
 					),
 				),
 			),
@@ -115,7 +115,7 @@ class CSSProcessorTest extends TestCase {
 					array(
 						'type'      => CSSProcessor::TOKEN_HASH,
 						'raw'       => '#-id',
-						'type_flag' => CSSProcessor::HASH_TOKEN_ID,
+						'type_flag' => 'id',
 					),
 				),
 			),
@@ -125,7 +125,7 @@ class CSSProcessorTest extends TestCase {
 					array(
 						'type'      => CSSProcessor::TOKEN_HASH,
 						'raw'       => '#-1id',
-						'type_flag' => CSSProcessor::HASH_TOKEN_UNRESTRICTED,
+						'type_flag' => 'unrestricted',
 					),
 				),
 			),
@@ -135,7 +135,7 @@ class CSSProcessorTest extends TestCase {
 					array(
 						'type'      => CSSProcessor::TOKEN_HASH,
 						'raw'       => '#\\@special',
-						'type_flag' => CSSProcessor::HASH_TOKEN_ID,
+						'type_flag' => 'id',
 					),
 				),
 			),
@@ -155,7 +155,7 @@ class CSSProcessorTest extends TestCase {
 					array(
 						'type'      => CSSProcessor::TOKEN_HASH,
 						'raw'       => '#id',
-						'type_flag' => CSSProcessor::HASH_TOKEN_ID,
+						'type_flag' => 'id',
 					),
 					array(
 						'type'      => CSSProcessor::TOKEN_WHITESPACE,

--- a/components/DataLiberation/Tests/CSSProcessorTest.php
+++ b/components/DataLiberation/Tests/CSSProcessorTest.php
@@ -68,6 +68,38 @@ class CSSProcessorTest extends TestCase {
 		return $tokens;
 	}
 
+	public function test_hash_tokens_expose_type_flags(): void {
+		$processor = CSSProcessor::create( '#id #1id .' );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( CSSProcessor::TOKEN_HASH, $processor->get_token_type() );
+		$this->assertSame( '#id', $processor->get_unnormalized_token() );
+		$this->assertSame( CSSProcessor::HASH_TOKEN_ID, $processor->get_token_type_flag() );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( CSSProcessor::TOKEN_WHITESPACE, $processor->get_token_type() );
+		$this->assertSame( ' ', $processor->get_unnormalized_token() );
+		$this->assertNull( $processor->get_token_type_flag() );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( CSSProcessor::TOKEN_HASH, $processor->get_token_type() );
+		$this->assertSame( '#1id', $processor->get_unnormalized_token() );
+		$this->assertSame( CSSProcessor::HASH_TOKEN_UNRESTRICTED, $processor->get_token_type_flag() );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( CSSProcessor::TOKEN_WHITESPACE, $processor->get_token_type() );
+		$this->assertSame( ' ', $processor->get_unnormalized_token() );
+		$this->assertNull( $processor->get_token_type_flag() );
+
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( CSSProcessor::TOKEN_DELIM, $processor->get_token_type() );
+		$this->assertSame( '.', $processor->get_unnormalized_token() );
+		$this->assertNull( $processor->get_token_type_flag() );
+
+		$this->assertFalse( $processor->next_token() );
+		$this->assertNull( $processor->get_token_type_flag() );
+	}
+
 	/**
 	 * Tests handling of non-UTF-8 byte sequences in identifiers.
 	 *


### PR DESCRIPTION
## Summary

Adds CSS Syntax hash-token type flag support to `CSSProcessor`.

Hash tokens now expose whether they are `id` or `unrestricted` via new constants and `get_token_type_flag()`, matching the spec more closely and giving downstream consumers the information they need to distinguish hash-token behavior.

Exposing that flag lets callers distinguish ID-selector-style hashes.

## Testing

Adds coverage for hash-token type flags, delimiter fallback, and clearing the flag between tokens.

The token type flag can likely be re-used for the number type, see
https://github.com/WordPress/php-toolkit/pull/233.