### PR TITLE
URLInTextProcessor: Preserve trailing punctuation during replacement

### DIFF
--- a/components/DataLiberation/Tests/URLInTextProcessorTest.php
+++ b/components/DataLiberation/Tests/URLInTextProcessorTest.php
@@ -462,10 +462,30 @@ class URLInTextProcessorTest extends TestCase {
 				'wikipedia.org',
 				'Have you seen wikipedia.org (or wp.org)?',
 			),
-			'Preserve trailing parenthesis'         => array(
-				'background: url(https://wordpress.org/image.jpg) no-repeat;',
+			'Preserve closing parenthesis before background shorthand' => array(
+				'background: url(https://wordpress.org/image.jpg) no-repeat center center fixed;',
 				'https://w.org/image.jpg',
-				'background: url(https://w.org/image.jpg) no-repeat;',
+				'background: url(https://w.org/image.jpg) no-repeat center center fixed;',
+			),
+			'Preserve double-quoted CSS URL delimiters' => array(
+				'background: url(  "https://wordpress.org/image.jpg") center / cover no-repeat;',
+				'https://w.org/image.jpg',
+				'background: url(  "https://w.org/image.jpg") center / cover no-repeat;',
+			),
+			'Preserve single-quoted URL in layered background' => array(
+				"background-image: linear-gradient(#0008, #0000), url('https://wordpress.org/image.jpg');",
+				'https://w.org/image.jpg',
+				"background-image: linear-gradient(#0008, #0000), url('https://w.org/image.jpg');",
+			),
+			'Preserve CSS after percent-encoded UTF-8 URL' => array(
+				'background: url(https://wordpress.org/uploads/Gr%C3%BC%C3%9Fe-%E2%9C%93-%28hero%29.jpg?label=Za%C5%BC%C3%B3%C5%82%C4%87) center / contain no-repeat;',
+				'https://cdn.example/uploads/Gr%C3%BC%C3%9Fe-%E2%9C%93-%28hero%29.jpg?label=Za%C5%BC%C3%B3%C5%82%C4%87',
+				'background: url(https://cdn.example/uploads/Gr%C3%BC%C3%9Fe-%E2%9C%93-%28hero%29.jpg?label=Za%C5%BC%C3%B3%C5%82%C4%87) center / contain no-repeat;',
+			),
+			'Preserve image-set descriptor after raw UTF-8 URL' => array(
+				'image-set(url(https://wordpress.org/uploads/zażółć-🌍.png) 1x, url(https://wordpress.org/uploads/zażółć-🌍@2x.png) 2x)',
+				'https://cdn.example/uploads/zażółć-🌍.png',
+				'image-set(url(https://cdn.example/uploads/zażółć-🌍.png) 1x, url(https://wordpress.org/uploads/zażółć-🌍@2x.png) 2x)',
 			),
 		);
 	}

--- a/components/DataLiberation/Tests/URLInTextProcessorTest.php
+++ b/components/DataLiberation/Tests/URLInTextProcessorTest.php
@@ -462,6 +462,11 @@ class URLInTextProcessorTest extends TestCase {
 				'wikipedia.org',
 				'Have you seen wikipedia.org (or wp.org)?',
 			),
+			'Preserve trailing parenthesis'         => array(
+				'background: url(https://wordpress.org/image.jpg) no-repeat;',
+				'https://w.org/image.jpg',
+				'background: url(https://w.org/image.jpg) no-repeat;',
+			),
 		);
 	}
 

--- a/components/DataLiberation/URL/PHP/class-phpurlintextprocessor.php
+++ b/components/DataLiberation/URL/PHP/class-phpurlintextprocessor.php
@@ -300,7 +300,7 @@ class PHPURLInTextProcessor {
 
 			$this->parsed_url    = $parsed_url;
 			$this->url_starts_at = $url_starts_at;
-			$this->url_length    = strlen( $matches[0][0] );
+			$this->url_length    = strlen( $this->matched_url );
 
 			return true;
 		}

--- a/components/DataLiberation/URL/PHP/class-phpurlintextprocessor.php
+++ b/components/DataLiberation/URL/PHP/class-phpurlintextprocessor.php
@@ -242,6 +242,16 @@ class PHPURLInTextProcessor {
 			) {
 				$this->matched_url = substr( $this->matched_url, 0, - 1 );
 			}
+			/*
+			 * Quoted CSS url() values end in `")` or `')`. Once the outer
+			 * parenthesis is removed, keep the quote outside the URL too.
+			 */
+			if (
+				"'" === $this->matched_url[ strlen( $this->matched_url ) - 1 ] ||
+				'"' === $this->matched_url[ strlen( $this->matched_url ) - 1 ]
+			) {
+				$this->matched_url = substr( $this->matched_url, 0, - 1 );
+			}
 			$url_starts_at              = $matches[0][1];
 			$this->bytes_already_parsed = $url_starts_at + strlen( $this->matched_url );
 


### PR DESCRIPTION
Replacing a URL before CSS closing delimiters could consume them. The stored replacement span came from the regular-expression candidate before its trailing `)` was excluded, and quoted `url()` candidates retained the quote exposed after that parenthesis was removed.

Store the length of the accepted URL and keep surrounding quote delimiters outside it. The regression cases cover unquoted and quoted `url()`, full background shorthand, layered backgrounds, `image-set()`, percent-encoded UTF-8 paths and queries, and raw UTF-8 paths.

## Testing

- `docker compose run --rm sandbox vendor/bin/phpunit components/DataLiberation/Tests/URLInTextProcessorTest.php`
- `docker compose run --rm sandbox vendor/bin/phpcs components/DataLiberation/URL/PHP/class-phpurlintextprocessor.php components/DataLiberation/Tests/URLInTextProcessorTest.php`