### PR TITLE
[PHP] Run Blueprint tests with the current SQLite release

### DIFF
--- a/components/Blueprints/SiteResolver/class-newsiteresolver.php
+++ b/components/Blueprints/SiteResolver/class-newsiteresolver.php
@@ -7,6 +7,7 @@ use WordPress\Blueprints\DataReference\File;
 use WordPress\Blueprints\Exception\BlueprintExecutionException;
 use WordPress\Blueprints\Progress\Tracker;
 use WordPress\Blueprints\Runtime;
+use WordPress\Blueprints\Steps\DefineConstantsStep;
 use WordPress\Blueprints\VersionStrings\VersionConstraint;
 use WordPress\HttpClient\Client;
 use WordPress\HttpClient\Request;
@@ -71,10 +72,6 @@ class NewSiteResolver {
 
 		// If SQLite integration zip provided, unzip into appropriate folder.
 		if ( 'sqlite' === $runtime->get_configuration()->get_database_engine() ) {
-			/*
-			 * @TODO: Ensure DB_NAME gets defined in wp-config.php before installing the SQLite plugin.
-			 */
-
 			$progress['resolve_assets']->setCaption( 'Downloading SQLite integration plugin' );
 			$resolved = $runtime->resolve( $assets['sqlite-integration'] );
 			if ( ! $resolved instanceof File ) {
@@ -114,6 +111,13 @@ class NewSiteResolver {
 				} else {
 					throw new BlueprintExecutionException( 'Neither wp-config.php, nor wp-config-sample.php was found in the WordPress archive.' );
 				}
+			}
+
+			// Database configuration constants must be available when core installation opens its connection.
+			$blueprint = $runtime->get_blueprint();
+			if ( ! empty( $blueprint['constants'] ) && is_array( $blueprint['constants'] ) ) {
+				$define_constants_step = new DefineConstantsStep( $blueprint['constants'] );
+				$define_constants_step->run( $runtime, $progress['install_wordpress'] );
 			}
 
 			// Perform installation using WP-CLI.

--- a/components/Blueprints/Tests/Unit/Steps/DefineConstantsStepTest.php
+++ b/components/Blueprints/Tests/Unit/Steps/DefineConstantsStepTest.php
@@ -61,6 +61,8 @@ class DefineConstantsStepTest extends StepTestCase {
 
 $table_prefix = 'wp_';
 define( 'DB_NAME', 'database_name_here' );
+define( 'SQLITE_JOURNAL_MODE', 'DELETE' );
+define( 'WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS', true );
 define( 'WP_DEBUG', true );
 
 /* That's all, stop editing! */
@@ -83,6 +85,8 @@ PHP
 
 $table_prefix = 'wp_';
 define( 'DB_NAME', 'database_name_here' );
+define( 'SQLITE_JOURNAL_MODE', 'DELETE' );
+define( 'WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS', true );
 define( 'WP_DEBUG', true );
 
 
@@ -107,6 +111,8 @@ PHP
 
 $table_prefix = 'wp_';
 define( 'DB_NAME', 'database_name_here' );
+define( 'SQLITE_JOURNAL_MODE', 'DELETE' );
+define( 'WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS', true );
 define( 'WP_DEBUG', true );
 
 /** Sets up WordPress vars and included files. */
@@ -127,6 +133,8 @@ PHP
 
 $table_prefix = 'wp_';
 define( 'DB_NAME', 'database_name_here' );
+define( 'SQLITE_JOURNAL_MODE', 'DELETE' );
+define( 'WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS', true );
 define( 'WP_DEBUG', true );
 
 
@@ -148,6 +156,8 @@ PHP
 <?php
 $table_prefix = 'wp_';
 define( 'DB_NAME', 'database_name_here' );
+define( 'SQLITE_JOURNAL_MODE', 'DELETE' );
+define( 'WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS', true );
 define( 'WP_DEBUG', true );
 require_once ABSPATH . 'wp-settings.php';
 PHP
@@ -165,6 +175,8 @@ PHP
 <?php
 $table_prefix = 'wp_';
 define( 'DB_NAME', 'database_name_here' );
+define( 'SQLITE_JOURNAL_MODE', 'DELETE' );
+define( 'WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS', true );
 define( 'WP_DEBUG', true );
 
 define( 'WP_MEMORY_LIMIT', '256M' );

--- a/components/Blueprints/Tests/Unit/Steps/DefineConstantsStepTest.php
+++ b/components/Blueprints/Tests/Unit/Steps/DefineConstantsStepTest.php
@@ -60,6 +60,7 @@ class DefineConstantsStepTest extends StepTestCase {
 <?php
 
 $table_prefix = 'wp_';
+define( 'DB_NAME', 'database_name_here' );
 define( 'WP_DEBUG', true );
 
 /* That's all, stop editing! */
@@ -81,6 +82,7 @@ PHP
 <?php
 
 $table_prefix = 'wp_';
+define( 'DB_NAME', 'database_name_here' );
 define( 'WP_DEBUG', true );
 
 
@@ -104,6 +106,7 @@ PHP
 <?php
 
 $table_prefix = 'wp_';
+define( 'DB_NAME', 'database_name_here' );
 define( 'WP_DEBUG', true );
 
 /** Sets up WordPress vars and included files. */
@@ -123,6 +126,7 @@ PHP
 <?php
 
 $table_prefix = 'wp_';
+define( 'DB_NAME', 'database_name_here' );
 define( 'WP_DEBUG', true );
 
 
@@ -143,6 +147,7 @@ PHP
 			<<<'PHP'
 <?php
 $table_prefix = 'wp_';
+define( 'DB_NAME', 'database_name_here' );
 define( 'WP_DEBUG', true );
 require_once ABSPATH . 'wp-settings.php';
 PHP
@@ -159,6 +164,7 @@ PHP
 			<<<'PHP'
 <?php
 $table_prefix = 'wp_';
+define( 'DB_NAME', 'database_name_here' );
 define( 'WP_DEBUG', true );
 
 define( 'WP_MEMORY_LIMIT', '256M' );

--- a/components/Blueprints/Tests/Unit/Steps/RunSQLStepTest.php
+++ b/components/Blueprints/Tests/Unit/Steps/RunSQLStepTest.php
@@ -146,7 +146,7 @@ PHP
 	 * Test handling SQL errors
 	 */
 	public function testHandleSQLErrors() {
-		$sql = "CREATE TABLE test_table (id INT PRIMARY KEY); INSERT INTO nonexistent_table VALUES (1);";
+		$sql = "CREATE TABLE test_table (id INT PRIMARY KEY);\nINSERT INTO nonexistent_table VALUES (1);";
 		$this->execution_context->put_contents( 'test.sql', $sql );
 
 		$step = new RunSqlStep( DataReference::create( './test.sql', [

--- a/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
+++ b/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
@@ -4,7 +4,6 @@ namespace WordPress\Blueprints\Tests\Unit\Steps;
 
 use PHPUnit\Framework\TestCase;
 use WordPress\Blueprints\DataReference\AbsoluteLocalPath;
-use WordPress\Blueprints\DataReference\DataReference;
 use WordPress\Blueprints\Runner;
 use WordPress\Blueprints\RunnerConfiguration;
 use WordPress\Blueprints\Runtime;
@@ -78,9 +77,6 @@ class StepTestCase extends TestCase {
 		$config
 			->set_blueprint( new AbsoluteLocalPath( wp_join_unix_paths( $this->execution_context_path, 'blueprint.json' ) ) )
 			->set_database_engine( 'sqlite' )
-			->set_sqlite_integration_plugin(
-				DataReference::create( 'https://downloads.wordpress.org/plugin/sqlite-database-integration.3.0.0.zip' )
-			)
 			->set_target_site_url( 'http://127.0.0.1:2456' );
 
 		$runner = new Runner( $config );

--- a/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
+++ b/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
@@ -79,7 +79,7 @@ class StepTestCase extends TestCase {
 			->set_blueprint( new AbsoluteLocalPath( wp_join_unix_paths( $this->execution_context_path, 'blueprint.json' ) ) )
 			->set_database_engine( 'sqlite' )
 			->set_sqlite_integration_plugin(
-				DataReference::create( 'https://downloads.wordpress.org/plugin/sqlite-database-integration.2.2.23.zip' )
+				DataReference::create( 'https://downloads.wordpress.org/plugin/sqlite-database-integration.3.0.0.zip' )
 			)
 			->set_target_site_url( 'http://127.0.0.1:2456' );
 

--- a/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
+++ b/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
@@ -64,7 +64,13 @@ class StepTestCase extends TestCase {
 			;
 		}
 
-		$blueprint = array( 'version' => 2 );
+		$blueprint = array(
+			'version'   => 2,
+			'constants' => array(
+				'SQLITE_JOURNAL_MODE'                           => 'DELETE',
+				'WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS' => true,
+			),
+		);
 		if ( PHP_VERSION_ID < 70400 ) {
 			$blueprint['wordpressVersion'] = '6.6.2';
 		}


### PR DESCRIPTION
Blueprint step tests now install and run against the current SQLite Database Integration release instead of version 2.2.23.

The fixture uses `RunnerConfiguration`'s unversioned plugin URL, which currently serves 3.0.0. SQLite 3.0 requires a non-empty `DB_NAME`, defaults to WAL journaling, and blocks older bundled SQLite versions unless the documented compatibility constant is set. The fixture therefore supplies `DB_NAME` in its minimal configuration files and declares `SQLITE_JOURNAL_MODE=DELETE` plus `WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS=true`. Tests which replace `wp-config.php` retain those database settings.

`NewSiteResolver` applies Blueprint constants before core installation opens the database connection. The normal constants step still runs later and remains idempotent. The SQL error test also puts its successful setup query and failing query on separate lines, matching `RunSqlStep`'s line-by-line execution.

## Testing

`vendor/bin/phpunit -c phpunit.xml components/Blueprints/Tests/Unit/Steps/DefineConstantsStepTest.php` (10 tests, 15 assertions)

`vendor/bin/phpunit -c phpunit.xml --filter '/(RunSQLStepTest|SetSiteOptionsStepTest)/' components/Blueprints/Tests/Unit/Steps` (11 tests, 33 assertions)

`vendor/bin/phpcs -d memory_limit=1G components/Blueprints/SiteResolver/class-newsiteresolver.php components/Blueprints/Tests/Unit/Steps/StepTestCase.php components/Blueprints/Tests/Unit/Steps/DefineConstantsStepTest.php components/Blueprints/Tests/Unit/Steps/RunSQLStepTest.php` (one pre-existing unused-parameter warning in `class-newsiteresolver.php`; no new violations)

`git diff --check`
