### PR TITLE
[PHP] Parse namespaced block comment names

### DIFF
--- a/components/DataLiberation/BlockMarkup/class-blockmarkupprocessor.php
+++ b/components/DataLiberation/BlockMarkup/class-blockmarkupprocessor.php
@@ -358,8 +358,10 @@ class BlockMarkupProcessor extends WP_HTML_Tag_Processor {
 		// Skip wp.
 		$at += 3;
 
-		// Parse the actual block name after wp.
-		$name_length = strspn( $text, 'abcdefghijklmnopqrstuwxvyzABCDEFGHIJKLMNOPRQSTUWXVYZ0123456789_-', $at );
+		// Parse the actual block name after wp. Core block names use the short
+		// `wp:name` form. Other blocks use `wp:namespace/name`.
+		$block_name_characters = 'abcdefghijklmnopqrstuwxvyzABCDEFGHIJKLMNOPRQSTUWXVYZ0123456789_-';
+		$name_length           = strspn( $text, $block_name_characters, $at );
 		if ( 0 === $name_length ) {
 			// This wasn't a block after all, just a regular comment.
 			$this->last_block_error = new WP_Error(
@@ -368,6 +370,21 @@ class BlockMarkupProcessor extends WP_HTML_Tag_Processor {
 			);
 
 			return true;
+		}
+
+		$namespace_separator_at = $at + $name_length;
+		if ( $namespace_separator_at < strlen( $text ) && '/' === $text[ $namespace_separator_at ] ) {
+			$name_after_namespace_length = strspn( $text, $block_name_characters, $namespace_separator_at + 1 );
+			if ( 0 === $name_after_namespace_length ) {
+				$this->last_block_error = new WP_Error(
+					'suspicious-delimiter',
+					sprintf( 'An HTML comment contained a block namespace that was not followed by a valid block name: %s', $text )
+				);
+
+				return true;
+			}
+
+			$name_length += 1 + $name_after_namespace_length;
 		}
 		$name = substr( $text, $name_starts_at, $name_length + 3 );
 		$at  += $name_length;

--- a/components/DataLiberation/Tests/BlockMarkupProcessorTest.php
+++ b/components/DataLiberation/Tests/BlockMarkupProcessorTest.php
@@ -21,6 +21,7 @@ class BlockMarkupProcessorTest extends TestCase {
 		return array(
 			'Opener with a line break before whitespace'       => array( "<!-- \nwp:paragraph -->", 'wp:paragraph', array() ),
 			'Opener without attributes'                        => array( '<!-- wp:paragraph -->', 'wp:paragraph', array() ),
+			'Namespaced opener without attributes'             => array( '<!-- wp:divi/text -->', 'wp:divi/text', array() ),
 			'Opener without the trailing whitespace'           => array( '<!--wp:paragraph-->', 'wp:paragraph', array() ),
 			'Opener with a lot of trailing whitespace'         => array( '<!--    wp:paragraph          -->', 'wp:paragraph', array() ),
 			'Opener with attributes'                           => array(
@@ -73,6 +74,11 @@ class BlockMarkupProcessorTest extends TestCase {
 				'wp:spacer',
 				array( 'height' => '20px' ),
 			),
+			'Namespaced self-closing block with attributes' => array(
+				'<!-- wp:divi/text {"content":"Hello"} /-->',
+				'wp:divi/text',
+				array( 'content' => 'Hello' ),
+			),
 		);
 	}
 
@@ -91,6 +97,7 @@ class BlockMarkupProcessorTest extends TestCase {
 	public static function provider_test_finds_block_closers() {
 		return array(
 			'Closer without attributes'                => array( '<!-- /wp:paragraph -->', 'wp:paragraph' ),
+			'Namespaced closer without attributes'     => array( '<!-- /wp:divi/text -->', 'wp:divi/text' ),
 			'Closer without the trailing whitespace'   => array( '<!--/wp:paragraph-->', 'wp:paragraph' ),
 			'Closer with a lot of trailing whitespace' => array( '<!--    /wp:paragraph          -->', 'wp:paragraph' ),
 		);
@@ -112,6 +119,7 @@ class BlockMarkupProcessorTest extends TestCase {
 		return array(
 			'Block name including !'                  => array( '<!-- wp:pa!ragraph -->' ),
 			'Block name including a whitespace'       => array( '<!-- wp: paragraph -->' ),
+			'Namespace without a block name'           => array( '<!-- wp:divi/ -->' ),
 			'No namespace in the block name'          => array( '<!-- paragraph -->' ),
 			'Non-object attributes'                   => array( '<!-- wp:paragraph "attrs" -->' ),
 			'Invalid JSON as attributes – Double }} ' => array( '<!-- wp:paragraph {"class":"wp-block"}} -->' ),


### PR DESCRIPTION
Recognizes custom block delimiters such as `<!-- wp:divi/text {"content":"Hello"} /-->` as block comments.

`BlockMarkupProcessor` previously stopped reading the name at `/`. It read `wp:divi`, tried to parse `/text ...` as JSON, and returned an ordinary `#comment`. The processor now accepts one namespace separator and requires a block name after it. The short core form, such as `wp:paragraph`, remains unchanged.

## Testing

The block processor tests cover namespaced openers, self-closing blocks, closers, and a namespace without a block name. The new namespaced cases fail with the previous parser and pass with this change.

```
vendor/bin/phpunit components/DataLiberation/Tests/BlockMarkupProcessorTest.php
vendor/bin/phpcs -d memory_limit=1G components/DataLiberation/BlockMarkup/class-blockmarkupprocessor.php
```