### PR TITLE
Leave fragment-only references alone when rewriting URLs

### DIFF
--- a/components/DataLiberation/Tests/RewriteUrlsTest.php
+++ b/components/DataLiberation/Tests/RewriteUrlsTest.php
@@ -213,6 +213,30 @@ MARKUP
 				'https://🚀-science.com/science',
 				'https://science.wordpress.org',
 			),
+			'Fragment-only reference in an HTML attribute is left alone' => array(
+				'<a href="#section">Jump</a>',
+				'<a href="#section">Jump</a>',
+				'https://legacy-blog.com',
+				'https://modern-webstore.org',
+			),
+			'Bare hash in an HTML attribute is left alone' => array(
+				'<a href="#">Placeholder</a>',
+				'<a href="#">Placeholder</a>',
+				'https://legacy-blog.com',
+				'https://modern-webstore.org',
+			),
+			'Fragment-only reference in a block attribute is left alone' => array(
+				'<!-- wp:button {"url":"#login"} -->',
+				'<!-- wp:button {"url":"#login"} -->',
+				'https://legacy-blog.com',
+				'https://modern-webstore.org',
+			),
+			'Absolute URL carrying a fragment is still rewritten and keeps its fragment' => array(
+				'<a href="https://legacy-blog.com/page#section">Deep link</a>',
+				'<a href="https://modern-webstore.org/page#section">Deep link</a>',
+				'https://legacy-blog.com',
+				'https://modern-webstore.org',
+			),
 		);
 	}
 

--- a/components/DataLiberation/URL/functions.php
+++ b/components/DataLiberation/URL/functions.php
@@ -70,7 +70,20 @@ function wp_rewrite_urls( $options ) {
 	while ( $p->next_url() ) {
 		$token_type = $p->get_token_type();
 		$raw_url    = $p->get_raw_url();
-		$cache_key  = $mapping_cache_key . "\0" . $token_type . "\0" . $raw_url;
+
+		/*
+		 * Leave fragment-only references alone. A URL like `#section` points
+		 * within the document that contains it, so there is no origin to
+		 * migrate. Resolving it against the base URL makes it look like a
+		 * child of the site being imported from, and rewriting it then turns
+		 * an in-page anchor into a link somewhere else entirely:
+		 * `#section` becomes `/#section`, and a bare `#` becomes `/`.
+		 */
+		if ( is_string( $raw_url ) && 0 === strpos( $raw_url, '#' ) ) {
+			continue;
+		}
+
+		$cache_key = $mapping_cache_key . "\0" . $token_type . "\0" . $raw_url;
 
 		$cached = $rewrite_cache->get( $cache_key );
 		if ( null !== $cached ) {


### PR DESCRIPTION
## The problem

`wp_rewrite_urls()` resolves every URL against the base URL before consulting the mapping. A fragment-only reference like `#section` has no host and no path, so after resolution it is indistinguishable from an ordinary same-site link, `is_child_url_of()` matches it, and it gets rewritten:

| in | out |
| --- | --- |
| `<a href="#section">` | `<a href="/#section">` |
| `<a href="#">` | `<a href="/">` |
| `<!-- wp:button {"url":"#login"} -->` | `<!-- wp:button {"url":"\/#login"} -->` |

An in-page anchor becomes a link to the site root, and a bare `#` loses its fragment entirely. In the importer this also breaks block validation: any block whose saved markup carries such an href (accordions, tab and anchor navigation, `#` placeholders handled by JavaScript) no longer matches its `save()` output after an import.

## The fix

Skip references whose raw value starts with `#` before the cache and the mapping are consulted. The guard reads `get_raw_url()` on purpose, since parsing is what destroys the distinction. It is scoped to references that are *only* a fragment. A URL carrying a fragment alongside a host or path still rewrites and keeps its fragment (`https://legacy-blog.com/page#section` becomes `https://modern-webstore.org/page#section`), and that case is in the tests as a control.

## Tests

Four cases added to `RewriteUrlsTest::provider_test_wp_rewrite_urls()`. Without the guard the three fragment-only cases fail with exactly the rewrites above; the absolute-URL-with-fragment control passes with and without it.

## Context

This is the upstream half of WordPress/wordpress-importer#263, where the same change was made against the vendored copy under `src/php-toolkit/`. Per @desrosj's review there, the toolkit should land it first and the importer then pick it up. It is a small `continue` at the top of the loop in `wp_rewrite_urls()`, so it should rebase over #307 either way.

Query-only references (`?filter=all`) have the same shape and currently become `/?filter=all`. Left alone here to keep this to the reported behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
