### PR TITLE
Apply NUL preprocessing to unquoted CSS URLs

### DIFF
--- a/components/DataLiberation/CSS/class-cssprocessor.php
+++ b/components/DataLiberation/CSS/class-cssprocessor.php
@@ -31,6 +31,9 @@ use function WordPress\Encoding\wp_scrub_utf8;
  * This processor delays normalization as much as possible. That keeps the raw byte
  * positions intact for accurate rewrites while still letting consumers ask for a
  * normalized token when they need one.
+ * For example, url(a<NUL>b) is a URL token whose value is a�b, where <NUL>
+ * means one zero byte in the source. That byte stays in the raw token, so later
+ * edits still use byte offsets from the original input.
  *
  * ### No EOF token
  *
@@ -1649,8 +1652,10 @@ class CSSProcessor {
 				"'" === $this->css[ $this->at ] ||
 				'(' === $this->css[ $this->at ] ||
 
-				// Non-printable code point.
-				$byte <= 0x08 ||
+				// NUL becomes U+FFFD during CSS preprocessing, so it is valid here.
+				// Keep its source byte for offsets; decode_range() replaces it when
+				// the caller reads the value. Other non-printable controls stay invalid.
+				( $byte >= 0x01 && $byte <= 0x08 ) ||
 
 				// Line Tabulation.
 				0x0B === $byte ||

--- a/components/DataLiberation/Tests/CSSPreprocessingTest.php
+++ b/components/DataLiberation/Tests/CSSPreprocessingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WordPress\DataLiberation\CSS\CSSProcessor;
+
+/** Checks CSS preprocessing without replacing the source bytes used for edits. */
+class CSSPreprocessingTest extends TestCase {
+	/**
+	 * NUL has the value U+FFFD during parsing, but still occupies one source byte.
+	 * Other forbidden control bytes must continue to produce bad URL tokens.
+	 *
+	 * @dataProvider preprocessing_cases
+	 */
+	public function test_preprocessed_token_keeps_source_bytes( $input, $type, $value ) {
+		$processor = CSSProcessor::create( $input );
+		$this->assertTrue( $processor->next_token() );
+		$this->assertSame( $type, $processor->get_token_type() );
+		$this->assertSame( $value, $processor->get_token_value() );
+		$this->assertSame( $input, $processor->get_unnormalized_token() );
+		$this->assertSame( 0, $processor->get_token_start() );
+		$this->assertSame( strlen( $input ), $processor->get_token_length() );
+		$this->assertFalse( $processor->next_token() );
+		$this->assertSame( $input, $processor->get_updated_css() );
+	}
+
+	/**
+	 * Restores JSON state at every byte split, including beside NUL and inside CRLF or an escape.
+	 * The expected token is specified by the test, not copied from a whole-string parse.
+	 *
+	 * @dataProvider preprocessing_cases
+	 */
+	public function test_preprocessing_survives_split_input_and_resume( $input, $type, $value ) {
+		for ( $split = 0; $split <= strlen( $input ); ++$split ) {
+			$processor = CSSProcessor::create_for_streaming();
+			$output = '';
+			$tokens = array();
+			foreach ( array( substr( $input, 0, $split ), substr( $input, $split ) ) as $index => $chunk ) {
+				$processor->append_bytes( $chunk, 1 === $index );
+				while ( $processor->next_token() ) {
+					$tokens[] = array( $processor->get_token_type(), $processor->get_token_value(), $processor->get_unnormalized_token() );
+				}
+				$output .= $processor->flush_processed_css();
+				$cursor = json_decode( json_encode( $processor->get_reentrancy_cursor() ), true );
+				$processor = CSSProcessor::create_for_streaming( $cursor );
+			}
+			$this->assertSame( array( array( $type, $value, $input ) ), $tokens, 'Split at byte ' . $split );
+			$this->assertSame( $input, $output, 'Split at byte ' . $split );
+		}
+	}
+
+	/** Supplies valid NUL values and nearby cases that must remain invalid CSS URLs. */
+	public static function preprocessing_cases() {
+		yield 'NUL as the URL' => array( "url(\x00)", CSSProcessor::TOKEN_URL, "\u{FFFD}" );
+		yield 'NUL before text' => array( "url(\x00a)", CSSProcessor::TOKEN_URL, "\u{FFFD}a" );
+		yield 'NUL inside text' => array( "url(a\x00b)", CSSProcessor::TOKEN_URL, "a\u{FFFD}b" );
+		yield 'NUL before closing parenthesis' => array( "url(a\x00)", CSSProcessor::TOKEN_URL, "a\u{FFFD}" );
+		yield 'NUL before EOF' => array( "url(a\x00", CSSProcessor::TOKEN_URL, "a\u{FFFD}" );
+		yield 'consecutive NUL bytes' => array( "url(a\x00\x00b)", CSSProcessor::TOKEN_URL, "a\u{FFFD}\u{FFFD}b" );
+		yield 'escaped literal NUL' => array( "url(a\\\x00b)", CSSProcessor::TOKEN_URL, "a\u{FFFD}b" );
+		yield 'zero escape' => array( 'url(a\0 b)', CSSProcessor::TOKEN_URL, "a\u{FFFD}b" );
+		yield 'zero escape followed by CRLF' => array( "url(a\\0\r\nb)", CSSProcessor::TOKEN_URL, "a\u{FFFD}b" );
+		yield 'NUL followed by trailing CRLF' => array( "url(a\x00\r\n)", CSSProcessor::TOKEN_URL, "a\u{FFFD}" );
+		yield 'NUL in a string' => array( "\"a\x00b\"", CSSProcessor::TOKEN_STRING, "a\u{FFFD}b" );
+		yield 'NUL in a name' => array( "a\x00b", CSSProcessor::TOKEN_IDENT, "a\u{FFFD}b" );
+		yield 'NUL after trailing whitespace' => array( "url(a \x00)", CSSProcessor::TOKEN_BAD_URL, null );
+		yield 'NUL after a forbidden control' => array( "url(a\x01\x00b)", CSSProcessor::TOKEN_BAD_URL, null );
+		foreach ( array( "\t", "\n", "\r", "\f", "\r\n" ) as $whitespace ) {
+			yield 'internal whitespace ' . bin2hex( $whitespace ) => array( 'url(a' . $whitespace . 'b)', CSSProcessor::TOKEN_BAD_URL, null );
+		}
+		foreach ( array_merge( range( 1, 8 ), array( 0x0B ), range( 0x0E, 0x1F ), array( 0x7F ) ) as $byte ) {
+			yield 'forbidden control ' . dechex( $byte ) => array( 'url(a' . chr( $byte ) . 'b)', CSSProcessor::TOKEN_BAD_URL, null );
+		}
+	}
+}

--- a/components/DataLiberation/Tests/CSSStreamProcessTest.php
+++ b/components/DataLiberation/Tests/CSSStreamProcessTest.php
@@ -53,6 +53,40 @@ class CSSStreamProcessTest extends TestCase {
 		$this->assertSame( strlen( $expected ), $state['output_bytes'] );
 	}
 
+	/**
+	 * Places NUL at the end of the second 32 KiB read, inside an unfinished URL.
+	 * Resume must retain that byte, rewrite the URL, and leave a later bad URL unchanged.
+	 *
+	 * @dataProvider interruptions
+	 */
+	public function test_nul_preprocessing_preserves_file_offsets_after_resume( $stop ) {
+		$first = 'a{src:url(https://old.example/first.png)}';
+		$url_start = 'a{src:url(https://old.example/a';
+		$comment = '/*' . str_repeat( 'x', 65535 - strlen( $first . '/**/' . $url_start ) ) . '*/';
+		$bad_url = "a{src:url(https://old.example/bad\x01.png)}";
+		$input = $first . $comment . $url_start . "\x00b.png)}" . $bad_url
+			. 'a{src:url(https://old.example/last.png)}';
+		$expected = 'a{src:url("https://old.example/moved/first.png")}' . $comment
+			. "a{src:url(\"https://old.example/moved/a\u{FFFD}b.png\")}" . $bad_url
+			. 'a{src:url("https://old.example/moved/last.png")}';
+		$this->assertSame( "\x00", $input[65535] );
+		file_put_contents( $this->directory . '/source.css', $input );
+		$this->assertSame( 'none' === $stop ? 0 : 99, $this->run_worker( $stop ), file_get_contents( $this->directory . '/worker.log' ) );
+		if ( 'none' !== $stop ) {
+			$state = json_decode( file_get_contents( $this->directory . '/state.json' ), true );
+			$this->assertSame( 'before' === $stop ? 32768 : 65536, $state['source_bytes'] );
+			if ( 'after' === $stop ) {
+				$this->assertStringContainsString( "\x00", base64_decode( $state['css']['pending_b64'] ) );
+			}
+			$this->assertSame( 0, $this->run_worker( 'none' ), file_get_contents( $this->directory . '/worker.log' ) );
+		}
+		$this->assertSame( $expected, file_get_contents( $this->directory . '/target.css' ) );
+		$this->assertSame( $input, file_get_contents( $this->directory . '/source.css' ) );
+		$state = json_decode( file_get_contents( $this->directory . '/state.json' ), true );
+		$this->assertSame( strlen( $input ), $state['source_bytes'] );
+		$this->assertSame( strlen( $expected ), $state['output_bytes'] );
+	}
+
 	/** Runs through completion or exits on either side of the second file checkpoint. */
 	public static function interruptions() {
 		return array( array( 'none' ), array( 'before' ), array( 'after' ) );

--- a/components/DataLiberation/Tests/CSSURLContextProcessTest.php
+++ b/components/DataLiberation/Tests/CSSURLContextProcessTest.php
@@ -32,6 +32,20 @@ class CSSURLContextProcessTest extends TestCase {
 		$this->assertSame( $input, file_get_contents( $this->directory . '/source.css' ) );
 	}
 
+	/** NUL-containing URLs can be rewritten; other controls still make a URL invalid. */
+	public function test_file_rewrite_applies_nul_preprocessing_before_url_validation() {
+		$comment = "/* Keep this NUL: \x00 and these line endings: \r\n\f */";
+		$bad_url = "a{src:url(https://old.example/bad\x01.png)}";
+		$input = $comment . "a{src:url(https://old.example/a\x00b.png)}" . $bad_url
+			. 'a{src:url(https://old.example/last.png)}';
+		$expected = $comment . "a{src:url(\"https://new.example/a\u{FFFD}b.png\")}" . $bad_url
+			. 'a{src:url("https://new.example/last.png")}';
+		file_put_contents( $this->directory . '/source.css', $input );
+		$this->assertSame( 0, $this->run_worker(), file_get_contents( $this->directory . '/worker.log' ) );
+		$this->assertSame( $expected, file_get_contents( $this->directory . '/target.css' ) );
+		$this->assertSame( $input, file_get_contents( $this->directory . '/source.css' ) );
+	}
+
 	/** The caller must not publish a stylesheet after URL-context tracking rejects excessive nesting. */
 	public function test_nesting_failure_leaves_the_existing_output_untouched() {
 		$input = 'a{src:' . str_repeat( 'image-set(', 129 ) . '"https://old.example/a"' . str_repeat( ')', 129 ) . '}';


### PR DESCRIPTION
Recognizes unquoted CSS URLs that contain a NUL byte, so URL rewriting does not skip them.

CSS replaces NUL with U+FFFD before it decides which token to produce. The parser already applied that replacement when reading a value, but its unquoted URL check rejected the raw NUL first. This change lets that byte reach the existing decoder. See [CSS input preprocessing](https://drafts.csswg.org/css-syntax-3/#input-preprocessing).

## Examples

`<NUL>` below means one zero byte in the input, not the five printed characters.

| Input | Before | After |
| --- | --- | --- |
| `url(a<NUL>b)` | Bad URL token; skipped by the URL iterator. | URL token with the value `a�b`. |
| `url(a<NUL>)` | Bad URL token. | URL token with the value `a�`. |
| `url(a <NUL>)` | Bad URL token. | Still invalid: text follows trailing whitespace. |

Other forbidden control bytes, such as `0x01`, still produce bad URL tokens. The original NUL stays in the raw source and saved cursor. Source offsets therefore still refer to the original file. Unchanged CSS keeps its original bytes.

## Testing

The new tests cover NUL at each position in a URL, consecutive NULs, escaped NUL, EOF, CRLF, and every other forbidden ASCII control byte. Each case also runs at every possible two-chunk split, with JSON state restored between chunks.

Real-file tests use child PHP processes. They rewrite a NUL-containing URL, keep a bad URL unchanged, and continue to a later valid URL. Streaming tests place NUL at the end of the second 32 KiB read and resume after stops before and after saving state. They check the exact output, the unchanged source, and both saved file offsets.

On base commit `8e411e7c`, 18 new cases fail, including all four new file-based cases. With this change, all 98 new cases pass. The full DataLiberation suite passes with 2,716 tests and 16 skips. PHP CodeSniffer passes.

This PR is based on `trunk` and does not depend on #314.
