### PR TITLE
[PHP] Pin the Blueprint SQLite test fixture

### DIFF
--- a/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
+++ b/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
@@ -4,6 +4,7 @@ namespace WordPress\Blueprints\Tests\Unit\Steps;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\Blueprints\DataReference\AbsoluteLocalPath;
+use WordPress\Blueprints\DataReference\DataReference;
 use WordPress\Blueprints\Runner;
 use WordPress\Blueprints\RunnerConfiguration;
 use WordPress\Blueprints\Runtime;
@@ -77,6 +78,9 @@ class StepTestCase extends TestCase {
 		$config
 			->set_blueprint( new AbsoluteLocalPath( wp_join_unix_paths( $this->execution_context_path, 'blueprint.json' ) ) )
 			->set_database_engine( 'sqlite' )
+			->set_sqlite_integration_plugin(
+				DataReference::create( 'https://downloads.wordpress.org/plugin/sqlite-database-integration.2.2.23.zip' )
+			)
 			->set_target_site_url( 'http://127.0.0.1:2456' );
 
 		$runner = new Runner( $config );


### PR DESCRIPTION
Blueprint step tests now install a fixed SQLite integration plugin release instead of downloading whichever release happens to be current.

The test setup creates a shared WordPress fixture with `sqlite-database-integration`. The unversioned download began serving 3.0.0 on August 13, which changed the generated site and made the same Blueprint tests fail across unrelated branches. Production runner configuration still uses the current plugin release; only the test fixture is pinned to 2.2.23.

The three affected `DefineConstantsStepTest` cases and `RunSQLStepTest::testHandleSQLErrors()` pass with the pinned fixture.
