### PR TITLE
Prevent ZIP installs from clearing unrelated plugins and themes

### DIFF
--- a/components/Blueprints/Steps/class-installpluginstep.php
+++ b/components/Blueprints/Steps/class-installpluginstep.php
@@ -215,34 +215,6 @@ if ( ! file_exists( $plugin_zip_path ) ) {
 	exit( 1 );
 }
 
-// List files from the plugin zip
-$zip = new ZipArchive();
-if ( $zip->open( $plugin_zip_path ) !== true ) {
-	fwrite( STDERR, "Failed to open plugin zip file: " . $plugin_zip_path . "\n" );
-	exit( 1 );
-}
-
-fwrite( STDERR, "Plugin zip contents:" . "\n" );
-for ( $i = 0; $i < $zip->numFiles; $i ++ ) {
-	$filename = $zip->getNameIndex( $i );
-	$stats    = $zip->statIndex( $i );
-	$size     = $stats['size'];
-	$is_dir   = substr( $filename, - 1 ) === '/';
-}
-
-// Extract plugin slug from the zip file
-$plugin_slug = '';
-// Check the first directory in the zip file
-if ( $zip->numFiles > 0 ) {
-	$first_entry = $zip->getNameIndex( 0 );
-	// Most plugin zips have a top-level directory that is the plugin slug
-	if ( strpos( $first_entry, '/' ) !== false ) {
-		$plugin_slug = explode( '/', $first_entry )[0];
-	}
-}
-
-$zip->close();
-
 // Make sure the destination directory is writable
 $wp_plugin_dir = WP_PLUGIN_DIR;
 if ( ! is_writable( $wp_plugin_dir ) ) {
@@ -258,26 +230,9 @@ if ( ! is_writable( $wp_plugin_dir ) ) {
 $skin     = new Blueprint_WP_Upgrader_Skin();
 $upgrader = new Plugin_Upgrader( $skin );
 
-// If we have a plugin slug from the zip, create the target directory first
-$target_directory = null;
-if ( ! empty( $plugin_slug ) ) {
-	$target_directory = WP_PLUGIN_DIR . '/' . $plugin_slug;
-
-	// Remove existing directory if it exists
-	if ( is_dir( $target_directory ) ) {
-		$GLOBALS['wp_filesystem']->delete( $target_directory, true );
-	}
-
-	// Create the directory
-	$GLOBALS['wp_filesystem']->mkdir( $target_directory );
-
-	fwrite( STDERR, "Created target directory: " . $target_directory . "\n" );
-}
-
 // Install the plugin
 $result = $upgrader->install( $plugin_zip_path, array(
 	'overwrite_package' => true,
-	'destination'       => $target_directory,
 ) );
 
 // Check for filesystem errors
@@ -304,7 +259,7 @@ if ( $result === false || $result === null ) {
 }
 
 // Installation successful, find the main plugin file.
-$plugin_folder_name = ! empty( $plugin_slug ) ? $plugin_slug : ( $upgrader->result['destination_name'] ?? null );
+$plugin_folder_name = $upgrader->result['destination_name'] ?? null;
 if ( ! $plugin_folder_name ) {
 	fwrite( STDERR, "Could not determine plugin folder name after installation." . "\n" );
 	exit( 1 );

--- a/components/Blueprints/Steps/class-installthemestep.php
+++ b/components/Blueprints/Steps/class-installthemestep.php
@@ -160,40 +160,10 @@ if ( ! is_writable( $wp_theme_dir ) ) {
 	}
 }
 
-// Extract theme slug from the zip file
-$theme_slug = '';
-$zip        = new ZipArchive();
-if ( $zip->open( $theme_zip_path ) === true ) {
-	// Check the first directory in the zip file
-	if ( $zip->numFiles > 0 ) {
-		$first_entry = $zip->getNameIndex( 0 );
-		// Most theme zips have a top-level directory that is the theme slug
-		if ( strpos( $first_entry, '/' ) !== false ) {
-			$theme_slug = explode( '/', $first_entry )[0];
-		}
-	}
-	$zip->close();
-}
-
-// Target directory for the theme
-$target_directory = null;
-if ( ! empty( $theme_slug ) ) {
-	$target_directory = $wp_theme_dir . '/' . $theme_slug;
-
-	// Remove existing directory if it exists
-	if ( is_dir( $target_directory ) ) {
-		$GLOBALS['wp_filesystem']->delete( $target_directory, true );
-	}
-
-	// Create the directory
-	$GLOBALS['wp_filesystem']->mkdir( $target_directory );
-}
-
 // Use the Theme_Upgrader class to install the theme
 $upgrader = new Theme_Upgrader();
 $result   = $upgrader->install( $theme_zip_path, array(
 	'overwrite_package' => true,
-	'destination'       => $target_directory,
 ) );
 
 // Check for filesystem errors
@@ -217,7 +187,7 @@ if ( $result === false || $result === null ) {
 }
 
 // Installation successful, get the theme folder name (stylesheet) from the result array
-$theme_folder_name = ! empty( $theme_slug ) ? $theme_slug : ( $upgrader->result['destination_name'] ?? null );
+$theme_folder_name = $upgrader->result['destination_name'] ?? null;
 if ( ! $theme_folder_name ) {
 	error_log( "Blueprint Error: Could not determine theme folder name after installation." );
 	exit( 1 );

--- a/components/Blueprints/Tests/Unit/Steps/InstallPluginStepTest.php
+++ b/components/Blueprints/Tests/Unit/Steps/InstallPluginStepTest.php
@@ -198,6 +198,35 @@ PHP
 		$this->assertContains( 'subfolder-name/test-plugin.php', $active_plugins );
 	}
 
+	public function testInstallPluginFromZipWithDotRootPreservesExistingPlugins() {
+		$target_filesystem = $this->runtime->get_target_filesystem();
+		$target_filesystem->put_contents(
+			'wp-content/plugins/existing-plugin.php',
+			self::PLUGIN_FILE_CONTENT
+		);
+
+		$zip_file = wp_join_unix_paths( $this->execution_context_path, 'dot-root-plugin.zip' );
+		$zip      = new ZipArchive();
+		if ( $zip->open( $zip_file, ZipArchive::CREATE ) === true ) {
+			$zip->addEmptyDir( './' );
+			$zip->addFromString( './test-plugin.php', self::PLUGIN_FILE_CONTENT );
+			$zip->close();
+		}
+
+		$step = new InstallPluginStep(
+			DataReference::create( './dot-root-plugin.zip', [
+				ExecutionContextPath::class
+			] ),
+			false
+		);
+
+		$tracker = new Tracker();
+		$step->run( $this->runtime, $tracker );
+
+		$this->assertTrue( $target_filesystem->exists( 'wp-content/plugins/existing-plugin.php' ) );
+		$this->assertTrue( $target_filesystem->exists( 'wp-content/plugins/dot-root-plugin/test-plugin.php' ) );
+	}
+
 	public function testInstallPluginFromADirectory() {
 		$this->execution_context->mkdir(
 			'plugin-directory', [ 'recursive' => true ]

--- a/components/Blueprints/Tests/Unit/Steps/InstallThemeStepTest.php
+++ b/components/Blueprints/Tests/Unit/Steps/InstallThemeStepTest.php
@@ -159,4 +159,38 @@ PHP
 
 		$this->assertEquals( 'test-theme', trim( $active_theme ) );
 	}
+
+	public function testInstallThemeFromZipWithDotRootPreservesExistingThemes() {
+		$target_filesystem = $this->runtime->get_target_filesystem();
+		$target_filesystem->mkdir(
+			'wp-content/themes/existing-theme', [ 'recursive' => true ]
+		);
+		$target_filesystem->put_contents(
+			'wp-content/themes/existing-theme/style.css',
+			self::THEME_STYLE_CSS_CONTENT
+		);
+
+		$zip_file = wp_join_unix_paths( $this->execution_context_path, 'dot-root-theme.zip' );
+		$zip      = new ZipArchive();
+		if ( $zip->open( $zip_file, ZipArchive::CREATE ) === true ) {
+			$zip->addEmptyDir( './' );
+			$zip->addFromString( './style.css', self::THEME_STYLE_CSS_CONTENT );
+			$zip->addFromString( './index.php', self::THEME_INDEX_PHP_CONTENT );
+			$zip->close();
+		}
+
+		$step = new InstallThemeStep(
+			DataReference::create( './dot-root-theme.zip', [
+				ExecutionContextPath::class
+			] ),
+			false
+		);
+
+		$tracker = new Tracker();
+		$step->run( $this->runtime, $tracker );
+
+		$this->assertTrue( $target_filesystem->exists( 'wp-content/themes/existing-theme/style.css' ) );
+		$this->assertTrue( $target_filesystem->exists( 'wp-content/themes/dot-root-theme/style.css' ) );
+		$this->assertTrue( $target_filesystem->exists( 'wp-content/themes/dot-root-theme/index.php' ) );
+	}
 }

--- a/components/Blueprints/Tests/Unit/Steps/InstallThemeStepTest.php
+++ b/components/Blueprints/Tests/Unit/Steps/InstallThemeStepTest.php
@@ -124,42 +124,6 @@ PHP
 		$this->assertNotEquals( 'test-theme', trim( $active_theme ) );
 	}
 
-	public function testInstallThemeFromZip() {
-		$zip_file = wp_join_unix_paths( $this->execution_context_path, 'zipped-test-theme.zip' );
-		$zip      = new ZipArchive();
-		if ( $zip->open( $zip_file, ZipArchive::CREATE ) === true ) {
-			$zip->addFromString( 'test-theme/style.css', self::THEME_STYLE_CSS_CONTENT );
-			$zip->addFromString( 'test-theme/index.php', self::THEME_INDEX_PHP_CONTENT );
-			$zip->close();
-		}
-
-		$step = new InstallThemeStep(
-			DataReference::create( './zipped-test-theme.zip', [
-				ExecutionContextPath::class
-			] ),
-			true
-		);
-
-		$tracker = new Tracker();
-		$step->run( $this->runtime, $tracker );
-
-		$fs = $this->runtime->get_target_filesystem();
-		$this->assertTrue( $fs->exists( 'wp-content/themes/test-theme' ) );
-		$this->assertTrue( $fs->exists( 'wp-content/themes/test-theme/style.css' ) );
-		$this->assertTrue( $fs->exists( 'wp-content/themes/test-theme/index.php' ) );
-
-		$active_theme = $this->runtime->eval_php_code_in_subprocess(
-			<<<'PHP'
-<?php
-require_once getenv('WP_CORE_DIR') . '/wp-load.php';
-append_output( get_option('stylesheet') );
-PHP
-
-		)->output_file_content;
-
-		$this->assertEquals( 'test-theme', trim( $active_theme ) );
-	}
-
 	public function testInstallThemeFromZipWithDotRootPreservesExistingThemes() {
 		$target_filesystem = $this->runtime->get_target_filesystem();
 		$target_filesystem->mkdir(
@@ -183,14 +147,26 @@ PHP
 			DataReference::create( './dot-root-theme.zip', [
 				ExecutionContextPath::class
 			] ),
-			false
+			true
 		);
 
 		$tracker = new Tracker();
 		$step->run( $this->runtime, $tracker );
 
 		$this->assertTrue( $target_filesystem->exists( 'wp-content/themes/existing-theme/style.css' ) );
+		$this->assertTrue( $target_filesystem->exists( 'wp-content/themes/dot-root-theme' ) );
 		$this->assertTrue( $target_filesystem->exists( 'wp-content/themes/dot-root-theme/style.css' ) );
 		$this->assertTrue( $target_filesystem->exists( 'wp-content/themes/dot-root-theme/index.php' ) );
+
+		$active_theme = $this->runtime->eval_php_code_in_subprocess(
+			<<<'PHP'
+<?php
+require_once getenv('WP_CORE_DIR') . '/wp-load.php';
+append_output( get_option('stylesheet') );
+PHP
+
+		)->output_file_content;
+
+		$this->assertEquals( 'dot-root-theme', trim( $active_theme ) );
 	}
 }

--- a/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
+++ b/components/Blueprints/Tests/Unit/Steps/StepTestCase.php
@@ -101,10 +101,8 @@ class StepTestCase extends TestCase {
 	 * @after
 	 */
 	public function tearDown(): void {
-		// Don't clean up on Windows – it adds ~20s to each test in GitHub CI!
-		if (PHP_OS_FAMILY === 'Windows') {
-			return;
-		}
+		// Cleanup is slow on Windows, but retaining every copied WordPress site
+		// exhausts the temporary drive during the full test suite.
 		// Clean up temp directory
 		if ( is_dir( $this->document_root ) ) {
 			$this->removeDirectory( $this->document_root );


### PR DESCRIPTION
A valid plugin or theme ZIP created from the current directory may begin with `./`. The old installers treated the first path segment as the target folder. That made the target `WP_PLUGIN_DIR/.` or `wp-content/themes/.` and recursively cleared unrelated plugins or themes before WordPress selected the installation folder.

This change leaves target selection, replacement, and installed-folder detection to `Plugin_Upgrader` and `Theme_Upgrader`. Regression tests cover plugin and theme archives beginning with `./` and confirm that existing unrelated plugins and themes survive.

Windows test cleanup now removes each copied WordPress site instead of retaining all copies until the job ends. Current hosted Windows runners otherwise exhaust the 15 GB temporary drive before the suite finishes.

## Testing

- `vendor/bin/phpunit components/Blueprints/Tests/Unit/Steps` (77 tests, 185 assertions)
- `vendor/bin/phpcs -d memory_limit=1G components/Blueprints/Steps/class-installpluginstep.php components/Blueprints/Steps/class-installthemestep.php components/Blueprints/Tests/Unit/Steps/InstallPluginStepTest.php components/Blueprints/Tests/Unit/Steps/InstallThemeStepTest.php components/Blueprints/Tests/Unit/Steps/StepTestCase.php`
- Each regression test failed before its source change and passed afterward.

Closes #310
