### PR TITLE
Encoding: stop ASCII scanning at the requested character limit

### DIFF
--- a/components/DataLiberation/Tests/CSSURLStreamProcessTest.php
+++ b/components/DataLiberation/Tests/CSSURLStreamProcessTest.php
@@ -22,7 +22,7 @@ class CSSURLStreamProcessTest extends TestCase {
 		rmdir( $this->directory );
 	}
 
-	/** A multi-chunk stylesheet with few URLs must finish within the worker's CPU budget. */
+	/** A multi-chunk stylesheet with few URLs must finish within the worker's execution budget. */
 	public function test_large_stylesheet_rewrite_does_not_rescan_ascii_suffixes() {
 		$rules = str_repeat( '.card{color:red;margin:10px}', 100000 );
 		$input = $rules . 'a{src:url(https://old.example/photo.png)}';

--- a/components/DataLiberation/Tests/CSSURLStreamProcessTest.php
+++ b/components/DataLiberation/Tests/CSSURLStreamProcessTest.php
@@ -22,6 +22,22 @@ class CSSURLStreamProcessTest extends TestCase {
 		rmdir( $this->directory );
 	}
 
+	/** A multi-chunk stylesheet with few URLs must finish within the worker's CPU budget. */
+	public function test_large_stylesheet_rewrite_does_not_rescan_ascii_suffixes() {
+		$rules = str_repeat( '.card{color:red;margin:10px}', 100000 );
+		$input = $rules . 'a{src:url(https://old.example/photo.png)}';
+		$expected = $rules . 'a{src:url("https://new.example/photo.png")}';
+		file_put_contents( $this->directory . '/source.css', $input );
+		$arguments = array( PHP_BINARY, __DIR__ . '/fixtures/css-stream/rewrite-large-file.php', $this->directory . '/source.css', $this->directory . '/target.css' );
+		$command = implode( ' ', array_map( 'escapeshellarg', $arguments ) );
+		$process = proc_open( $command, array( 0 => array( 'pipe', 'r' ), 1 => array( 'file', $this->directory . '/worker.log', 'w' ), 2 => array( 'file', $this->directory . '/worker.log', 'a' ) ), $pipes, null, null, array( 'bypass_shell' => true ) );
+		$this->assertIsResource( $process );
+		fclose( $pipes[0] );
+		$this->assertSame( 0, proc_close( $process ), file_get_contents( $this->directory . '/worker.log' ) );
+		$this->assertSame( hash( 'sha256', $expected ), hash_file( 'sha256', $this->directory . '/target.css' ) );
+		$this->assertSame( $input, file_get_contents( $this->directory . '/source.css' ) );
+	}
+
 	/**
 	 * Checks an uninterrupted rewrite and two runs that exit before or after saving state.
 	 * A new process must finish each stopped run with the exact expected file bytes.

--- a/components/DataLiberation/Tests/CSSURLStreamProcessTest.php
+++ b/components/DataLiberation/Tests/CSSURLStreamProcessTest.php
@@ -22,7 +22,7 @@ class CSSURLStreamProcessTest extends TestCase {
 		rmdir( $this->directory );
 	}
 
-	/** A multi-chunk stylesheet with few URLs must finish within the worker's execution budget. */
+	/** A multi-chunk stylesheet with few URLs must not trigger repeated scans of its remaining bytes. */
 	public function test_large_stylesheet_rewrite_does_not_rescan_ascii_suffixes() {
 		$rules = str_repeat( '.card{color:red;margin:10px}', 100000 );
 		$input = $rules . 'a{src:url(https://old.example/photo.png)}';

--- a/components/DataLiberation/Tests/fixtures/css-stream/rewrite-large-file.php
+++ b/components/DataLiberation/Tests/fixtures/css-stream/rewrite-large-file.php
@@ -1,26 +1,42 @@
 <?php
 
-require dirname( __DIR__, 5 ) . '/bootstrap.php';
-
-use WordPress\DataLiberation\URL\CSSURLProcessor;
-
-// A one-character UTF-8 check must not scan the rest of a 1 MiB chunk.
-// Ten seconds leaves room for slow CI workers, but stops the old repeated
-// suffix scans before they hold up the rest of the test suite.
-set_time_limit( 10 );
-$input = fopen( $argv[1], 'rb' );
-$output = fopen( $argv[2], 'wb' );
-$processor = CSSURLProcessor::create_for_streaming();
-while ( ! feof( $input ) ) {
-	$processor->append_bytes( fread( $input, 1048576 ) );
-	if ( feof( $input ) ) {
-		$processor->input_finished();
+namespace WordPress\Encoding\compat {
+	// PHP resolves the helper's unqualified strspn() call here in this worker
+	// only. Run the real native scan, but count its returned ASCII bytes so
+	// the test measures repeated work without depending on the CI runner's speed.
+	function strspn( $bytes, $characters, $offset, $length ) {
+		static $ascii_bytes_scanned = 0;
+		$count = \strspn( $bytes, $characters, $offset, $length );
+		$ascii_bytes_scanned += $count;
+		if ( $ascii_bytes_scanned > ASCII_SCAN_BYTE_BUDGET ) {
+			throw new \RuntimeException( 'UTF-8 ASCII scans read more than eight times the stylesheet size.' );
+		}
+		return $count;
 	}
-	while ( $processor->next_url() ) {
-		$processor->set_raw_url( 'https://new.example/photo.png' );
+}
+
+namespace {
+	use WordPress\DataLiberation\URL\CSSURLProcessor;
+
+	// CSS may inspect a character more than once to classify a token, but
+	// scanning each remaining 1 MiB suffix would exceed this generous budget.
+	define( 'WordPress\Encoding\compat\ASCII_SCAN_BYTE_BUDGET', 8 * filesize( $argv[1] ) );
+	require dirname( __DIR__, 5 ) . '/bootstrap.php';
+
+	$input = fopen( $argv[1], 'rb' );
+	$output = fopen( $argv[2], 'wb' );
+	$processor = CSSURLProcessor::create_for_streaming();
+	while ( ! feof( $input ) ) {
+		$processor->append_bytes( fread( $input, 1048576 ) );
+		if ( feof( $input ) ) {
+			$processor->input_finished();
+		}
+		while ( $processor->next_url() ) {
+			$processor->set_raw_url( 'https://new.example/photo.png' );
+			fwrite( $output, $processor->flush_processed_css() );
+		}
 		fwrite( $output, $processor->flush_processed_css() );
 	}
-	fwrite( $output, $processor->flush_processed_css() );
+	fclose( $input );
+	fclose( $output );
 }
-fclose( $input );
-fclose( $output );

--- a/components/DataLiberation/Tests/fixtures/css-stream/rewrite-large-file.php
+++ b/components/DataLiberation/Tests/fixtures/css-stream/rewrite-large-file.php
@@ -1,0 +1,26 @@
+<?php
+
+require dirname( __DIR__, 5 ) . '/bootstrap.php';
+
+use WordPress\DataLiberation\URL\CSSURLProcessor;
+
+// A one-character UTF-8 check must not scan the rest of a 1 MiB chunk.
+// Ten seconds leaves room for slow CI workers, but stops the old repeated
+// suffix scans before they hold up the rest of the test suite.
+set_time_limit( 10 );
+$input = fopen( $argv[1], 'rb' );
+$output = fopen( $argv[2], 'wb' );
+$processor = CSSURLProcessor::create_for_streaming();
+while ( ! feof( $input ) ) {
+	$processor->append_bytes( fread( $input, 1048576 ) );
+	if ( feof( $input ) ) {
+		$processor->input_finished();
+	}
+	while ( $processor->next_url() ) {
+		$processor->set_raw_url( 'https://new.example/photo.png' );
+		fwrite( $output, $processor->flush_processed_css() );
+	}
+	fwrite( $output, $processor->flush_processed_css() );
+}
+fclose( $input );
+fclose( $output );

--- a/components/Encoding/Tests/Utf8ScanTest.php
+++ b/components/Encoding/Tests/Utf8ScanTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use function WordPress\Encoding\compat\_wp_scan_utf8;
+
+class Utf8ScanTest extends TestCase {
+
+	/** @dataProvider scan_limits */
+	public function test_scan_stops_at_the_requested_byte_or_character_limit( $bytes, $start, $max_bytes, $max_characters, $expected_count, $expected_offset, $expected_invalid ) {
+		$at = $start;
+		$invalid_length = 0;
+		$count = _wp_scan_utf8( $bytes, $at, $invalid_length, $max_bytes, $max_characters );
+
+		$this->assertSame( $expected_count, $count );
+		$this->assertSame( $expected_offset, $at );
+		$this->assertSame( $expected_invalid, $invalid_length );
+	}
+
+	public static function scan_limits() {
+		return array(
+			'one ASCII character' => array( 'abcdef', 0, null, 1, 1, 1, 0 ),
+			'no characters' => array( 'abcdef', 0, null, 0, 0, 0, 0 ),
+			'nonzero offset' => array( 'abcdef', 2, null, 2, 2, 4, 0 ),
+			'byte limit first' => array( 'abcdef', 0, 2, 4, 2, 2, 0 ),
+			'character limit first' => array( 'abcdef', 0, 4, 2, 2, 2, 0 ),
+			'unlimited scan' => array( 'abcdef', 0, null, null, 6, 6, 0 ),
+			'limit beyond input' => array( 'abcdef', 0, null, 10, 6, 6, 0 ),
+			'multibyte then ASCII' => array( "\xc3\xb1abcd", 0, null, 2, 2, 3, 0 ),
+			'stop after multibyte' => array( "\xc3\xb1abcd", 0, null, 1, 1, 2, 0 ),
+			'ASCII then multibyte' => array( "a\xc3\xb1b", 0, null, 2, 2, 3, 0 ),
+			'invalid byte beyond limit' => array( "ab\xff", 0, null, 2, 2, 2, 0 ),
+			'invalid byte before limit' => array( "ab\xff", 0, null, 3, 2, 2, 1 ),
+		);
+	}
+}

--- a/components/Encoding/compat-utf8.php
+++ b/components/Encoding/compat-utf8.php
@@ -60,6 +60,9 @@ function _wp_scan_utf8( string $bytes, int &$at, int &$invalid_length, ?int $max
 		 *
 		 * This optimization step improves the speed from 10x to 100x
 		 * depending on whether the JIT has optimized the function.
+		 * Each ASCII byte is one code point. Limit the scan to the requested
+		 * count too: CSS asks for one character at each token boundary, and
+		 * scanning the remaining input first would repeat work at every token.
 		 */
 		$ascii_byte_count = strspn(
 			$bytes,
@@ -67,7 +70,7 @@ function _wp_scan_utf8( string $bytes, int &$at, int &$invalid_length, ?int $max
 			"\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f" .
 			" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f",
 			$i,
-			$end - $i
+			min( $end - $i, $max_count - $count )
 		);
 
 		if ( $count + $ascii_byte_count >= $max_count ) {


### PR DESCRIPTION
Stops a one-character UTF-8 read from scanning the rest of the ASCII input. This removes the repeated scans that make full-site CSS downloads time out in WordPress/reprint#764.

For `.card{color:red;margin:10px}`, the CSS parser asks `_wp_scan_utf8()` whether a token-boundary byte can start a name. It requests one character. The helper's `strspn()` nevertheless scans the entire remaining ASCII suffix before returning a count of one. Doing this at each boundary makes larger stylesheets much slower.

Each ASCII byte is one character. Limit `strspn()` to the smaller of the remaining byte budget and character budget. Returned counts, byte offsets, and invalid-byte handling stay the same.

## Tests

The new process test reads a 2.8 MB stylesheet in 1 MiB chunks, rewrites its final URL, and checks the output hash and unchanged source. The worker counts the bytes returned by the real native ASCII scan. It fails if those scans read more than eight times the input size. The released code crosses that limit after only 99 source bytes; the corrected scanner completes the file and its exact output check. This tests repeated work without depending on runner speed. Twelve scanner cases cover byte and character limits, nonzero offsets, multibyte text, and invalid bytes before or after the limit.

The same nine Reprint WordPress E2E tests took 150.9 seconds with v0.10.0 and 11.0 seconds with this one-line change applied to an isolated container's dependency copy. They check actual migrated page, stylesheet, image, and font requests, plus interrupted downloads and resume failures. No test time limit was raised.

All 29 CI checks pass, including PHP 7.2–8.5 on Linux, macOS, and Windows, lint, and documentation snippets. The nine child-process CSS tests also pass locally. The full local suite ran 6,049 tests and had one Blueprint failure about missing PHP error text; the same case fails with the unchanged UTF-8 code. The full local lint command reports existing warnings in unrelated files.
